### PR TITLE
ENT-3152: updating license activation/reminder email text

### DIFF
--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -8,15 +8,15 @@
         {% endfilter %}
     </p>
     <p>
-        {% if REMINDER %} {% trans "Reminder - your edX license is awaiting activation!" %} {% endif %}
+        {% if REMINDER %}{% trans "Reminder - your edX license is awaiting activation!" %}<br><br>{% endif %}
 
-        {% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
+        {% trans "You have been assigned a license to an edX Enterprise Subscription. edX offers high-quality online courses from the world's best universities and institutions. After activating your license, you'll have instant access to enroll in a wide-array of courses." %}
         <br><br>
-        <a href="{{ LICENSE_ACTIVATION_LINK }}">{% trans "Activate your edX license" %}</a>
+        <a href="{{ LICENSE_ACTIVATION_LINK }}">{% trans "Activate your license" %}</a>{% trans " and begin your learning journey." %}
         <br><br>
-        {% trans "edX Login:" %} {{ USER_EMAIL }}
+        {% trans "edX Login: " %}{{ USER_EMAIL }}
         <br>
-        {% trans "Expiration Date:" %} {{ EXPIRATION_DATE }}
+        {% trans "Expiration Date: " %}{{ EXPIRATION_DATE }}
     </p>
     <p>
         {% filter force_escape %}

--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -7,13 +7,17 @@
             {{ TEMPLATE_GREETING }}
         {% endfilter %}
     </p>
+    {% if REMINDER %}
+        <p>
+            {% trans "Reminder - your edX license is awaiting activation!" %}
+        </p>
+    {% endif %}
     <p>
-        {% if REMINDER %}{% trans "Reminder - your edX license is awaiting activation!" %}<br><br>{% endif %}
-
         {% trans "You have been assigned a license to an edX Enterprise Subscription. edX offers high-quality online courses from the world's best universities and institutions. After activating your license, you'll have instant access to enroll in a wide-array of courses." %}
-        <br><br>
+    </p>
+    <p>
         <a href="{{ LICENSE_ACTIVATION_LINK }}">{% trans "Activate your license" %}</a>{% trans " and begin your learning journey." %}
-        <br><br>
+    </p>
         {% trans "edX Login: " %}{{ USER_EMAIL }}
         <br>
         {% trans "Expiration Date: " %}{{ EXPIRATION_DATE }}

--- a/license_manager/templates/email/activation.txt
+++ b/license_manager/templates/email/activation.txt
@@ -2,15 +2,15 @@
 
 {{ TEMPLATE_GREETING }}
 
-{% if REMINDER %} {% trans "Reminder - your edX license is awaiting activation!" %} {% endif %}
+{% if REMINDER %}{% trans "Reminder - your edX license is awaiting activation!" %}{% endif %}
 
-{% trans "You may redeem your license for any course(s) that are in your organization's subscription catalog. To redeem:" %}
+{% trans "You have been assigned a license to an edX Enterprise Subscription. edX offers high-quality online courses from the world's best universities and institutions. After activating your license, you'll have instant access to enroll in a wide-array of courses." %}
 
-{{ LICENSE_ACTIVATION_LINK }}
+{% trans "Activate your license and begin your learning journey: " %}{{ LICENSE_ACTIVATION_LINK }}
 
-{% trans "edX Login:" %} {{ USER_EMAIL }}
-{% trans "Expiration Date:" %} {{ EXPIRATION_DATE }}
+{% trans "edX Login: " %}{{ USER_EMAIL }}
+{% trans "Expiration Date: " %}{{ EXPIRATION_DATE }}
 
 {{ TEMPLATE_CLOSING }}
 
-{% trans "Unsubscribe:" %} {{ UNSUBSCRIBE_LINK }}
+{% trans "Unsubscribe: " %}{{ UNSUBSCRIBE_LINK }}


### PR DESCRIPTION
## Description

Updated the text for license activation and reminder emails. 

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3152

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
