### PR TITLE
Add gunicorn to dev requirements

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -9,4 +9,5 @@ ddt                       # Data-driven tests
 diff-cover                # Changeset diff test coverage
 django-debug-toolbar      # For debugging Django
 #transifex-client         # For managing translations
+gunicorn
 inflect

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,6 +44,7 @@ edx-rest-api-client==1.9.2  # via -r requirements/validation.txt
 factory-boy==2.12.0       # via -r requirements/validation.txt
 faker==4.1.0              # via -r requirements/validation.txt, factory-boy
 future==0.18.2            # via -r requirements/validation.txt, pyjwkest
+gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.9                 # via -r requirements/validation.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/validation.txt, inflect, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/dev.in, jinja2-pluralize
@@ -112,3 +113,4 @@ zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools


### PR DESCRIPTION
Fixes issue where gunicorn would not be found on an app restart

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
