### PR TITLE
Remove session auth from license-subsidy view

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -922,6 +922,16 @@ class LicenseSubsidyViewTests(TestCase):
             query_params['course_key'] = self.course_key
         return url + '/?' + query_params.urlencode()
 
+    def test_get_subsidy_no_jwt(self):
+        """
+        Verify the view returns a 401 for users trying to authenticate without a JWT (that is, using session auth).
+        """
+        client = APIClient()
+        client.login(username=self.user.username, password=USER_PASSWORD)
+        url = self._get_url_with_params()
+        response = client.get(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
     def test_get_subsidy_missing_role(self):
         """
         Verify the view returns a 403 for users without the learner role.

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -863,7 +863,7 @@ class LicenseSubsidyViewTests(TestCase):
 
         # API client setup
         self.api_client = APIClient()
-        self.api_client.login(username=self.user.username, password=USER_PASSWORD)
+        self.api_client.force_authenticate(user=self.user)
 
     @classmethod
     def setUpTestData(cls):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -336,7 +336,7 @@ class LicenseSubidyView(APIView):
     """
     View for fetching the data on the subsidy provided by a license.
     """
-    authentication_classes = [JwtAuthentication, SessionAuthentication]
+    authentication_classes = [JwtAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     @property


### PR DESCRIPTION
Since this view requires reading the user_id from the JWT, removing
this prevents the issue where you could auth with sessionAuth and then
your lms_user_id would be matched as `None`.