### PR TITLE
Add Salesforce, Netsuite fields to Subscriptions

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -20,6 +20,8 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'expiration_date',
         'enterprise_customer_uuid',
         'enterprise_catalog_uuid',
+        'salesforce_opportunity_id',
+        'netsuite_product_id',
     )
     writable_fields = (
         'num_licenses',

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -33,3 +33,6 @@ SUBSCRIPTIONS_ADMIN_LEARNER_ACCESS_PERMISSION = 'subscriptions.has_learner_or_ad
 # Subsidy constants
 PERCENTAGE_DISCOUNT_TYPE = 'percentage'
 LICENSE_DISCOUNT_VALUE = 100  # Represents a 100% off value
+
+# Salesforce constants
+SALESFORCE_ID_LENGTH = 18  # The salesforce_opportunity_id must be exactly 18 characters

--- a/license_manager/apps/subscriptions/migrations/0007_add_netsuite_and_salesforce_fields.py
+++ b/license_manager/apps/subscriptions/migrations/0007_add_netsuite_and_salesforce_fields.py
@@ -1,0 +1,36 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscriptions', '0006_create_subscription_learner_role'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalsubscriptionplan',
+            name='netsuite_product_id',
+            field=models.IntegerField(default=1, help_text='Locate the Sales Order record in NetSuite and copy the Product ID field (numeric).'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='historicalsubscriptionplan',
+            name='salesforce_opportunity_id',
+            field=models.CharField(default='000000000000ABCABC', help_text='Locate the appropriate Salesforce Opportunity record and copy the Opportunity ID field (18 characters).', max_length=18, validators=[django.core.validators.MinLengthValidator(18)]),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='subscriptionplan',
+            name='netsuite_product_id',
+            field=models.IntegerField(default=1, help_text='Locate the Sales Order record in NetSuite and copy the Product ID field (numeric).'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='subscriptionplan',
+            name='salesforce_opportunity_id',
+            field=models.CharField(default='000000000000ABCABC', help_text='Locate the appropriate Salesforce Opportunity record and copy the Opportunity ID field (18 characters).', max_length=18, validators=[django.core.validators.MinLengthValidator(18)]),
+            preserve_default=False,
+        ),
+    ]

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from django.core.validators import MinLengthValidator
 from django.db import models
 from django.utils.translation import gettext as _
 from edx_rbac.models import UserRole, UserRoleAssignment
@@ -14,6 +15,7 @@ from license_manager.apps.subscriptions.constants import (
     ACTIVATED,
     ASSIGNED,
     LICENSE_STATUS_CHOICES,
+    SALESFORCE_ID_LENGTH,
     UNASSIGNED,
 )
 
@@ -58,6 +60,22 @@ class SubscriptionPlan(TimeStampedModel):
 
     is_active = models.BooleanField(
         default=False
+    )
+
+    salesforce_opportunity_id = models.CharField(
+        max_length=SALESFORCE_ID_LENGTH,
+        validators=[MinLengthValidator(SALESFORCE_ID_LENGTH)],
+        blank=False,
+        null=False,
+        help_text=_(
+            "Locate the appropriate Salesforce Opportunity record and copy the Opportunity ID field (18 characters)."
+        )
+    )
+
+    netsuite_product_id = models.IntegerField(
+        help_text=_(
+            "Locate the Sales Order record in NetSuite and copy the Product ID field (numeric)."
+        )
     )
 
     @property

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -1,14 +1,26 @@
+import random
+import string
 from datetime import date, timedelta
 from uuid import uuid4
 
 import factory
 
 from license_manager.apps.core.models import User
-from license_manager.apps.subscriptions.constants import UNASSIGNED
+from license_manager.apps.subscriptions.constants import (
+    SALESFORCE_ID_LENGTH,
+    UNASSIGNED,
+)
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 
 USER_PASSWORD = 'password'
+
+
+def get_random_salesforce_id():
+    """
+    Returns a random alpha-numeric string of the correct length for a salesforce opportunity id.
+    """
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=SALESFORCE_ID_LENGTH))
 
 
 class SubscriptionPlanFactory(factory.DjangoModelFactory):
@@ -28,6 +40,8 @@ class SubscriptionPlanFactory(factory.DjangoModelFactory):
     expiration_date = date.today() + timedelta(days=366)
     enterprise_customer_uuid = factory.LazyFunction(uuid4)
     enterprise_catalog_uuid = factory.LazyFunction(uuid4)
+    netsuite_product_id = factory.Faker('random_int')
+    salesforce_opportunity_id = factory.LazyFunction(get_random_salesforce_id)
 
 
 class LicenseFactory(factory.DjangoModelFactory):

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -20,7 +20,8 @@ def get_random_salesforce_id():
     """
     Returns a random alpha-numeric string of the correct length for a salesforce opportunity id.
     """
-    return ''.join(random.choices(string.ascii_letters + string.digits, k=SALESFORCE_ID_LENGTH))
+    return ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+                   for _ in range(SALESFORCE_ID_LENGTH))
 
 
 class SubscriptionPlanFactory(factory.DjangoModelFactory):

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -10,6 +10,7 @@ from license_manager.apps.subscriptions.forms import SubscriptionPlanForm
 from license_manager.apps.subscriptions.tests.factories import (
     LicenseFactory,
     SubscriptionPlanFactory,
+    get_random_salesforce_id,
 )
 
 
@@ -23,6 +24,8 @@ def make_bound_subscription_form(
     expiration_date=date.today() + timedelta(days=366),
     enterprise_customer_uuid=faker.uuid4(),
     enterprise_catalog_uuid=faker.uuid4(),
+    netsuite_product_id=faker.random_int(),
+    salesforce_opportunity_id=get_random_salesforce_id(),
     num_licenses=0,
     is_active=False
 ):
@@ -36,8 +39,10 @@ def make_bound_subscription_form(
         'expiration_date': expiration_date,
         'enterprise_customer_uuid': enterprise_customer_uuid,
         'enterprise_catalog_uuid': enterprise_catalog_uuid,
+        'netsuite_product_id': netsuite_product_id,
+        'salesforce_opportunity_id': salesforce_opportunity_id,
         'num_licenses': num_licenses,
-        'is_active': is_active
+        'is_active': is_active,
     }
     return SubscriptionPlanForm(form_data)
 


### PR DESCRIPTION
Adds the salesforce_opportunity_id field to track the business
transaction of a customer purchasing a subscription. Adds the
netsuite_product_id field to track the "product/content catalog" sold
to the customer. These fields will need to be populated by an admin
from ECS using the Django Admin site at the time the subscription is
created.
The migration adds one-time default values for the salesforce and
netsuite fields to handle the existing subscriptions in our database.
As we don't have any real transactions or data yet for stage & prod
license-manager, this is just dummy data.

ENT-3090

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3090