### PR TITLE
Specify the worker image in docker-compose worker definition.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     container_name: license_manager.memcache
 
   worker:
+    image: openedx/license-manager.worker
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Description

Without this change, running the worker via docker-compose is somehow running a stale (image...or something??) thing where not all of the python packages are installed.
