### PR TITLE
Add endpoint for assigning licenses to users

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -71,7 +71,7 @@ class CustomTextSerializer(serializers.ModelSerializer):
         ]
 
 
-class LicenseEmailSerializer(CustomTextSerializer):
+class LicenseSingleEmailSerializer(CustomTextSerializer):
     """
     Serializer that takes custom text and allows additionally specifying a user_email for license management.
 
@@ -86,4 +86,24 @@ class LicenseEmailSerializer(CustomTextSerializer):
     class Meta(CustomTextSerializer.Meta):
         fields = CustomTextSerializer.Meta.fields + [
             'user_email',
+        ]
+
+
+class LicenseEmailSerializer(CustomTextSerializer):
+    """
+    Serializer that takes custom text and allows additionally specifying multiple user_emails for license management.
+
+    Requires that a list of valid, non-empty emails are submitted.
+    """
+    user_emails = serializers.ListField(
+        child=serializers.EmailField(
+            allow_blank=False,
+            write_only=True,
+        ),
+        allow_empty=False,
+    )
+
+    class Meta(CustomTextSerializer.Meta):
+        fields = CustomTextSerializer.Meta.fields + [
+            'user_emails',
         ]

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -148,7 +148,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         # Validate the user_emails and text sent in the data
         self._validate_data(request.data)
         # Dedupe emails before turning back into a list for indexing
-        user_emails = list(set(request.data.get('user_emails')))
+        user_emails = list(set(request.data.get('user_emails', [])))
 
         # Make sure there are enough unassigned licenses
         num_user_emails = len(user_emails)
@@ -173,9 +173,9 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
 
         # Get a queryset of only the number of licenses we need to assign
         unassigned_licenses = subscription_plan.unassigned_licenses[:num_user_emails]
-        for index, unassigned_license in enumerate(unassigned_licenses):
+        for unassigned_license, email in zip(unassigned_licenses, user_emails):
             # Assign each email to a license and mark the license as assigned
-            unassigned_license.user_email = user_emails[index]
+            unassigned_license.user_email = email
             unassigned_license.status = constants.ASSIGNED
         # Efficiently update the licenses in bulk
         License.objects.bulk_update(unassigned_licenses, ['user_email', 'status'])

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -8,16 +8,13 @@ from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from license_manager.apps.api.serializers import (
-    CustomTextSerializer,
-    LicenseEmailSerializer,
-    LicenseSerializer,
-    SubscriptionPlanSerializer,
+from license_manager.apps.api import serializers
+from license_manager.apps.api.tasks import (
+    send_activation_email_task,
+    send_reminder_email_task,
 )
-from license_manager.apps.api.tasks import send_reminder_email_task
 from license_manager.apps.api.utils import localized_utcnow
 from license_manager.apps.subscriptions import constants
-from license_manager.apps.subscriptions.constants import ASSIGNED
 from license_manager.apps.subscriptions.models import (
     License,
     SubscriptionPlan,
@@ -32,7 +29,7 @@ class SubscriptionViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyMo
     """ Viewset for read operations on SubscriptionPlans."""
     lookup_field = 'uuid'
     lookup_url_kwarg = 'subscription_uuid'
-    serializer_class = SubscriptionPlanSerializer
+    serializer_class = serializers.SubscriptionPlanSerializer
     permission_required = constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
 
     # fields that control permissions for 'list' actions
@@ -110,11 +107,13 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         return License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('-activation_date')
 
     def get_serializer_class(self):
+        if self.action == 'assign':
+            return serializers.LicenseEmailSerializer
         if self.action == 'remind':
-            return LicenseEmailSerializer
+            return serializers.LicenseSingleEmailSerializer
         if self.action == 'remind_all':
-            return CustomTextSerializer
-        return LicenseSerializer
+            return serializers.CustomTextSerializer
+        return serializers.LicenseSerializer
 
     def _get_subscription_plan(self):
         """
@@ -145,6 +144,52 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         serializer.is_valid(raise_exception=True)
 
     @action(detail=False, methods=['post'])
