### PR TITLE
Remove connection.open call

### DIFF
--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -85,7 +85,6 @@ def _send_email_with_activation(custom_template_text, email_recipient_list, subs
 
     # Use a single connection to send all messages
     with mail.get_connection() as connection:
-        connection.open()
         connection.send_messages(emails)
 
 


### PR DESCRIPTION
From https://docs.djangoproject.com/en/2.2/topics/email/#email-backends
we do not need to manually open and close the connection

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
