### PR TITLE
Update CORS_ORIGIN_WHITELIST to include frontend-admin-portal hostname

### DIFF
--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -56,6 +56,7 @@ CELERY_ALWAYS_EAGER = (
 
 # CORS CONFIG
 CORS_ORIGIN_WHITELIST = [
+    'http://localhost:1991',  # frontend-admin-portal
     'http://localhost:8734',  # frontend-app-learner-portal-enterprise
 ]
 # END CORS


### PR DESCRIPTION
## Description

This PR adds admin portal hostname to CORS_ORIGIN_WHITELIST in the devstack.py file to enable POST requests from admin portal. 