### PR TITLE
Add csrf urls from edx-drf-extensions

### DIFF
--- a/license_manager/urls.py
+++ b/license_manager/urls.py
@@ -29,6 +29,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'', include(oauth2_urlpatterns)),
+    url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
     url(r'^api-docs/', get_swagger_view(title='License Manager API')),


### PR DESCRIPTION
This explicitly adds the urls used for getting a csrf token for POST
requests from the frontend.

token url accessible at `/csrf/api/v1/token`