### PR TITLE
Remove enrollment_link field from license-subsidy

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1062,7 +1062,6 @@ class LicenseSubsidyViewTests(TestCase):
             'subsidy_id': str(self.activated_license.uuid),
             'start_date': str(self.active_subscription_for_customer.start_date),
             'expiration_date': str(self.active_subscription_for_customer.expiration_date),
-            'enrollment_link': '',
         }
 
     @mock.patch('license_manager.apps.api.v1.views.SubscriptionPlan.contains_content')

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -386,7 +386,5 @@ class LicenseSubidyView(APIView):
             'subsidy_id': user_license.uuid,
             'start_date': subscription_plan.start_date,
             'expiration_date': subscription_plan.expiration_date,
-            # TODO: Enrollment link to be implemented by https://openedx.atlassian.net/browse/ENT-3079
-            'enrollment_link': '',
         })
         return Response(ordered_data)


### PR DESCRIPTION
As we have decided to adjust ENT-3079 to instead create the enrollment
url on the frontend, we no longer need to supply the enrollment link
that was going to provide the route to the backend's enrollment view.