### PR TITLE
Add the enterprise learner portal to CORS origin whitelist

### DIFF
--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -54,6 +54,12 @@ CELERY_ALWAYS_EAGER = (
 )
 # END CELERY
 
+# CORS CONFIG
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+]
+# END CORS
+
 # Make some loggers less noisy (useful during test failure)
 import logging
 


### PR DESCRIPTION
## Description

Now that the Learner Portal will be calling the license-manager API(s), we need to add the Learner Portal hostname to the CORS_ORIGIN_WHITELIST.

Note: edx-internal PR to add it for stage/prod (https://github.com/edx/edx-internal/pull/2219)

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
