### PR TITLE
Clean up email code

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -182,14 +182,3 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
         queryset_values = queryset.values('status').annotate(count=Count('status')).order_by('-count')
         license_overview = list(queryset_values)
         return Response(license_overview, status=status.HTTP_200_OK)
-
-    @action(detail=False, methods=['get'], url_path='test-send-email')
-    def test_send_email(self, request, subscription_uuid=None):
-        client = emails.SESEmailClient()
-        response = client.send_email(
-            ['bbaker@edx.org'],
-            'Test Subject',
-            'Test Text Body',
-            '<p>Test Html Body</p>',
-        )
-        return Response(response, status=status.HTTP_200_OK)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 
 -c constraints.txt
 
-boto3
 Django>=2.2,<2.3          # Web application framework
 django-cors-headers
 django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,8 +7,8 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.14.2             # via -r requirements/base.in, django-ses
-botocore==1.17.2          # via boto3, s3transfer
+boto3==1.14.3             # via django-ses
+botocore==1.17.3          # via boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2020.4.5.2       # via requests
 chardet==3.0.4            # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,8 +9,8 @@ anyjson==0.3.3            # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/validation.txt, pytest
 billiard==3.3.0.23        # via -r requirements/validation.txt, celery
-boto3==1.14.2             # via -r requirements/validation.txt, django-ses
-botocore==1.17.2          # via -r requirements/validation.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/validation.txt, django-ses
+botocore==1.17.3          # via -r requirements/validation.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/validation.txt
 certifi==2020.4.5.2       # via -r requirements/validation.txt, requests
 chardet==3.0.4            # via -r requirements/validation.txt, requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,8 +12,8 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-boto3==1.14.2             # via -r requirements/test.txt, django-ses
-botocore==1.17.2          # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/test.txt, django-ses
+botocore==1.17.3          # via -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/test.txt
 certifi==2020.4.5.2       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,8 +7,8 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.2             # via -r requirements/base.txt, django-ses
-botocore==1.17.2          # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/base.txt, django-ses
+botocore==1.17.3          # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.txt
 certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -34,7 +34,7 @@ edx-drf-extensions==6.0.0  # via -r requirements/base.txt
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==1.9.2  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, pyjwkest
-gevent==20.6.1            # via -r requirements/production.in
+gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,8 +8,8 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.2             # via -r requirements/base.txt, django-ses
-botocore==1.17.2          # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/base.txt, django-ses
+botocore==1.17.3          # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.txt
 certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,8 +9,8 @@ anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.2             # via -r requirements/base.txt, django-ses
-botocore==1.17.2          # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/base.txt, django-ses
+botocore==1.17.3          # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.txt
 certifi==2020.4.5.2       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,8 +9,8 @@ anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/tes
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.2             # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.2          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.3             # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.17.3          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/quality.txt, -r requirements/test.txt
 certifi==2020.4.5.2       # via -r requirements/quality.txt, -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests


### PR DESCRIPTION
After changing a number of things in license-manager's assume role
policy (that will be documented in confluence), we no longer need the
SESEmailClient. The connection to SES seems to be automatically
handled by the assume role policy which connects to SES.
The only change is that we don't close the connection, and we may need
to update our email code to send to a maximum of 50 recipients at a
time.
* Also removes boto3 as a direct dependency and upgrades some packages