### PR TITLE
create a new license-activation view.

### DIFF
--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -1,10 +1,13 @@
 """ Utility functions. """
+import uuid
 from datetime import datetime
 
 from django.shortcuts import get_object_or_404
+from edx_rbac.utils import get_decoded_jwt
 from pytz import UTC
+from rest_framework.exceptions import ParseError
 
-from license_manager.apps.subscriptions.models import SubscriptionPlan
+from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 
 def localized_utcnow():
@@ -22,3 +25,61 @@ def get_subscription_plan_from_enterprise(request):
         enterprise_customer_uuid=enterprise_customer_uuid,
         is_active=True,
     )
+
+
+def get_activation_key_from_request(request, email_from_jwt=None):
+    """
+    Helper function to get an ``activation_key``, in the form of a UUID4, from a
+    request's query params.
+
+    Params:
+        ``request`` - A DRF Request object.
+        ``email_from_jwt`` (optional, str) - An email that has already been found in the request's JWT.
+    Returns: An activation_key UUID.
+    """
+    if not email_from_jwt:
+        email_from_jwt = get_email_from_jwt(get_decoded_jwt(request))
+
+    try:
+        return uuid.UUID(request.query_params['activation_key'])
+    except KeyError:
+        raise ParseError('activation_key is a required parameter')
+    except ValueError:
+        raise ParseError('{} is not a valid activation key.'.format(request.query_params['activation_key']))
+
+
+def get_user_id_from_jwt(decoded_jwt):
+    """
+    Helper function to get the ``user_id`` key out of a decoded JWT.
+    """
+    return decoded_jwt.get('user_id')
+
+
+def get_email_from_jwt(decoded_jwt):
+    """
+    Helper function to get the ``email`` key out of a decoded JWT.
+    """
+    return decoded_jwt.get('email')
+
+
+def get_subscription_plan_by_activation_key(request):
+    """
+    Helper function to return the active subscription plan associated
+    with the license identified by the `activation_key` query param on a request
+    and the ``email`` provided in the renquest's JWT.
+
+    Params:
+        ``request`` - A DRF Request object.
+    Returns: A ``SubscriptionPlan`` object.
+    """
+    activation_key = get_activation_key_from_request(request)
+
+    email_from_jwt = get_email_from_jwt(get_decoded_jwt(request))
+
+    user_license = get_object_or_404(
+        License,
+        activation_key=activation_key,
+        user_email=email_from_jwt,
+        subscription_plan__is_active=True,
+    )
+    return user_license.subscription_plan

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -73,5 +73,10 @@ urlpatterns = [
         views.LicenseSubidyView.as_view(),
         name='license-subsidy',
     ),
+    url(
+        r'license-activation',
+        views.LicenseActivationView.as_view(),
+        name='license-activation',
+    ),
 ]
 urlpatterns += router.urls + subscription_router.urls

--- a/license_manager/docker_gunicorn_configuration.py
+++ b/license_manager/docker_gunicorn_configuration.py
@@ -15,6 +15,7 @@ def pre_request(worker, req):
     worker.log.info("%s %s" % (req.method, req.path))
 
 
