### PR TITLE
Read-only endpoints for subscriptions and licenses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ../src:/edx/src:cached
     # This should be the same as the `CMD` in the devapp build stage
     # of the Dockerfile
-    command: bash -c 'gunicorn --reload --workers=2 --name license_manager -b :18170 -c /edx/app/license_manager/license_manager/docker_gunicorn_configuration.py --log-file - --max-requests=1000 license_manager.wsgi:application'
+    command: bash -c 'while true; do gunicorn --reload --workers=2 --name license_manager -b :18170 -c /edx/app/license_manager/license_manager/docker_gunicorn_configuration.py --log-file - --max-requests=1000 license_manager.wsgi:application; sleep 2; done'
     ports:
       - "18170:18170"
     depends_on:

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -1,4 +1,43 @@
-# Serializers that can be shared across multiple versions of the API
-# should be created here. As the API evolves, serializers may become more
-# specific to a particular version of the API. In this case, the serializers
-# in question should be moved to versioned sub-package.
+from rest_framework import serializers
+
+from license_manager.apps.subscriptions.models import License, SubscriptionPlan
+
+
+class SubscriptionPlanSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `SubscriptionPlan` model.
+    """
+    licenses = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SubscriptionPlan
+        fields = [
+            'uuid',
+            'purchase_date',
+            'start_date',
+            'expiration_date',
+            'enterprise_customer_uuid',
+            'enterprise_catalog_uuid',
+            'licenses',
+        ]
+
+    def get_licenses(self, obj):
+        return {
+            'total': obj.num_licenses,
+            'allocated': obj.num_allocated_licenses,
+        }
+
+
+class LicenseSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `License` model.
+    """
+    class Meta:
+        model = License
+        fields = [
+            'uuid',
+            'status',
+            'user_email',
+            'activation_date',
+            'last_remind_date',
+        ]

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -18,6 +18,7 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
             'expiration_date',
             'enterprise_customer_uuid',
             'enterprise_catalog_uuid',
+            'is_active',
             'licenses',
         ]
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -115,6 +115,7 @@ def _assert_subscription_response_correct(response, subscription):
     assert response['start_date'] == _get_date_string(subscription.start_date)
     assert response['expiration_date'] == _get_date_string(subscription.expiration_date)
     assert response['enterprise_catalog_uuid'] == str(subscription.enterprise_catalog_uuid)
