### PR TITLE
ENT-2835: update last_remind_date for a license after email is successfully sent

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2,7 +2,6 @@
 """
 Tests for the Subscription and License V1 API view sets.
 """
-from datetime import date
 from uuid import uuid4
 
 import mock

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -576,14 +576,10 @@ class LicenseViewSetActionTests(TestCase):
     def test_remind(self, mock_send_reminder_emails_task):
         """
         Verify that the remind endpoint sends an email to the specified user with a pending license.
-
-        Also verifies that:
-            - A custom greeting and closing can be sent to the endpoint
-            - The license's `last_remind_date` is updated to reflect that an email was just sent out
+        Also verifies that a custom greeting and closing can be sent to the endpoint
         """
         email = 'test@example.com'
         pending_license = LicenseFactory.create(user_email=email, status=constants.ASSIGNED)
-        assert pending_license.last_remind_date is None  # The learner should not have been reminded yet
         self.subscription_plan.licenses.set([pending_license])
 
         greeting = 'Hello'
@@ -615,10 +611,7 @@ class LicenseViewSetActionTests(TestCase):
     def test_remind_all(self, mock_send_reminder_emails_task):
         """
         Verify that the remind all endpoint sends an email to each user with a pending license.
-
-        Also verifies that:
-            - A custom greeting and closing can be sent to the endpoint.
-            - The licenses' `last_remind_date` fields are updated to reflect that an email was just sent out.
+        Also verifies that a custom greeting and closing can be sent to the endpoint.
         """
         # Create some pending and non-pending licenses for the subscription
         unassigned_licenses = LicenseFactory.create_batch(5, status=constants.UNASSIGNED)

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -17,7 +17,6 @@ from license_manager.apps.api.tasks import (
     send_activation_email_task,
     send_reminder_email_task,
 )