+    def assign(self, request, subscription_uuid=None):
+        # Validate the user_emails and text sent in the data
+        self._validate_data(request.data)
+        # Dedupe emails before turning back into a list for indexing
+        user_emails = list(set(request.data.get('user_emails')))
+
+        # Make sure there are enough unassigned licenses
+        num_user_emails = len(user_emails)
+        subscription_plan = self._get_subscription_plan()
+        num_unassigned_licenses = subscription_plan.unassigned_licenses.count()
+        if num_user_emails > num_unassigned_licenses:
+            msg = (
+                'There are not enough unassigned licenses to complete your request.'
+                'You attempted to assign {} licenses, but there are only {} available.'
+            ).format(num_user_emails, num_unassigned_licenses)
+            return Response(msg, status=status.HTTP_400_BAD_REQUEST)
+
+        # Make sure none of the provided emails have already been associated with a license in the subscription
+        already_associated_emails = list(
+            subscription_plan.licenses.filter(user_email__in=user_emails).values_list('user_email', flat=True)
+        )
+        if already_associated_emails:
+            msg = 'The following user emails are already associated with a license: {}'.format(
+                already_associated_emails,
+            )
+            return Response(msg, status=status.HTTP_400_BAD_REQUEST)
+
+        # Get a queryset of only the number of licenses we need to assign
+        unassigned_licenses = subscription_plan.unassigned_licenses[:num_user_emails]
+        for index, unassigned_license in enumerate(unassigned_licenses):
+            # Assign each email to a license and mark the license as assigned
+            unassigned_license.user_email = user_emails[index]
+            unassigned_license.status = constants.ASSIGNED
+        # Efficiently update the licenses in bulk
+        License.objects.bulk_update(unassigned_licenses, ['user_email', 'status'])
+
+        # Send activation emails
+        send_activation_email_task.delay(
+            self._get_custom_text(request.data),
+            user_emails,
+            subscription_uuid,
+        )
+
+        return Response(status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['post'])
     def remind(self, request, subscription_uuid=None):
         """
         Given a single email in the POST data, sends a reminder email that they have a license pending activation.
@@ -160,8 +205,13 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
 
         # Make sure there is a license that is still pending activation associated with the given email
         user_email = request.data.get('user_email')
+        subscription_plan = self._get_subscription_plan()
         try:
-            user_license = License.objects.get(user_email=user_email, status=ASSIGNED)
+            user_license = License.objects.get(
+                subscription_plan=subscription_plan,
+                user_email=user_email,
+                status=constants.ASSIGNED,
+            )
         except ObjectDoesNotExist:
             msg = 'Could not find any licenses pending activation that are associated with the email: {}'.format(
                 user_email,
@@ -172,7 +222,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         send_reminder_email_task.delay(
             self._get_custom_text(request.data),
             [user_email],
-            self.kwargs['subscription_uuid'],
+            subscription_uuid,
         )
 
         # Set last remind date to now
@@ -192,7 +242,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         self._validate_data(request.data)
 
         subscription_plan = self._get_subscription_plan()
-        pending_licenses = License.objects.filter(subscription_plan=subscription_plan, status=ASSIGNED)
+        pending_licenses = subscription_plan.licenses.filter(status=constants.ASSIGNED)
         if not pending_licenses:
             return Response('Could not find any licenses pending activation', status=status.HTTP_404_NOT_FOUND)
 
@@ -201,7 +251,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         send_reminder_email_task.delay(
             self._get_custom_text(request.data),
             pending_user_emails,
-            self.kwargs['subscription_uuid'],
+            subscription_uuid,
         )
 
         # Set last remind date to now for all pending licenses

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -58,6 +58,16 @@ class SubscriptionPlan(TimeStampedModel):
     )
 
     @property
+    def unassigned_licenses(self):
+        """
+        Gets all of the unassigned licenses associated with the subscription.
+
+        Returns:
+            Queryset
+        """
+        return self.licenses.filter(status=UNASSIGNED)
+
+    @property
     def num_licenses(self):
         """
         Gets the total number of licenses associated with the subscription.

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -118,6 +118,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'PAGE_SIZE': 10,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # Internationalization


### PR DESCRIPTION
## Description

This adds the "assign" endpoint as another action on the LicenseViewSet

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-2834


## Testing considerations

### Test /assign validation
- Navigate to /api/v1/subscriptions/{subscription_uuid}/licenses/assign
- Verify that sending a POST request with no `user_emails` in the data fails and an error is shown that says the email is required
- Verify that sending a POST request with `user_emails` set to `[]` in the data fails and an error is shown that says the list can't be an empty
- Verify that sending a POST request with an invalid `user_emails` `['lkajsdflkajsdf']` in the data fails and an error is shown that says the email must be valid
- Verify that you can send a POST request with or without a custom 'greeting' or 'closing' in the data
- Create a SubscriptionPlan with 0 licenses at http://localhost:18170/admin/subscriptions/subscriptionplan/add/
  - Send a POST request with a valid list of `user_emails` and verify that an error is shown that not enough licenses are available
- Edit your SubscriptionPlan to add a license to it and assign it to some email (test@example.com)
  - Send a POST request with that email you assigned in the data `user_emails: ['test@example.com']` and verify that an error is shown that says `test@example.com` is already associated with a license


### Test /assign functionality
- Make sure you have a SubscriptionPlan with available (unassigned) licenses associated with it
- Navigate to /api/v1/subscriptions/{subscription_uuid}/licenses/assign 
- Send a POST request to the endpoint with a custom greeting and closing, and a list of valid user emails
  - Verify that the endpoint returns a 200
  - Verify that the emails show up in the logs for all the users who were specified
  - Go to Django Admin and verify that you can find licenses with those user emails and a status of assigned now