### PR TITLE
Create licenses after subscription is saved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,8 @@ dev.stop: # Stops containers so they can be restarted
 %-restart: # Restart the specified service container
 	docker-compose restart $*
 
-attach:
-	docker attach license_manager
+%-attach:
+	docker attach license_manager.$*
 
 docker_build:
 	docker build . -f Dockerfile -t openedx/license-manager

--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -27,6 +27,12 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
     )
     fields = read_only_fields + writable_fields
 
+    def save_model(self, request, obj, form, change):
+        # Create licenses to be associated with the subscription plan after creating the subscription plan
+        num_new_licenses = form.cleaned_data.get('num_licenses', 0) - obj.num_licenses
+        super().save_model(request, obj, form, change)
+        SubscriptionPlan.increase_num_licenses(obj, num_new_licenses)
+
     def get_readonly_fields(self, request, obj=None):
         """
         If subscription already exists, make all fields but num_licenses and is_active read-only

--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -16,13 +16,6 @@ class SubscriptionPlanForm(forms.ModelForm):
         super(SubscriptionPlanForm, self).__init__(*args, **kwargs)
         self.fields['num_licenses'].initial = self.instance.num_licenses
 
-    def save(self, commit=True):
-        subscription_uuid = super(SubscriptionPlanForm, self).save(commit=commit)
-        # Create licenses to be associated with the subscription plan
-        num_new_licenses = self.cleaned_data.get('num_licenses', 0) - self.instance.num_licenses
-        SubscriptionPlan.increase_num_licenses(self.instance, num_new_licenses)
-        return subscription_uuid
-
     def is_valid(self):
         # Perform original validation and return if false
         if not super(SubscriptionPlanForm, self).is_valid():

--- a/license_manager/apps/subscriptions/tests/test_admin.py
+++ b/license_manager/apps/subscriptions/tests/test_admin.py
@@ -1,0 +1,26 @@
+# pylint: disable=redefined-outer-name
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from license_manager.apps.subscriptions.admin import SubscriptionPlanAdmin
+from license_manager.apps.subscriptions.models import SubscriptionPlan
+from license_manager.apps.subscriptions.tests.utils import (
+    make_bound_subscription_form,
+)
+
+
+@pytest.mark.django_db
+def test_licenses_subscription_creation():
+    """
+    Verify that creating a SubscriptionPlan creates its associated Licenses after it is created.
+    """
+    subscription_admin = SubscriptionPlanAdmin(SubscriptionPlan, AdminSite())
+    request = RequestFactory()
+    num_licenses = 5
+    form = make_bound_subscription_form(num_licenses=num_licenses)
+    obj = form.save()  # Get the object returned from saving the form to save to the database
+    assert obj.licenses.count() == 0  # Verify no Licenses have been created yet
+    change = False
+    subscription_admin.save_model(request, obj, form, change)
+    assert obj.licenses.count() == num_licenses

--- a/license_manager/apps/subscriptions/tests/test_forms.py
+++ b/license_manager/apps/subscriptions/tests/test_forms.py
@@ -2,14 +2,13 @@ from datetime import date, timedelta
 from unittest import TestCase
 
 import ddt
-from faker import Factory as FakerFactory
 from pytest import mark
 
 from license_manager.apps.subscriptions.forms import SubscriptionPlanForm
 from license_manager.apps.subscriptions.models import SubscriptionPlan
-
-
-faker = FakerFactory.create()
+from license_manager.apps.subscriptions.tests.utils import (
+    make_bound_subscription_form,
+)
 
 
 @mark.django_db
@@ -18,32 +17,6 @@ class TestSubscriptionPlanForm(TestCase):
     """
     Unit tests for the SubscriptionPlanForm
     """
-    @staticmethod
-    def _make_bound_form(
-        title=faker.pystr(min_chars=1, max_chars=127),
-        purchase_date=date.today(),
-        start_date=date.today(),
-        expiration_date=date.today() + timedelta(days=366),
-        enterprise_customer_uuid=faker.uuid4(),
-        enterprise_catalog_uuid=faker.uuid4(),
-        num_licenses=0,
-        is_active=False
-    ):
-        """
-        Builds a bound SubscriptionPlanForm
-        """
-        form_data = {
-            'title': title,
-            'purchase_date': purchase_date,
-            'start_date': start_date,
-            'expiration_date': expiration_date,
-            'enterprise_customer_uuid': enterprise_customer_uuid,
-            'enterprise_catalog_uuid': enterprise_catalog_uuid,
-            'num_licenses': num_licenses,
-            'is_active': is_active
-        }
-        return SubscriptionPlanForm(form_data)
-
     @ddt.data(
         (0, True),     # Minimum value for num_licenses
         (1000, True),  # Maximum value for num_licenses
@@ -55,7 +28,7 @@ class TestSubscriptionPlanForm(TestCase):
         """
         Test to check validation conditions for the num_licenses field
         """
-        form = self._make_bound_form(num_licenses=num_licenses)
+        form = make_bound_subscription_form(num_licenses=num_licenses)
         assert form.is_valid() is is_valid
 
     @ddt.data(
@@ -68,18 +41,5 @@ class TestSubscriptionPlanForm(TestCase):
         """
         Test to check validation conditions for the expiration_date field
         """
-        form = self._make_bound_form(expiration_date=expiration_date)
+        form = make_bound_subscription_form(expiration_date=expiration_date)
         assert form.is_valid() is is_valid
-
-    @ddt.data(
-        0,    # Create no Licenses
-        1,    # Create a single License
-        1000  # Create the maximum number of Licenses possible
-    )
-    def test_save_increase_num_licenses(self, num_licenses):
-        """
-        Test to check that increase_num_licenses is called with num_licenses
-        """
-        form = self._make_bound_form(num_licenses=num_licenses)
-        subscription_plan = form.save()
-        assert SubscriptionPlan.objects.get(uuid=subscription_plan.uuid).num_licenses == num_licenses

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -1,0 +1,37 @@
+"""
+Testing utilities for the Subscriptions app.
+"""
+from datetime import date, timedelta
+
+from faker import Factory as FakerFactory
+
+from license_manager.apps.subscriptions.forms import SubscriptionPlanForm
+
+
+faker = FakerFactory.create()
+
+
+def make_bound_subscription_form(
+    title=faker.pystr(min_chars=1, max_chars=127),
+    purchase_date=date.today(),
+    start_date=date.today(),
+    expiration_date=date.today() + timedelta(days=366),
+    enterprise_customer_uuid=faker.uuid4(),
+    enterprise_catalog_uuid=faker.uuid4(),
+    num_licenses=0,
+    is_active=False
+):
+    """
+    Builds a bound SubscriptionPlanForm
+    """
+    form_data = {
+        'title': title,
+        'purchase_date': purchase_date,
+        'start_date': start_date,
+        'expiration_date': expiration_date,
+        'enterprise_customer_uuid': enterprise_customer_uuid,
+        'enterprise_catalog_uuid': enterprise_catalog_uuid,
+        'num_licenses': num_licenses,
+        'is_active': is_active
+    }
+    return SubscriptionPlanForm(form_data)

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -3,6 +3,17 @@ from license_manager.settings.local import *
 # Generic OAuth2 variables irrespective of SSO/backend service key types.
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'license_manager',
+        'USER': 'root',
+        'PASSWORD': '',
+        'HOST': 'license_manager.mysql',
+        'PORT': '3306',
+    }
+}
+
 # OAuth2 variables specific to social-auth/SSO login use case.
 SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'license_manager-sso-key')
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'license_manager-sso-secret')


### PR DESCRIPTION
Switching so that our local database matches our stage and production
database. This is done in response to a bug with creating child rows
before parent rows in stage, which worked ok locally.
License creation is also moved to prevent the MySQL foreign key constraint failure

ENT-2987