-from license_manager.apps.api.utils import localized_utcnow
 from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.models import (
     License,
@@ -217,7 +216,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         user_email = request.data.get('user_email')
         subscription_plan = self._get_subscription_plan()
         try:
-            user_license = License.objects.get(
+            License.objects.get(
                 subscription_plan=subscription_plan,
                 user_email=user_email,
                 status=constants.ASSIGNED,
@@ -234,10 +233,6 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
             [user_email],
             subscription_uuid,
         )
-
-        # Set last remind date to now
-        user_license.last_remind_date = localized_utcnow()
-        user_license.save()
 
         return Response(status=status.HTTP_200_OK)
 
@@ -263,11 +258,6 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
             pending_user_emails,
             subscription_uuid,
         )
-
-        # Set last remind date to now for all pending licenses
-        for pending_license in pending_licenses:
-            pending_license.last_remind_date = localized_utcnow()
-        License.objects.bulk_update(pending_licenses, ['last_remind_date'])
 
         return Response(status=status.HTTP_200_OK)
 

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -205,7 +205,6 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
 
         This endpoint reminds users by sending an email to the given email address, if there is a license which has not
         yet been activated that is associated with that email address.
-        Additionally, updates the license to reflect that a reminder was just sent.
 
         # TODO: Restrict to enterprise admins with edx-rbac implementation
         """

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -80,6 +80,7 @@ def send_reminder_emails(custom_template_text, email_recipient_list, subscriptio
             logger.info(
                 'Could not find any licenses pending activation that are associated with the email: %s', user_email
             )
+            raise
 
     # Set last remind date to now for all pending licenses
     for pending_license in pending_licenses:

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -65,22 +65,11 @@ def send_reminder_emails(custom_template_text, email_recipient_list, subscriptio
     )
 
     # Gather the licenses for each email that's been reminded
-    pending_licenses = []
-    for user_email in email_recipient_list:
-        try:
-            pending_licenses.append(
-                License.objects.get(
-                    subscription_plan=subscription_plan,
-                    user_email=user_email,
-                    status=ASSIGNED,
-                )
-            )
-        except ObjectDoesNotExist:
-            # This should never be hit since the same condition is checked in api.v1.views.remind
-            logger.info(
-                'Could not find any licenses pending activation that are associated with the email: %s', user_email
-            )
-            raise
+    pending_licenses = License.objects.filter(
+        subscription_plan=subscription_plan,
+        status=ASSIGNED,
+        user_email__in=email_recipient_list
+    )
 
     # Set last remind date to now for all pending licenses
     for pending_license in pending_licenses:

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -1,10 +1,11 @@
-import mock
+from smtplib import SMTPException
 
+import mock
+from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 
 from license_manager.apps.subscriptions import constants, emails
-from license_manager.apps.subscriptions.constants import ASSIGNED
 from license_manager.apps.subscriptions.tests.utils import (
     assert_last_remind_date_correct,
     make_test_email_data,
@@ -16,13 +17,9 @@ class EmailTests(TestCase):
         super().setUp()
         test_email_data = make_test_email_data()
         self.subscription_plan = test_email_data['subscription_plan']
+        self.licenses = test_email_data['licenses']
         self.custom_template_text = test_email_data['custom_template_text']
         self.email_recipient_list = test_email_data['email_recipient_list']
-
-        self.license = test_email_data['license']
-        self.license.status = ASSIGNED
-        self.license.user_email = self.email_recipient_list[0]
-        self.license.save()
 
     def test_send_activation_emails(self):
         """
@@ -42,40 +39,38 @@ class EmailTests(TestCase):
         self.assertEqual(message.subject, constants.LICENSE_ACTIVATION_EMAIL_SUBJECT)
         self.assertFalse('Reminder' in message.body)
 
-    def test_send_reminder_emails(self):
+    def test_send_reminder_email(self):
         """
         Tests that reminder emails are correctly sent.
         """
-        user_emails = [self.license.user_email]
+        lic = self.licenses[0]
         emails.send_reminder_emails(
             self.custom_template_text,
-            user_emails,
-            self.license.subscription_plan,
+            [lic.user_email],
+            self.licenses[0].subscription_plan,
         )
-        self.assertEqual(
-            len(mail.outbox),
-            len(user_emails)
-        )
+        self.assertEqual(len(mail.outbox), 1)
         # Verify the contents of the first message
         message = mail.outbox[0]
         self.assertEqual(message.subject, constants.LICENSE_REMINDER_EMAIL_SUBJECT)
         # Verify that 'Reminder' does show up for the reminder case
         self.assertTrue('Reminder' in message.body)
         # Verify the 'last_remind_date' of all licenses have been updated
-        assert_last_remind_date_correct([self.license], True)
+        assert_last_remind_date_correct([lic], True)
 
-    @mock.patch('license_manager.apps.subscriptions.emails.mail.get_connection')
-    def test_send_reminder_email_failure_no_remind_date_update(self, mock_get_connection):
+    def test_send_reminder_email_failure_no_remind_date_update(self):
         """
         Tests that when sending the remind email fails, last_remind_date is not updated
         """
-        mock_get_connection.send_messages.side_effect = Exception('Test Exception')
-        emails.send_reminder_emails(
-            self.custom_template_text,
-            [self.license.user_email],
-            self.license.subscription_plan,
-        )
-        # Verify no messages were sent
-        self.assertEqual(len(mail.outbox), 0)
-        # Verify the 'last_remind_date' was not updated
-        assert_last_remind_date_correct([self.license], False)
+        send_messages = "%s.%s" % (settings.EMAIL_BACKEND, 'send_messages')
+        with mock.patch(send_messages, side_effect=SMTPException):
+            lic = self.licenses[1]
+            emails.send_reminder_emails(
+                self.custom_template_text,
+                [lic.user_email],
+                lic.subscription_plan,
+            )
+            # Verify no messages were sent
+            self.assertEqual(len(mail.outbox), 0)
+            # Verify the 'last_remind_date' was not updated
+            assert_last_remind_date_correct([lic], False)

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -19,8 +19,8 @@ class EmailTests(TestCase):
 
         self.license = test_email_data['license']
         self.license.status = ASSIGNED
-        self.license.subscription_plan = self.subscription_plan
         self.license.user_email = self.email_recipient_list[0]
+        self.license.save()
 
     def test_send_activation_emails(self):
         """
@@ -48,7 +48,7 @@ class EmailTests(TestCase):
         emails.send_reminder_emails(
             self.custom_template_text,
             user_emails,
-            self.subscription_plan,
+            self.license.subscription_plan,
         )
         self.assertEqual(
             len(mail.outbox),

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -47,7 +47,7 @@ class EmailTests(TestCase):
         emails.send_reminder_emails(
             self.custom_template_text,
             [lic.user_email],
-            self.licenses[0].subscription_plan,
+            lic.subscription_plan,
         )
         self.assertEqual(len(mail.outbox), 1)
         # Verify the contents of the first message

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -56,3 +56,17 @@ def make_test_email_data():
             't.soprano@badabing.net',
         ]
     }
+
+
+def assert_last_remind_date_correct(licenses, should_be_updated):
+    """
+    Helper that verifies that all of the given licenses have had their last_remind_date updated if applicable.
+
+    If they should not have been updated, then it checks that last_remind_date is still None.
+    """
+    for license_obj in licenses:
+        license_obj.refresh_from_db()
+        if should_be_updated:
+            assert license_obj.last_remind_date.date() == date.today()
+        else:
+            assert license_obj.last_remind_date is None

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -7,6 +7,7 @@ from faker import Factory as FakerFactory
 
 from license_manager.apps.subscriptions.forms import SubscriptionPlanForm
 from license_manager.apps.subscriptions.tests.factories import (
+    LicenseFactory,
     SubscriptionPlanFactory,
 )
 
@@ -46,6 +47,7 @@ def make_test_email_data():
     """
     return {
         'subscription_plan': SubscriptionPlanFactory(),
+        'license': LicenseFactory(),
         'custom_template_text': {
             'greeting': 'Hello',
             'closing': 'Goodbye',

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -64,10 +64,10 @@ def make_test_email_data():
     ]
 
     # Use emails from list created above to create assigned licenses
-    for i in range(len(email_recipient_list)):
-        licenses[i].user_email = email_recipient_list[i]
-        licenses[i].status = ASSIGNED
-        licenses[i].save()
+    for lic, email in zip(licenses, email_recipient_list):
+        lic.user_email = email
+        lic.status = ASSIGNED
+        lic.save()
 
     return {
         'subscription_plan': subscription,
@@ -86,9 +86,6 @@ def assert_last_remind_date_correct(licenses, should_be_updated):
     for license_obj in licenses:
         license_obj.refresh_from_db()
         if should_be_updated:
-            if license_obj.last_remind_date is None:
-                assert False
-            else:
-                assert license_obj.last_remind_date.date() == date.today()
+            assert license_obj.last_remind_date.date() == date.today()
         else:
             assert license_obj.last_remind_date is None


### PR DESCRIPTION
## Description

The last_remind_date used to be updated in views.py regardless of whether the emails were successfully sent from the celery task. The updating of this field now happens within the task and won't occur if the email transmission fails.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3058

## Testing Instructions

- Pull branch, seed subscriptions/license data
- For testing purposes, raise an Exception from _send_email_with_activation
- Hit the remind endpoint: http://localhost:18170/api/v1/subscriptions/UUID/licenses/remind/
- Submit a POST request with an email that is associated with a license in the ASSIGNED state
- Observe a 200 response is returned
- Observe (in Django Admin) that the last_remind_date for the given license has NOT been updated
- Observe in the worker logs that the Exception raised has been output

## Post-review

Squash commits into discrete sets of changes
