### PR TITLE
Add back SessionAuthentication to views using jwt

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -970,16 +970,6 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
             query_params['course_key'] = self.course_key
         return url + '/?' + query_params.urlencode()
 
-    def test_get_subsidy_no_jwt(self):
-        """
-        Verify the view returns a 401 for users trying to authenticate without a JWT (that is, using session auth).
-        """
-        client = APIClient()
-        client.login(username=self.user.username, password=USER_PASSWORD)
-        url = self._get_url_with_params()
-        response = client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
     def test_get_subsidy_missing_role(self):
         """
         Verify the view returns a 403 for users without the learner role.

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -340,7 +340,6 @@ class LicenseBaseView(APIView):
     Base view for creating specific, one-off views
     that deal with licenses.
     """
-    authentication_classes = [JwtAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     @cached_property

--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -6,6 +6,7 @@ from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 @admin.register(License)
 class LicenseAdmin(admin.ModelAdmin):
+    readonly_fields = ['activation_key']
     exclude = ['history']
 
 


### PR DESCRIPTION
Previously SessionAuthentication was removed as it was thought that
these views only needed JWT auth to function, but it seems that
frontend-platform's auth api client needs both to work properly.
Also adds activation_key to be visible in Django Admin to help
developers.