### PR TITLE
Added custom filter for License

### DIFF
--- a/license_manager/apps/api/filters.py
+++ b/license_manager/apps/api/filters.py
@@ -1,0 +1,20 @@
+"""
+Filters for the License API.
+"""
+
+from django_filters import rest_framework as filters
+
+from license_manager.apps.subscriptions.models import License
+
+
+class LicenseStatusFilter(filters.FilterSet):
+    """Filter for License Status"""
+    status = filters.CharFilter(method='filter_by_status')
+
+    class Meta:
+        model = License
+        fields = ['status']
+
+    def filter_by_status(self, queryset, name, value):  # pylint: disable=unused-argument
+        status_values = value.strip().split(',')
+        return queryset.filter(status__in=status_values).distinct()

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from license_manager.apps.api import serializers, utils
+from license_manager.apps.api.filters import LicenseStatusFilter
 from license_manager.apps.api.tasks import (
     send_activation_email_task,
     send_reminder_email_task,
@@ -94,7 +95,7 @@ class LicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelVi
         'last_remind_date',
     ]
     search_fields = ['user_email']
-    filterset_fields = ['status']
+    filter_class = LicenseStatusFilter
     permission_required = constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
 
     # The fields that control permissions for 'list' actions.


### PR DESCRIPTION
## Description

Description of changes made
Added support for custom filtering for license api, this is being done to fix issues at the frontend.


Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3150

## Testing considerations

- The License api should now also work when multiple query params for the same key are passed. For example, 
http://localhost:18170/api/v1/subscriptions/28fe2977-01a5-443d-947f-37c73bd715f3/licenses/?status=assigned,activated,deactivated


## Post-review

Squash commits into discrete sets of changes
