### PR TITLE
 Add endpoint for sending license reminder emails 

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -43,3 +43,47 @@ class LicenseSerializer(serializers.ModelSerializer):
             'activation_date',
             'last_remind_date',
         ]
+
+
+class CustomTextSerializer(serializers.ModelSerializer):
+    """
+    Serializer for specifying custom text to use in license management emails.
+
+    It's a bit of a hack for it to be a model serializer, but it makes the connection to the license model in the views
+    cleaner.
+    """
+    greeting = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        write_only=True,
+    )
+    closing = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        write_only=True,
+    )
+
+    class Meta:
+        model = License
+        fields = [
+            'greeting',
+            'closing',
+        ]
+
+
+class LicenseEmailSerializer(CustomTextSerializer):
+    """
+    Serializer that takes custom text and allows additionally specifying a user_email for license management.
+
+    Requires that a valid, non-empty email is submitted.
+    """
+    user_email = serializers.EmailField(
+        allow_blank=False,
+        required=True,
+        write_only=True,
+    )
+
+    class Meta(CustomTextSerializer.Meta):
+        fields = CustomTextSerializer.Meta.fields + [
+            'user_email',
+        ]

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1,10 +1,19 @@
+from datetime import datetime
+
+from django.core.exceptions import ObjectDoesNotExist
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, viewsets
+from rest_framework import filters, status, views, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from license_manager.apps.api.serializers import (
+    CustomTextSerializer,
     LicenseSerializer,
+    LicenseEmailSerializer,
     SubscriptionPlanSerializer,
 )
+from license_manager.apps.subscriptions import emails
+from license_manager.apps.subscriptions.constants import ASSIGNED
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 
@@ -48,7 +57,6 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
     """ Viewset for read operations on Licenses."""
     lookup_field = 'uuid'
     lookup_url_kwarg = 'license_uuid'
