### PR TITLE
Explicitly add auth/perm classes.  Update settings to match enterpris…

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -4,7 +4,11 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rbac.mixins import PermissionRequiredForListingMixin
-from rest_framework import filters, status, viewsets
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
+from rest_framework import filters, permissions, status, viewsets
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -27,6 +31,9 @@ logger = logging.getLogger(__name__)
 
 class SubscriptionViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelViewSet):
     """ Viewset for read operations on SubscriptionPlans."""
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
     lookup_field = 'uuid'
     lookup_url_kwarg = 'subscription_uuid'
     serializer_class = serializers.SubscriptionPlanSerializer
@@ -70,6 +77,9 @@ class SubscriptionViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyMo
 
 class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelViewSet):
     """ Viewset for read operations on Licenses."""
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
     lookup_field = 'uuid'
     lookup_url_kwarg = 'license_uuid'
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -65,6 +65,7 @@ MIDDLEWARE = (
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtRedirectToLoginIfUnauthenticatedMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -225,7 +226,8 @@ BACKEND_SERVICE_EDX_OAUTH2_KEY = 'license-manager-backend-service-key'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'license-manager-service-secret'
 
 JWT_AUTH = {
-    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'JWT_ISSUER': 'http://127.0.0.1:18000/oauth2',
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('preferred_username'),
@@ -235,13 +237,14 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
     'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
+    'JWT_SECRET_KEY': 'SET-ME-PLEASE',
     # JWT_ISSUERS enables token decoding for multiple issuers (Note: This is not a native DRF-JWT field)
     # We use it to allow different values for the 'ISSUER' field, but keep the same SECRET_KEY and
     # AUDIENCE values across all issuers.
     'JWT_ISSUERS': [
         {
             'AUDIENCE': 'SET-ME-PLEASE',
-            'ISSUER': 'http://localhost:8000/oauth2',
+            'ISSUER': 'http://localhost:18000/oauth2',
             'SECRET_KEY': 'SET-ME-PLEASE'
         },
     ],

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -29,10 +29,23 @@ BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'license_manager-backend-service-secret')
 
 JWT_AUTH.update({
-    'JWT_SECRET_KEY': SOCIAL_AUTH_EDX_OAUTH2_SECRET,
+    'JWT_SECRET_KEY': 'lms-secret',
     'JWT_ISSUER': 'http://localhost:18000/oauth2',
-    'JWT_AUDIENCE': SOCIAL_AUTH_EDX_OAUTH2_KEY,
+    'JWT_AUDIENCE': None,
+    'JWT_VERIFY_AUDIENCE': False,
+    'JWT_PUBLIC_SIGNING_JWK_SET': (
+        '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
+        '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'
+        '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
+        'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
+    ),
+    'JWT_ISSUERS': [{
+        'AUDIENCE': 'lms-key',
+        'ISSUER': 'http://localhost:18000/oauth2',
+        'SECRET_KEY': 'lms-secret',
+    }],
 })
+
 
 # BEGIN CELERY
 CELERYD_HIJACK_ROOT_LOGGER = True


### PR DESCRIPTION
…e-catalog's template.

The default perm/auth DRF classes defined in Django settings weren’t taking (for a reason I don't understand).  The remainder of the changes are just to make license-manager match enterprise-catalog.