+    assert response['is_active'] == subscription.is_active
     assert response['licenses'] == {
         'total': subscription.num_licenses,
         'allocated': subscription.num_allocated_licenses,

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1,0 +1,284 @@
+# pylint: disable=redefined-outer-name
+"""
+Tests for the Subscription and License V1 API view sets.
+"""
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.urls import reverse
+from django_dynamic_fixture import get as get_model_fixture
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from license_manager.apps.core.models import User
+from license_manager.apps.subscriptions.constants import ASSIGNED
+from license_manager.apps.subscriptions.tests.factories import (
+    LicenseFactory,
+    SubscriptionPlanFactory,
+)
+
+
+@pytest.fixture
+def api_client():
+    """
+    Fixture that provides a DRF test APIClient.
+    """
+    return APIClient()
+
+
+@pytest.fixture
+def non_staff_user():
+    """
+    Fixture that provides a plain 'ole authenticated User instance.
+    Non-staff, non-admin.
+    """
+    return get_model_fixture(User)
+
+
+@pytest.fixture
+def staff_user():
+    """
+    Fixture that provides a User instance for whom staff=True.
+    """
+    return get_model_fixture(User, is_staff=True, is_superuser=False)
+
+
+@pytest.fixture
+def superuser():
+    """
+    Fixture that provides a superuser.
+    """
+    return get_model_fixture(User, is_staff=True, is_superuser=True)
+
+
+def _subscriptions_list_request(api_client, user, enterprise_customer_uuid=None):
+    """
+    Helper method that requests a list of subscriptions entities for a given enterprise_customer_uuid.
+    """
+    api_client.force_authenticate(user=user)
+    url = reverse('api:v1:subscriptions-list')
+    if enterprise_customer_uuid is not None:
+        url += '?enterprise_customer_uuid={uuid}'.format(uuid=enterprise_customer_uuid)
+    return api_client.get(url)
+
+
+def _subscriptions_detail_request(api_client, user, subscription_uuid):
+    """
+    Helper method that requests details for a specific subscription_uuid.
+    """
+    api_client.force_authenticate(user=user)
+    url = reverse('api:v1:subscriptions-detail', kwargs={'subscription_uuid': subscription_uuid})
+    return api_client.get(url)
+
+
+def _licenses_list_request(api_client, user, subscription_uuid):
+    """
+    Helper method that requests a list of licenses for a given subscription_uuid.
+    """
+    api_client.force_authenticate(user=user)
+    url = reverse('api:v1:licenses-list', kwargs={'subscription_uuid': subscription_uuid})
+    return api_client.get(url)
+
+
+def _licenses_detail_request(api_client, user, subscription_uuid, license_uuid):
+    """
+    Helper method that requests details for a specific license_uuid.
+    """
+    api_client.force_authenticate(user=user)
+    url = reverse('api:v1:licenses-detail', kwargs={
+        'subscription_uuid': subscription_uuid,
+        'license_uuid': license_uuid
+    })
+    return api_client.get(url)
+
+
+def _get_date_string(date):
+    """
+    Helper to get the string associated with a date, or None if it doesn't exist.
+
+    Returns:
+        string or None: The string representation of the date if it exists.
+    """
+    if not date:
+        return None
+    return str(date)
+
+
+def _assert_subscription_response_correct(response, subscription):
+    """
+    Helper for asserting that the response for a subscription matches the object's values.
+    """
+    assert response['enterprise_customer_uuid'] == str(subscription.enterprise_customer_uuid)
+    assert response['uuid'] == str(subscription.uuid)
+    assert response['purchase_date'] == _get_date_string(subscription.purchase_date)
+    assert response['start_date'] == _get_date_string(subscription.start_date)
+    assert response['expiration_date'] == _get_date_string(subscription.expiration_date)
+    assert response['enterprise_catalog_uuid'] == str(subscription.enterprise_catalog_uuid)
+    assert response['licenses'] == {
+        'total': subscription.num_licenses,
+        'allocated': subscription.num_allocated_licenses,
+    }
+
+
+def _assert_license_response_correct(response, subscription_license):
+    """
+    Helper for asserting that the response for a subscription_license matches the object's values.
+    """
+    assert response['uuid'] == str(subscription_license.uuid)
+    assert response['status'] == subscription_license.status
+    assert response['user_email'] == subscription_license.user_email
+    assert response['activation_date'] == _get_date_string(subscription_license.activation_date)
+    assert response['last_remind_date'] == _get_date_string(subscription_license.last_remind_date)
+
+
+@pytest.mark.django_db
+def test_subscription_plan_list_unauthenticated_user_403(api_client):
+    """
+    Verify that unauthenticated users receive a 403 from the subscription plan list endpoint.
+    """
+    response = _subscriptions_list_request(api_client, AnonymousUser(), enterprise_customer_uuid=uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_subscription_plan_retrieve_unauthenticated_user_403(api_client):
+    """
+    Verify that unauthenticated users receive a 403 from the subscription plan retrieve endpoint.
+    """
+    response = _subscriptions_detail_request(api_client, AnonymousUser(), uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_license_list_unauthenticated_user_403(api_client):
+    """
+    Verify that unauthenticated users receive a 403 from the license list endpoint.
+    """
+    response = _licenses_list_request(api_client, AnonymousUser(), uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_license_retrieve_unauthenticated_user_403(api_client):
+    """
+    Verify that unauthenticated users receive a 403 from the license retrieve endpoint.
+    """
+    response = _licenses_detail_request(api_client, AnonymousUser(), uuid4(), uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_subscription_plan_list_non_staff_user_403(api_client, non_staff_user):
+    response = _subscriptions_list_request(api_client, non_staff_user, enterprise_customer_uuid='foo')
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_subscription_plan_detail_non_staff_user_403(api_client, non_staff_user):
+    response = _subscriptions_detail_request(api_client, non_staff_user, uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_licenses_list_non_staff_user_403(api_client, non_staff_user):
+    response = _licenses_list_request(api_client, non_staff_user, uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_license_detail_non_staff_user_403(api_client, non_staff_user):
+    response = _licenses_detail_request(api_client, non_staff_user, uuid4(), uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_subscription_plan_list_staff_user_200(api_client, staff_user):
+    """
+    Verify that the subscription list view for staff users gives the correct response.
+
+    Additionally checks that the staff user only sees the subscription plans associated with the enterprise customer as
+    specified by the query parameter.
+    """
+    enterprise_customer_uuid = uuid4()
+    first_subscription = SubscriptionPlanFactory.create(enterprise_customer_uuid=enterprise_customer_uuid)
+    # Associate some unassigned and assigned licenses to the first subscription
+    unassigned_licenses = LicenseFactory.create_batch(5)
+    assigned_licenses = LicenseFactory.create_batch(2, status=ASSIGNED)
+    first_subscription.licenses.set(unassigned_licenses + assigned_licenses)
+    # Create one more subscription for the enterprise with no licenses
+    second_subscription = SubscriptionPlanFactory.create(enterprise_customer_uuid=enterprise_customer_uuid)
+    # Create another subscription not associated with the enterprise that shouldn't show up
+    SubscriptionPlanFactory.create()
+
+    response = _subscriptions_list_request(api_client, staff_user, enterprise_customer_uuid=enterprise_customer_uuid)
+    assert status.HTTP_200_OK == response.status_code
+    results = response.data['results']
+    assert len(results) == 2
+    _assert_subscription_response_correct(results[0], first_subscription)
+    _assert_subscription_response_correct(results[1], second_subscription)
+
+
+@pytest.mark.django_db
+def test_subscription_plan_list_staff_user_no_query_param(api_client, staff_user):
+    """
+    Verify that the subscription list view for staff gives no results if there is no query param.
+    """
+    SubscriptionPlanFactory.create()
+    response = _subscriptions_list_request(api_client, staff_user)
+    assert status.HTTP_200_OK == response.status_code
+    results = response.data['results']
+    assert len(results) == 0
+
+
+@pytest.mark.django_db
+def test_subscription_plan_list_superuser_200(api_client, superuser):
+    """
+    Verify that the subscription list view for superusers returns all subscription plans.
+    """
+    SubscriptionPlanFactory.create_batch(10)
+    response = _subscriptions_list_request(api_client, superuser)
+    assert status.HTTP_200_OK == response.status_code
+    results = response.data['results']
+    assert len(results) == 10
+
+
+@pytest.mark.django_db
+def test_subscription_plan_detail_staff_user_200(api_client, staff_user):
+    """
+    Verify that the subscription detail view for staff gives the correct result.
+    """
+    subscription = SubscriptionPlanFactory.create()
+    # Associate some licenses with the subscription
+    unassigned_licenses = LicenseFactory.create_batch(3)
+    assigned_licenses = LicenseFactory.create_batch(5, status=ASSIGNED)
+    subscription.licenses.set(unassigned_licenses + assigned_licenses)
+    response = _subscriptions_detail_request(api_client, staff_user, subscription.uuid)
+    assert status.HTTP_200_OK == response.status_code
+    _assert_subscription_response_correct(response.data, subscription)
+
+
+@pytest.mark.django_db
+def test_license_list_staff_user_200(api_client, staff_user):
+    subscription = SubscriptionPlanFactory.create()
+    # Associate some licenses with the subscription
+    unassigned_license = LicenseFactory.create()
+    assigned_license = LicenseFactory.create(status=ASSIGNED, user_email='fake@fake.com')
+    subscription.licenses.set([unassigned_license, assigned_license])
+    response = _licenses_list_request(api_client, staff_user, subscription.uuid)
+    assert status.HTTP_200_OK == response.status_code
+    results = response.data['results']
+    assert len(results) == 2
+    _assert_license_response_correct(results[0], unassigned_license)
+    _assert_license_response_correct(results[1], assigned_license)
+
+
+@pytest.mark.django_db
+def test_license_detail_staff_user_200(api_client, staff_user):
+    subscription = SubscriptionPlanFactory.create()
+    # Associate some licenses with the subscription
+    subscription_license = LicenseFactory.create()
+    subscription.licenses.set([subscription_license])
+    response = _licenses_detail_request(api_client, staff_user, subscription.uuid, subscription_license.uuid)
+    assert status.HTTP_200_OK == response.status_code
+    _assert_license_response_correct(response.data, subscription_license)

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -1,4 +1,69 @@
-""" API v1 URLs. """
+"""
+URL definitions for license manager API version 1.
+
+The use of `NestedSimpleRouter` below allows us to defined
+nested routes backed by the `SubscriptionViewSet`.  That is:
+
+/api/v1/subscriptions/{subscription_uuid}/licenses/
+/api/v1/subscriptions/{subscription_uuid}/licenses/{license_uuid}/
+"""
+from rest_framework_nested import routers
+
+from license_manager.apps.api.v1 import views
+
 
 app_name = 'v1'
-urlpatterns = []
+
+
+class NestedMixin(routers.NestedMixin):
+    """
+    This is a hack to work around a shortcoming of the rest_framework_nested
+    `NestedMixin` class: https://github.com/alanjds/drf-nested-routers/issues/147
+
+    Without this trickery, you can't tell `NestedMixin` to just use
+    the `lookup_field` or `lookup_url_kwarg` of the router's viewset as the
+    lookup URL kwarg of a nested router - it will *always* try to build its
+    own, non-empty default if not provided, and will insist on appending a "_"
+    if you provide a non-empty value.  The properties below trick this base
+    class's __init__() method into not doing anything during mutation,
+    but returning an empty string when `nest_prefix` is read.  The `nest_prefix`
+    is used as a prefix of either the ViewSets `lookup_url` or `lookup_url_kwarg`
+    field when building the lookup regular expression's name.
+    """
+    @property
+    def nest_prefix(self):
+        return ""
+
+    @nest_prefix.setter
+    def nest_prefix(self, value):
+        pass
+
+    def check_valid_name(self, value):
+        return True
+
+
+class NestedSimpleRouter(NestedMixin, routers.SimpleRouter):
+    """
+    Same as `rest_framework_nested.routers.NestedSimpleRouter`, only
+    with the custom `NestedMixin` defined above.
+    """
+
+
+router = routers.SimpleRouter()
+router.register(
+    prefix=r'subscriptions',
+    viewset=views.SubscriptionViewSet,
+    basename='subscriptions',
+)
+
+subscription_router = NestedSimpleRouter(
+    parent_router=router,
+    parent_prefix=r'subscriptions',
+)
+subscription_router.register(
+    r'licenses',
+    views.LicenseViewSet,
+    basename='licenses',
+)
+
+urlpatterns = router.urls + subscription_router.urls

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1,1 +1,70 @@
-# Create your views here.
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, viewsets
+
+from license_manager.apps.api.serializers import (
+    LicenseSerializer,
+    SubscriptionPlanSerializer,
+)
+from license_manager.apps.subscriptions.models import License, SubscriptionPlan
+
+
+class SubscriptionViewSet(viewsets.ReadOnlyModelViewSet):
+    """ Viewset for read operations on SubscriptionPlans."""
+    lookup_field = 'uuid'
+    lookup_url_kwarg = 'subscription_uuid'
+    serializer_class = SubscriptionPlanSerializer
+
+    def get_queryset(self):
+        """
+        Gets the queryset of subscriptions available to the requester and their enterprise.
+
+        For the detail view, all subscriptions are currently in the queryset, but this will change when we add rbac.
+        The enterprise is specified by the `enterprise_customer_uuid` query parameter. This query parameter is useable
+        only by staff users, with non-staff users already restricted from this viewset. Additionally, staff users are
+        only able to get information about subscriptions associated with enterprises for which they are admins.
+
+        TODO: Some of this functionality is not currently implemented, and will need to be done as part of the work to
+        add edx-rbac permissions to the service.
+
+        Returns:
+            Queryset: The queryset of SubscriptionPlans the user has access to.
+        """
+        request_action = getattr(self, 'action', None)
+        if request_action == 'retrieve':
+            return SubscriptionPlan.objects.all()
+
+        user = self.request.user
+        if user.is_superuser:
+            return SubscriptionPlan.objects.all()
+
+        enterprise_customer_uuid = self.request.query_params.get('enterprise_customer_uuid', None)
+        if not enterprise_customer_uuid:
+            return SubscriptionPlan.objects.none()
+
+        return SubscriptionPlan.objects.filter(enterprise_customer_uuid=enterprise_customer_uuid)
+
+
+class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
+    """ Viewset for read operations on Licenses."""
+    lookup_field = 'uuid'
+    lookup_url_kwarg = 'license_uuid'
+    serializer_class = LicenseSerializer
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    ordering_fields = [
+        'user_email',
+        'status',
+        'activation_date',
+        'last_remind_date',
+    ]
+    filterset_fields = [
+        'user_email',
+        'status'
+    ]
+
+    def get_queryset(self):
+        """
+        Restricts licenses to those only linked with the subscription plan specified in the route.
+
+        TODO: Restrict this to only those valid with the user's enterprise when we add rbac
+        """
+        return License.objects.filter(subscription_plan=self.kwargs['subscription_uuid'])

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -60,19 +60,6 @@ class SubscriptionPlan(TimeStampedModel):
 
     @property
     def num_licenses(self):
-        return self.licenses.all().count()
-
-    def increase_num_licenses(self, num_new_licenses):
-        """
-        Method to increase the number of licenses associated with an instance of SubscriptionPlan by num_new_licenses.
-        """
-        new_licenses = [License(subscription_plan=self) for _ in range(num_new_licenses)]
-        return License.objects.bulk_create(new_licenses)
-
-    history = HistoricalRecords()
-
-    @property
-    def num_licenses(self):
         """
         Gets the total number of licenses associated with the subscription.
 
@@ -92,6 +79,15 @@ class SubscriptionPlan(TimeStampedModel):
             already allocated.
         """
         return self.licenses.filter(status__in=(ACTIVATED, ASSIGNED)).count()
+
+    def increase_num_licenses(self, num_new_licenses):
+        """
+        Method to increase the number of licenses associated with an instance of SubscriptionPlan by num_new_licenses.
+        """
+        new_licenses = [License(subscription_plan=self) for _ in range(num_new_licenses)]
+        License.objects.bulk_create(new_licenses)
+
+    history = HistoricalRecords()
 
     class Meta:
         verbose_name = _("Subscription Plan")

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -6,6 +6,8 @@ from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 from license_manager.apps.subscriptions.constants import (
+    ACTIVATED,
+    ASSIGNED,
     LICENSE_STATUS_CHOICES,
     UNASSIGNED,
 )
@@ -68,6 +70,28 @@ class SubscriptionPlan(TimeStampedModel):
         return License.objects.bulk_create(new_licenses)
 
     history = HistoricalRecords()
+
+    @property
+    def num_licenses(self):
+        """
+        Gets the total number of licenses associated with the subscription.
+
+        Returns:
+            int: The count of how many licenses are associated with the subscription plan.
+        """
+        return self.licenses.count()
+
+    @property
+    def num_allocated_licenses(self):
+        """
+        Gets the number of allocated licenses associated with the subscription. A license is
+        defined as allocated if it has either been activated by a user, or assigned to a user.
+
+        Returns:
+        int: The count of how many licenses that are associated with the subscription plan are
+            already allocated.
+        """
+        return self.licenses.filter(status__in=(ACTIVATED, ASSIGNED)).count()
 
     class Meta:
         verbose_name = _("Subscription Plan")

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'corsheaders',
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
+    'django_filters',
     'rest_framework',
     'rest_framework_swagger',
     'social_django',
@@ -96,6 +97,21 @@ DATABASES = {
         'HOST': '',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         'PORT': '',  # Set to empty string for default.
     }
+}
+
+# Django Rest Framework
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'edx_rest_framework_extensions.auth.jwt.authentication.JwtAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.IsAdminUser',
+    ],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'PAGE_SIZE': 10,
 }
 
 # Internationalization

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,11 +5,13 @@
 Django>=2.2,<2.3          # Web application framework
 django-cors-headers
 django-extensions
+django-filter
 django-model-utils
 django-rest-swagger
 django-simple-history
 django-waffle
 djangorestframework
+drf-nested-routers
 edx-auth-backends
 edx-django-utils
 edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-newrelic==5.12.1.141      # via edx-django-utils
+newrelic==5.14.0.142      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,13 +15,15 @@ coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.3.0  # via -r requirements/base.in
 django-extensions==2.2.9  # via -r requirements/base.in
+django-filter==2.2.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.10.0  # via -r requirements/base.in
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/base.in, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-utils==3.2.2   # via -r requirements/base.in, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,8 @@
 
 # Inflect 4.0.0 requires python>=3.6
 inflect<4.0.0
-
+# Upgrading requires social-auth-core>=3.3.0 which we don't want yet
+social-auth-app-django==3.1.0
 # The upgrade to 3.3.0 is what triggered users to lose superuser status; see ARCHBOM-1078 for details.
 social-auth-core==3.2.0
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,8 +10,7 @@
 
 # Inflect 4.0.0 requires python>=3.6
 inflect<4.0.0
-# Upgrading requires social-auth-core>=3.3.0 which we don't want yet
-social-auth-app-django==3.1.0
+
 # The upgrade to 3.3.0 is what triggered users to lose superuser status; see ARCHBOM-1078 for details.
 social-auth-core==3.2.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,13 +25,15 @@ django-cors-headers==3.3.0  # via -r requirements/validation.txt
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
 django-extensions==2.2.9  # via -r requirements/validation.txt
+django-filter==2.2.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
 django-simple-history==2.10.0  # via -r requirements/validation.txt
 django-waffle==0.20.0     # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/validation.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
-djangorestframework==3.11.0  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/validation.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
+djangorestframework==3.11.0  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/validation.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
 edx-django-utils==3.2.2   # via -r requirements/validation.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/validation.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -57,13 +57,12 @@ markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -r requirements/validation.txt
 more-itertools==8.3.0     # via -r requirements/validation.txt, pytest
-newrelic==5.12.1.141      # via -r requirements/validation.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/validation.txt, pytest
 path.py==12.4.0           # via -r requirements/validation.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/validation.txt, path.py
-pathlib2==2.3.5           # via -r requirements/validation.txt, pytest
 pbr==5.4.5                # via -r requirements/validation.txt, stevedore
 pip-tools==5.2.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/validation.txt, diff-cover, pytest
@@ -84,7 +83,7 @@ pymongo==3.10.1           # via -r requirements/validation.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/validation.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/validation.txt
 pytest-django==3.9.0      # via -r requirements/validation.txt
-pytest==5.4.2             # via -r requirements/validation.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/validation.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/validation.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/validation.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/validation.txt, social-auth-core
@@ -96,7 +95,7 @@ requests==2.23.0          # via -r requirements/validation.txt, coreapi, edx-drf
 rest-condition==1.0.3     # via -r requirements/validation.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends
@@ -107,7 +106,7 @@ text-unidecode==1.3       # via -r requirements/validation.txt, faker, python-sl
 typed-ast==1.4.1          # via -r requirements/validation.txt, astroid
 uritemplate==3.0.1        # via -r requirements/validation.txt, coreapi
 urllib3==1.25.9           # via -r requirements/validation.txt, requests
-wcwidth==0.2.2            # via -r requirements/validation.txt, pytest
+wcwidth==0.2.3            # via -r requirements/validation.txt, pytest
 wrapt==1.11.2             # via -r requirements/validation.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/validation.txt, importlib-metadata
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -33,7 +33,7 @@ django-simple-history==2.10.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-doc8==0.8.0               # via -r requirements/doc.in
+doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
@@ -59,17 +59,16 @@ markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
-newrelic==5.12.1.141      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
-pygments==2.6.1           # via readme-renderer, sphinx
+pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
@@ -80,7 +79,7 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
@@ -94,7 +93,7 @@ rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0  # via -r requirements/test.txt, edx-auth-backends
@@ -112,7 +111,7 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
-wcwidth==0.2.2            # via -r requirements/test.txt, pytest
+wcwidth==0.2.3            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,15 +26,17 @@ defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social
 django-cors-headers==3.3.0  # via -r requirements/test.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/test.txt
+django-filter==2.2.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.10.0  # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
-djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-utils==3.2.2   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,13 +15,15 @@ coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-extensions==2.2.9  # via -r requirements/base.txt
+django-filter==2.2.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,7 +39,7 @@ jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==1.4.6        # via -r requirements/production.in
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -42,7 +42,7 @@ kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,13 +18,15 @@ coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-extensions==2.2.9  # via -r requirements/base.txt
+django-filter==2.2.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/base.txt, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,11 +51,10 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.3.0     # via pytest
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest
-pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
@@ -71,7 +70,7 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.9.0         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.2             # via pytest-cov, pytest-django
+pytest==5.4.3             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
@@ -83,7 +82,7 @@ requests==2.23.0          # via -r requirements/base.txt, coreapi, edx-drf-exten
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
@@ -93,6 +92,6 @@ text-unidecode==1.3       # via faker, python-slugify
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
-wcwidth==0.2.2            # via pytest
+wcwidth==0.2.3            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,12 +23,14 @@ defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social
 django-cors-headers==3.3.0  # via -r requirements/base.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
 django-extensions==2.2.9  # via -r requirements/base.txt
+django-filter==2.2.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.10.0  # via -r requirements/base.txt
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-utils==3.2.2   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -23,13 +23,15 @@ defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/tes
 django-cors-headers==3.3.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
 django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
+django-filter==2.2.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.10.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-model-utils, djangorestframework, drf-jwt, edx-auth-backends, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
-djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-filter, django-model-utils, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
+djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.2.2   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/test.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -53,13 +53,12 @@ markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/tes
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
-newrelic==5.12.1.141      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -78,7 +77,7 @@ pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/tes
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
@@ -90,7 +89,7 @@ requests==2.23.0          # via -r requirements/quality.txt, -r requirements/tes
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
@@ -101,6 +100,6 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/test.txt, requests
-wcwidth==0.2.2            # via -r requirements/test.txt, pytest
+wcwidth==0.2.3            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata


### PR DESCRIPTION
## Description

* Exposes new routes for subscriptions and licenses (they're nested!):
```
/api/v1/subscriptions/?enterprise_customer_uuid={some_uuid} (subscription list endpoint)
/api/v1/subscriptions/{subscription_uuid}/ (subscription detail endpoint)
/api/v1/subscriptions/{subscription_uuid}/licenses/ (license list endpoint)
/api/v1/subscriptions/{subscription_uuid/licenses/{license_uuid}/ (license detail endpoint)
```

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-2750

## Testing considerations
Testing superuser flow (and most of the implementation):
- Create a subscription plan at http://localhost:18170/admin/subscriptions/subscriptionplan/ and allocate at least two licenses
- Navigate to http://localhost:18170/admin/subscriptions/license/ and change one license's status to 'active' or 'assigned', and give it an email: `fake@example.org`.
- Go to http://localhost:18170/api/v1/subscriptions/ and confirm the data looks correct. An important to field to notice is that `licenses` should have the correct number of total licenses, and one allocated license from the one changed in django admin
- Go to http://localhost:18170/api/v1/subscriptions/{subscription_uuid}/licenses/ and confirm the data is correct
  -  At this route, play around with the ordering and filtering parameters. For the most important one, add `?user_email=fake@example.org` and confirm that only the licenses with that email are returned
  - Add `?status=assigned` (assuming you chose `assigned` as the status for the license earlier) and confirm that only licenses with that status are returned
  - Add `?ordering=-user_email` and see the results ordered appropriately. The endpoint also supports ordering by status, `activation_date`, and `last_remind_date`. Those seemed like useful fields to be able to sort by in the future, but they are not explicitly called out in the ticket.
- Go to http://localhost:18170/api/v1/subscriptions/{subscription_uuid}/licenses/{license_uuid} and confirm that the data is correct for that license

Testing unauthenticated flow:
- Log out, hit all the endpoints listed above, and confirm they give a `401`

Testing non-staff flow:
- Log in as `verified@example.com` in the lms, hit all the endpoints listed above, and confirm they give a `403`

Testing staff flow:
- Make a user staff on license manager
- Hit `api/v1/subscriptions` with no query param and confirm no subscription plans show up
- Add a new subscription plan, set an `enterprise_customer_uuid`, and create a license to use with it
- Hit `api/v1/subscriptions/?enterprise_customer_uuid={enterprise_customer_uuid}` and confirm you can see only the subscription you specified. 
- HIt `api/v1/subscriptions/{subscription_uuid}/licenses/` and confirm you can see only licenses associated with that subscription

## Post-review

Squash commits into discrete sets of changes