-    serializer_class = LicenseSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     ordering_fields = [
         'user_email',
@@ -67,4 +75,101 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
 
         TODO: Restrict this to only those valid with the user's enterprise when we add rbac
         """
-        return License.objects.filter(subscription_plan=self.kwargs['subscription_uuid'])
+        return License.objects.filter(subscription_plan=self._get_subscription_plan())
+
+    def get_serializer_class(self):
+        if self.action == 'remind':
+            return LicenseEmailSerializer
+        if self.action == 'remind_all':
+            return CustomTextSerializer
+        return LicenseSerializer
+
+    def _get_subscription_plan(self):
+        """
+        Helper that returns the subscription plan specified by `subscription_uuid` in the request.
+        """
+        return SubscriptionPlan.objects.get(uuid=self.kwargs['subscription_uuid'])
+
+    def _get_custom_text(self, data):
+        """
+        Returns a dictionary with the custom text given in the POST data.
+        """
+        return {
+            'greeting': data.get('greeting', ''),
+            'closing': data.get('closing', ''),
+        }
+
+    def _validate_data(self, data):
+        """
+        Helper that validates the data sent in from a POST request.
+
+        Return HTTP 400 response if the data is invalid.
+        """
+        serializer_class = self.get_serializer_class()
+        serializer = serializer_class(data=data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['post'])
+    def remind(self, request, subscription_uuid=None, license_uuid=None):
+        """
+        Given a single email in the POST data, sends a reminder email that they have a license pending activation.
+
+        This endpoint reminds users by sending an email to the given email address, if there is a license which has not
+        yet been activated that is associated with that email address.
+        Additionally, updates the license to reflect that a reminder was just sent.
+        """
+        # Validate the user_email and text sent in the data
+        self._validate_data(request.data)
+
+        # Make sure there is a license that is still pending activation associated with the given email
+        user_email = request.data.get('user_email')
+        try:
+            license = License.objects.get(user_email=user_email, status=ASSIGNED)
+        except ObjectDoesNotExist:
+            msg = 'Could not find any licenses pending activation that are associated with the email: {}'.format(
+                user_email,
+            )
+            return Response(msg, status=status.HTTP_404_NOT_FOUND)
+
+        subscription_plan = self._get_subscription_plan()
+        # Send activation reminder email
+        emails.send_reminder_emails(
+            self._get_custom_text(request.data),
+            [user_email],
+            subscription_plan,
+        )
+
+        # Set last remind date to now
+        license.last_remind_date = datetime.now()
+        license.save()
+
+        return Response(status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['post'], url_path='remind-all')
+    def remind_all(self, request, subscription_uuid=None, license_uuid=None):
+        """
+        Reminds all users in the subscription who have a pending license that their license is awaiting activation.
+
+        Additionally, updates all pending licenses to reflect that a reminder was just sent.
+        """
+        # Validate the text sent in the data
+        self._validate_data(request.data)
+
+        subscription_plan = self._get_subscription_plan()
+        pending_licenses = License.objects.filter(subscription_plan=subscription_plan, status=ASSIGNED)
+        pending_user_emails = pending_licenses.values_list('user_email', flat=True)
+
+        # Send activation reminder email to all pending users
+        emails.send_reminder_emails(
+            self._get_custom_text(request.data),
+            [pending_user_emails],
+            subscription_plan,
+        )
+
+        # Set last remind date to now for all pending licenses
+        for license in pending_licenses:
+            license.last_remind_date = datetime.now()
+        License.objects.bulk_update(pending_licenses, ['last_remind_date'])
+
+        return Response(status=status.HTTP_200_OK)

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -10,11 +10,11 @@ LICENSE_STATUS_CHOICES = (
     (DEACTIVATED, 'Deactivated'),
 )
 
-# Subject line used for emails
+# Subject lines used for emails
 # TODO: Get subject line for each type of email from UX (ENT-2979)
 LICENSE_ACTIVATION_EMAIL_SUBJECT = 'edX License Activation'
-LICENSE_REMINDER_EMAIL_SUBJECT = 'Reminder: Activate your edX License!'
+# LICENSE_REMINDER_EMAIL_SUBJECT = 'Reminder - your edX license is awaiting activation!'
+LICENSE_REMINDER_EMAIL_SUBJECT = 'Your edX License is pending'
 
 # Template names used for emails
 LICENSE_ACTIVATION_EMAIL_TEMPLATE = 'activation'
-LICENSE_REMINDER_EMAIL_TEMPLATE = 'reminder'  # TODO: implement reminder email functionality (ENT-2835)

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -5,32 +5,88 @@ from django.template.loader import get_template
 from license_manager.apps.subscriptions.constants import (
     LICENSE_ACTIVATION_EMAIL_SUBJECT,
     LICENSE_ACTIVATION_EMAIL_TEMPLATE,
+    LICENSE_REMINDER_EMAIL_SUBJECT,
 )
 
 
-def send_activation_emails(custom_template_text, email_recipient_list, subscription_expiration_date):
+def send_activation_emails(custom_template_text, email_recipient_list, subscription_plan):
     """
-    Send a license activation email to a given set of users
+    Sends an activation email updated with the custom template text to the given recipients.
+
+    Args:
+        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
+            the email template.
+        email_recipient_list (list of str): List of recipients to send the emails to.
+        subscription_plan (SubscriptionPlan): The subscription that the recipients are associated with or
+            will be associated with.
     """
-    # Construct each message to be sent and append onto the activation_emails list
-    activation_emails = []
+    context = {
+        'template_name': LICENSE_ACTIVATION_EMAIL_TEMPLATE,
+        'subject': LICENSE_ACTIVATION_EMAIL_SUBJECT,
+    }
+    _send_email_with_activation(
+        custom_template_text,
+        email_recipient_list,
+        subscription_plan,
+        context,
+    )
+
+
+def send_reminder_emails(custom_template_text, email_recipient_list, subscription_plan):
+    """
+    Sends a reminder email updated with the custom template text to the given recipients.
+
+    Args:
+        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
+            the email template.
+        email_recipient_list (list of str): List of recipients to send the emails to.
+        subscription_plan (SubscriptionPlan): The subscription that the recipients are associated with or
+            will be associated with.
+    """
+    context = {
+        'template_name': LICENSE_ACTIVATION_EMAIL_TEMPLATE,
+        'subject': LICENSE_REMINDER_EMAIL_SUBJECT,
+        'REMINDER': True,
+    }
+    _send_email_with_activation(
+        custom_template_text,
+        email_recipient_list,
+        subscription_plan,
+        context,
+    )
+
+
+def _send_email_with_activation(custom_template_text, email_recipient_list, subscription_plan, context):
+    """
+    Helper that sends emails with the given template with an activation link to the the given list of emails.
+
+    Args:
+        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
+            the email template.
+        email_recipient_list (list of str): List of recipients to send the emails to.
+        subscription_plan (SubscriptionPlan): The subscription that the recipients are associated with or
+            will be associated with.
+        context (dict): Dictionary of context variables for template rendering. Context takes an optional `REMINDER`
+            key. If `REMINDER` is provided, a reminder message is added to the email.
+    """
+    # Construct each message to be sent and appended onto the email list
+    emails = []
     for email_address in email_recipient_list:
         # Construct user specific context for each message
-        context = {
+        context.update({
             'LICENSE_ACTIVATION_LINK': _generate_license_activation_link(),
             'USER_EMAIL': email_address,
-        }
-        activation_emails.append(_message_from_context_and_template(
+        })
+        emails.append(_message_from_context_and_template(
             context,
-            LICENSE_ACTIVATION_EMAIL_TEMPLATE,
             custom_template_text,
-            subscription_expiration_date
+            subscription_plan,
         ))
 
     # Use a single connection to send all messages
     with mail.get_connection() as connection:
         connection.open()
-        connection.send_messages(activation_emails)
+        connection.send_messages(emails)
         connection.close()
 
 
@@ -46,22 +102,30 @@ def _get_rendered_template_content(template_name, extension, context):
     return get_template(message_template).render(context)
 
 
-def _message_from_context_and_template(context, template_name, custom_template_text, expiration_date):
+def _message_from_context_and_template(context, custom_template_text, subscription_plan):
     """
-    Creates an activation email to be sent to a learner
+    Creates a message about the subscription_plan in the template specified by the context, with custom_template_text.
+
+    Args:
+        context (dict): Dictionary of context variables for template rendering.
+        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
+            the email template.
+        subscription_plan (SubscriptionPlan): The subscription that the recipients are associated with or
+            will be associated with.
 
     Returns:
         EmailMultiAlternative: an individual message constructed from the information provided, not yet sent
     """
     # Update context to be used for Django template rendering
     context.update({
-        'EXPIRATION_DATE': expiration_date,
+        'EXPIRATION_DATE': subscription_plan.expiration_date,
         'TEMPLATE_CLOSING': custom_template_text['closing'],
         'TEMPLATE_GREETING': custom_template_text['greeting'],
         'UNSUBSCRIBE_LINK': settings.EMAIL_UNSUBSCRIBE_LINK,
     })
 
     # Render the message contents using Django templates
+    template_name = context['template_name']
     txt_content = _get_rendered_template_content(template_name, '.txt', context)
     html_content = _get_rendered_template_content(template_name, '.html', context)
 
@@ -78,7 +142,7 @@ def _message_from_context_and_template(context, template_name, custom_template_t
     }
 
     message = mail.EmailMultiAlternatives(
-        subject=LICENSE_ACTIVATION_EMAIL_SUBJECT,
+        subject=context['subject'],
         body=txt_content,
         from_email=from_email_string,
         to=[context['USER_EMAIL']],

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -183,8 +183,9 @@ class License(TimeStampedModel):
         """
         return (
             "<License with UUID '{uuid}' "
-            "for SubscriptionPlan'{subscription_plan_uuid}'>".format(
+            "for SubscriptionPlan '{title}' with UUID '{subscription_plan_uuid}'>".format(
                 uuid=self.uuid,
+                title=self.subscription_plan.title,
                 subscription_plan_uuid=self.subscription_plan.uuid,
             )
         )

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -3,8 +3,13 @@ from uuid import uuid4
 
 import factory
 
+
+from license_manager.apps.core.models import User
 from license_manager.apps.subscriptions.constants import UNASSIGNED
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
+
+
+USER_PASSWORD = 'password'
 
 
 class SubscriptionPlanFactory(factory.DjangoModelFactory):
@@ -38,3 +43,20 @@ class LicenseFactory(factory.DjangoModelFactory):
     uuid = factory.LazyFunction(uuid4)
     status = UNASSIGNED
     subscription_plan = factory.SubFactory(SubscriptionPlanFactory)
+
+
+class UserFactory(factory.DjangoModelFactory):
+    """
+    Test factory for the `User` model.
+    """
+    username = factory.Faker('user_name')
+    password = factory.PostGenerationMethodCall('set_password', USER_PASSWORD)
+    email = factory.Faker('email')
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    is_active = True
+    is_staff = False
+    is_superuser = False
+
+    class Meta:
+        model = User

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 import factory
 
-
 from license_manager.apps.core.models import User
 from license_manager.apps.subscriptions.constants import UNASSIGNED
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -1,8 +1,7 @@
 from django.core import mail
 from django.test import TestCase
 
-from license_manager.apps.subscriptions import constants
-from license_manager.apps.subscriptions import emails
+from license_manager.apps.subscriptions import constants, emails
 from license_manager.apps.subscriptions.tests.factories import (
     SubscriptionPlanFactory,
 )

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -1,6 +1,7 @@
 from django.core import mail
 from django.test import TestCase
 
+from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions import emails
 from license_manager.apps.subscriptions.tests.factories import (
     SubscriptionPlanFactory,
@@ -11,26 +12,49 @@ class EmailTests(TestCase):
     def setUp(self):
         super().setUp()
         self.subscription_plan = SubscriptionPlanFactory()
-
-    def test_activation_emails_sent(self):
-        """
-        Tests that an activation email is placed in the outbox when sent
-        """
-        activation_custom_template_text = {
+        self.custom_template_text = {
             'greeting': 'Hello',
             'closing': 'Goodbye',
         }
-        email_recipient_list = [
+        self.email_recipient_list = [
             'boatymcboatface@mit.edu',
             'saul.goodman@bettercallsaul.com',
             't.soprano@badabing.net',
         ]
+
+    def test_send_activation_emails(self):
+        """
+        Tests that activation emails are correctly sent.
+        """
         emails.send_activation_emails(
-            activation_custom_template_text,
-            email_recipient_list,
-            self.subscription_plan.expiration_date
+            self.custom_template_text,
+            self.email_recipient_list,
+            self.subscription_plan,
         )
         self.assertEqual(
             len(mail.outbox),
-            len(email_recipient_list)
+            len(self.email_recipient_list)
         )
+        # Verify the contents of the first message
+        message = mail.outbox[0]
+        self.assertEqual(message.subject, constants.LICENSE_ACTIVATION_EMAIL_SUBJECT)
+        self.assertFalse('Reminder' in message.body)
+
+    def test_send_reminder_emails(self):
+        """
+        Tests that reminder emails are correctly sent.
+        """
+        emails.send_reminder_emails(
+            self.custom_template_text,
+            self.email_recipient_list,
+            self.subscription_plan,
+        )
+        self.assertEqual(
+            len(mail.outbox),
+            len(self.email_recipient_list)
+        )
+        # Verify the contents of the first message
+        message = mail.outbox[0]
+        self.assertEqual(message.subject, constants.LICENSE_REMINDER_EMAIL_SUBJECT)
+        # Verify that 'Reminder' does show up for the reminder case
+        self.assertTrue('Reminder' in message.body)

--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -8,7 +8,7 @@
         {% endfilter %}
     </p>
     <p>
-        {% if REMINDER %} {% trans "Reminder - your edX enterprise license is awaiting activation!" %} {% endif %}
+        {% if REMINDER %} {% trans "Reminder - your edX license is awaiting activation!" %} {% endif %}
 
         {% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
         <br><br>

--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -8,6 +8,8 @@
         {% endfilter %}
     </p>
     <p>
+        {% if REMINDER %} {% trans "Reminder - your edX enterprise license is awaiting activation!" %} {% endif %}
+
         {% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
         <br><br>
         <a href="{{ LICENSE_ACTIVATION_LINK }}">{% trans "Activate your edX license" %}</a>

--- a/license_manager/templates/email/activation.txt
+++ b/license_manager/templates/email/activation.txt
@@ -2,7 +2,7 @@
 
 {{ TEMPLATE_GREETING }}
 
-{% if REMINDER %} {% trans "Reminder - your edX enterprise license is awaiting activation!" %} {% endif %}
+{% if REMINDER %} {% trans "Reminder - your edX license is awaiting activation!" %} {% endif %}
 
 {% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
 

--- a/license_manager/templates/email/activation.txt
+++ b/license_manager/templates/email/activation.txt
@@ -2,6 +2,8 @@
 
 {{ TEMPLATE_GREETING }}
 
+{% if REMINDER %} {% trans "Reminder - your edX enterprise license is awaiting activation!" %} {% endif %}
+
 {% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
 
 {{ LICENSE_ACTIVATION_LINK }}

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -17,6 +17,7 @@ edx-auth-backends
 edx-django-utils
 edx-drf-extensions
 edx-rest-api-client==1.9.2
+mysqlclient
 pytz
 celery==3.1.26.post2
 redis==2.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,6 +37,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
+mysqlclient==1.4.6        # via -r requirements/base.in
 newrelic==5.14.0.142      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,6 +60,7 @@ markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -r requirements/validation.txt
 more-itertools==8.3.0     # via -r requirements/validation.txt, pytest
+mysqlclient==1.4.6        # via -r requirements/validation.txt
 newrelic==5.14.0.142      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
@@ -67,7 +68,7 @@ packaging==20.4           # via -r requirements/validation.txt, pytest
 path.py==12.4.0           # via -r requirements/validation.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/validation.txt, path.py
 pbr==5.4.5                # via -r requirements/validation.txt, stevedore
-pip-tools==5.2.0          # via -r requirements/pip-tools.txt
+pip-tools==5.2.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/validation.txt, diff-cover, pytest
 polib==1.1.0              # via -r requirements/validation.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/validation.txt, edx-django-utils

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -61,6 +61,7 @@ markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+mysqlclient==1.4.6        # via -r requirements/test.txt
 newrelic==5.14.0.142      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.0          # via -r requirements/pip-tools.in
+pip-tools==5.2.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -3,5 +3,4 @@
 
 gevent
 gunicorn
-mysqlclient
 PyYAML>=5.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -32,7 +32,7 @@ edx-drf-extensions==6.0.0  # via -r requirements/base.txt
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, pyjwkest
-gevent==20.6.0            # via -r requirements/production.in
+gevent==20.6.1            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
@@ -40,7 +40,7 @@ itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==1.4.6        # via -r requirements/production.in
+mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -44,6 +44,7 @@ kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
+mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,6 +53,7 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.3.0     # via pytest
+mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.14.0.142      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -55,6 +55,7 @@ markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/tes
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
 newrelic==5.14.0.142      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger


### PR DESCRIPTION
## Description

- Refactors how emails are sent
- Adds /licenses/remind endpoint which allows reminding a single user, specified by an email, that their license is pending activation
- Adds /licenses/remind-all endpoint which allows reminding all users of a subscription that have pending licenses that their licenses are pending activation

Still to come in separate PRs:
- Handle the emails in a celery task
- Handle errors in sending emails and only update `last_remind_date` on successful emails

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-2835

## Testing considerations
- Create a SubscriptionPlan with 3+ licenses at http://localhost:18170/admin/subscriptions/subscriptionplan/add/

### Test /remind validation
- Navigate to /api/v1/subscriptions/{subscription_uuid}/licenses/remind
- Verify that sending a POST request with no `user_email` in the data fails and an error is shown that says the email is required
- Verify that sending a POST request with `user_email` set to '' in the data fails and an error is shown that says the email is required / can not be blank
- Verify that sending a POST request with an invalid `user_email` ('lkajsdflkajsdf') in the data fails and an error is shown that says the email must be valid
- Verify that you can send a POST request with or without a custom 'greeting' or 'closing' in the data

### Test /remind functionality
- Assign a license to a user by navigating to http://localhost:18170/admin/subscriptions/license/ , changing a license associated with your subscription to have a status of assigned, and filling in the user email
- Navigate to /api/v1/subscriptions/{subscription_uuid}/licenses/remind
- Send a POST request with a custom greeting and closing, and the user email you assigned in the data.
  - Verify that the endpoint returns a 200
  - Verify that an email shows up in the logs that is sent to the specified user, has your custom greeting and closing, and shows a reminder message
  - Navigate to the license edit admin screen for the license you previously edited http://localhost:18170/admin/subscriptions/license/{license_uuid/change , and confirm that the `last_remind_date` field has been properly updated

### Test /remind-all functionality
- Assign a license to a different user in your same subscription plan through the same steps as before
- Change another license to have a status of `activated` and assign it to another user email
- Navigate to /api/v1/subscriptions/{subscription_uuid}/licenses/remind-all
- Send a POST request to the endpoint with a custom greeting and closing
  - Verify that the endpoint returns a 200
  - Verify that emails show up in the logs for all of the users that had pending licenses, but emails to the other users do not show up
  - Navigate to the admin screen for licenses and verify that all of the pending licenses in the subscription have had their `last_remind_date` fields updated accordingly, but the others have not