+# pylint: disable=import-outside-toplevel
 def close_all_caches():
     """
     Close the cache so that newly forked workers cannot accidentally share

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,55 +7,58 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.14.10            # via django-ses
-botocore==1.17.10         # via boto3, s3transfer
+boto3==1.14.20            # via django-ses
+botocore==1.17.20         # via boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
+cryptography==2.9.2       # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.in
 django-crum==0.7.6        # via edx-rbac
-django-extensions==2.2.9  # via -r requirements/base.in
+django-extensions==3.0.2  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.1         # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
-drf-jwt==1.14.0           # via edx-drf-extensions
+drf-jwt==1.16.2           # via edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
-edx-celeryutils==0.5.0    # via -r requirements/base.in
+edx-celeryutils==0.5.1    # via -r requirements/base.in
 edx-django-utils==3.2.3   # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==6.1.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.in
 future==0.18.2            # via django-ses, edx-celeryutils, pyjwkest
-idna==2.9                 # via requests
+idna==2.10                # via requests
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==4.0.0.post0   # via edx-celeryutils
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
-mysqlclient==1.4.6        # via -r requirements/base.in
+mysqlclient==2.0.1        # via -r requirements/base.in
 newrelic==5.14.1.144      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
 psutil==1.2.1             # via edx-django-utils
+pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions
-python3-openid==3.1.0     # via social-auth-core
+python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django, django-ses
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
@@ -65,7 +68,7 @@ rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger
-six==1.15.0               # via django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,17 +9,19 @@ anyjson==0.3.3            # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/validation.txt, pytest
 billiard==3.3.0.23        # via -r requirements/validation.txt, celery
-boto3==1.14.10            # via -r requirements/validation.txt, django-ses
-botocore==1.17.10         # via -r requirements/validation.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/validation.txt, django-ses
+botocore==1.17.20         # via -r requirements/validation.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/validation.txt, requests
+cffi==1.14.0              # via -r requirements/validation.txt, cryptography
 chardet==3.0.4            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.4   # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
-coverage==5.1             # via -r requirements/validation.txt, pytest-cov
+coverage==5.2             # via -r requirements/validation.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/validation.txt, pyjwt
 ddt==1.4.1                # via -r requirements/dev.in, -r requirements/validation.txt
 defusedxml==0.6.0         # via -r requirements/validation.txt, python3-openid, social-auth-core
 diff-cover==3.0.1         # via -r requirements/dev.in
@@ -27,33 +29,34 @@ django-cors-headers==3.4.0  # via -r requirements/validation.txt
 django-crum==0.7.6        # via -r requirements/validation.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
-django-extensions==2.2.9  # via -r requirements/validation.txt
+django-extensions==3.0.2  # via -r requirements/validation.txt
 django-filter==2.3.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
 django-ses==1.0.1         # via -r requirements/validation.txt
 django-simple-history==2.11.0  # via -r requirements/validation.txt
 django-waffle==1.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/validation.txt, botocore
-drf-jwt==1.14.0           # via -r requirements/validation.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/validation.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
-edx-celeryutils==0.5.0    # via -r requirements/validation.txt
+edx-celeryutils==0.5.1    # via -r requirements/validation.txt
 edx-django-utils==3.2.3   # via -r requirements/validation.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/validation.txt, edx-rbac
+edx-drf-extensions==6.1.0  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
-edx-lint==1.4.1           # via -r requirements/validation.txt
+edx-lint==1.5.0           # via -r requirements/validation.txt
 edx-opaque-keys==2.1.0    # via -r requirements/validation.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/validation.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/validation.txt
 factory-boy==2.12.0       # via -r requirements/validation.txt
 faker==4.1.1              # via -r requirements/validation.txt, factory-boy
+freezegun==0.3.15         # via -r requirements/validation.txt
 future==0.18.2            # via -r requirements/validation.txt, django-ses, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
-idna==2.9                 # via -r requirements/validation.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/validation.txt, inflect, path, pluggy, pytest
+idna==2.10                # via -r requirements/validation.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/validation.txt, inflect, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/dev.in, jinja2-pluralize
 isort==4.3.21             # via -r requirements/validation.txt, pylint
 itypes==1.2.0             # via -r requirements/validation.txt, coreapi
@@ -67,7 +70,7 @@ markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/validation.txt
 more-itertools==8.4.0     # via -r requirements/validation.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/validation.txt
+mysqlclient==2.0.1        # via -r requirements/validation.txt
 newrelic==5.14.1.144      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
@@ -82,23 +85,24 @@ polib==1.1.0              # via -r requirements/validation.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/validation.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/validation.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/validation.txt
+pycparser==2.20           # via -r requirements/validation.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/validation.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/validation.txt
 pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/validation.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/validation.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/validation.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/validation.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/validation.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/validation.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/validation.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/validation.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/validation.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/validation.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/validation.txt
 pytest-django==3.9.0      # via -r requirements/validation.txt
 pytest==5.4.3             # via -r requirements/validation.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/validation.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/validation.txt, social-auth-core
+python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via -r requirements/validation.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
 pytz==2020.1              # via -r requirements/validation.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-i18n-tools
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/validation.txt
@@ -109,7 +113,7 @@ rules==2.2                # via -r requirements/validation.txt
 s3transfer==0.3.3         # via -r requirements/validation.txt, boto3
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,50 +12,53 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-boto3==1.14.10            # via -r requirements/test.txt, django-ses
-botocore==1.17.10         # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/test.txt, django-ses
+botocore==1.17.20         # via -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==2.2.9  # via -r requirements/test.txt
+django-extensions==3.0.2  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-ses==1.0.1         # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.15.2          # via -r requirements/test.txt, botocore, doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
-edx-celeryutils==0.5.0    # via -r requirements/test.txt
+edx-celeryutils==0.5.1    # via -r requirements/test.txt
 edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/test.txt, edx-rbac
-edx-lint==1.4.1           # via -r requirements/test.txt
+edx-drf-extensions==6.1.0  # via -r requirements/test.txt, edx-rbac
+edx-lint==1.5.0           # via -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
+freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
-idna==2.9                 # via -r requirements/test.txt, requests
+idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.1  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
@@ -67,7 +70,7 @@ markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/test.txt
+mysqlclient==2.0.1        # via -r requirements/test.txt
 newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
@@ -76,22 +79,23 @@ pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
+python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 readme-renderer==26.0     # via -r requirements/doc.in
@@ -104,12 +108,12 @@ rules==2.2                # via -r requirements/test.txt
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.1.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,32 +7,34 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.10            # via -r requirements/base.txt, django-ses
-botocore==1.17.10         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/base.txt, django-ses
+botocore==1.17.20         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==2.2.9  # via -r requirements/base.txt
+django-extensions==3.0.2  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.1         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.0    # via -r requirements/base.txt
+edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
+edx-drf-extensions==6.1.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -40,26 +42,27 @@ future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celery
 gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
-idna==2.9                 # via -r requirements/base.txt, requests
+idna==2.10                # via -r requirements/base.txt, requests
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==1.4.6        # via -r requirements/base.txt
+mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
-python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/production.in
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -70,7 +73,7 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,40 +8,42 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.10            # via -r requirements/base.txt, django-ses
-botocore==1.17.10         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/base.txt, django-ses
+botocore==1.17.20         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==2.2.9  # via -r requirements/base.txt
+django-extensions==3.0.2  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.1         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.0    # via -r requirements/base.txt
+edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.4.1           # via -r requirements/quality.in
+edx-drf-extensions==6.1.0  # via -r requirements/base.txt, edx-rbac
+edx-lint==1.5.0           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
-idna==2.9                 # via -r requirements/base.txt, requests
+idna==2.10                # via -r requirements/base.txt, requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
@@ -51,24 +53,25 @@ kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==1.4.6        # via -r requirements/base.txt
+mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
-python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
@@ -78,7 +81,7 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,6 +10,7 @@ ddt
 django-dynamic-fixture    # library to create dynamic model instances for testing purposes
 edx-lint
 factory-boy
+freezegun
 mock
 pytest-cov
 pytest-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,23 +9,25 @@ anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.10            # via -r requirements/base.txt, django-ses
-botocore==1.17.10         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/base.txt, django-ses
+botocore==1.17.20         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.1             # via -r requirements/test.in, pytest-cov
+coverage==5.2             # via -r requirements/test.in, pytest-cov
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==2.2.9  # via -r requirements/base.txt
+django-extensions==3.0.2  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
@@ -34,21 +36,22 @@ django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.0    # via -r requirements/base.txt
+edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.4.1           # via -r requirements/test.in
+edx-drf-extensions==6.1.0  # via -r requirements/base.txt, edx-rbac
+edx-lint==1.5.0           # via -r requirements/test.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via factory-boy
+freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
-idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.1  # via pluggy, pytest
+idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
@@ -60,7 +63,7 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
-mysqlclient==1.4.6        # via -r requirements/base.txt
+mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
@@ -69,21 +72,22 @@ pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions, faker
-python-slugify==4.0.0     # via code-annotations
-python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via code-annotations
+python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, code-annotations
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -94,7 +98,7 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,48 +9,51 @@ anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/tes
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.10            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.10         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.20            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.17.20         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==2.2.9  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.2  # via -r requirements/quality.txt, -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-ses==1.0.1         # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/quality.txt, -r requirements/test.txt, botocore
-drf-jwt==1.14.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==0.5.0    # via -r requirements/quality.txt, -r requirements/test.txt
+edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.2.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-drf-extensions==6.1.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
-edx-lint==1.4.1           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-lint==1.5.0           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.1           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
+freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
-idna==2.9                 # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/test.txt, path, pluggy, pytest
+idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/test.txt, path, pluggy, pytest
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema
@@ -62,7 +65,7 @@ markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/tes
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/quality.txt, -r requirements/test.txt
+mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
 newrelic==5.14.1.144      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
@@ -76,22 +79,23 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.txt
+pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, botocore, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
+python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
@@ -102,7 +106,7 @@ rules==2.2                # via -r requirements/quality.txt, -r requirements/tes
 s3transfer==0.3.3         # via -r requirements/quality.txt, -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends


### PR DESCRIPTION
## Description

One change from original AC - don't put the `activation_key` in the route.  It makes it harder to do a lookup for permission-checking using the RBAC decorator.  Also, it makes our set of license endpoints inconsistent; we'd parameterize the `uuid` field in one set, by then the `activation_key` in another.  Instead, use an unparameterized route and make `activation_key` a query parameter.

Open Questions:
* Making a POST request with an empty body but a meaningful query parameter feels a little weird.  Is there a more appropriate request type?  Or should we use the body to store the value that we're doing a lookup by?

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3098

## Testing considerations

- In Postman, get a new JWT associated with an email (e.g. edx@example.com).
- Assign a License to that user.
- Get into your local Django shell, find a license that's been assigned to your user, set it's `activation_key` attribute to a new UUID4, and save it.  Copy the `activation_key`
- Make a POST request to http://localhost:18170/api/v1/license-activation?activation_key={your_activation_key}
- Should get a 204 response.  You should also notice that your license object now is activated, has an activation date, and an lms_user_id.

## Post-review

Squash commits into discrete sets of changes
