### PR TITLE
Update api utils to 400 when keys missing from JWT

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -349,11 +349,11 @@ class LicenseBaseView(APIView):
 
     @property
     def lms_user_id(self):
-        return utils.get_user_id_from_jwt(self.decoded_jwt)
+        return utils.get_key_from_jwt(self.decoded_jwt, 'user_id')
 
     @property
     def user_email(self):
-        return utils.get_email_from_jwt(self.decoded_jwt)
+        return utils.get_key_from_jwt(self.decoded_jwt, 'email')
 
 
 class LicenseSubidyView(LicenseBaseView):
@@ -421,7 +421,8 @@ class LicenseActivationView(LicenseBaseView):
         Route: /api/v1/license-activation?activation_key=your-key
 
         Returns:
-            * 400 Bad Request - if the ``activation_key`` query parameter is malformed or missing.
+            * 400 Bad Request - if the ``activation_key`` query parameter is malformed or missing, or if
+                the user's email could not be found in the jwt.
             * 401 Unauthorized - if the requesting user is not authenticated.
             * 403 Forbidden - if the requesting user is not allowed to access the associated
                  license's subscription plan.


### PR DESCRIPTION
As we need the views that rely on the user's info from the JWT to also
have session authentication (in order for calls from the learner-portal
to work), there is a chance that calls from the browser may not have a
JWT associated with them. This shouldn't happen frequently (if at all),
as these views are not meant to be used from the browser, but this
update ensures that an error is raised and information is returned in
the case that it does occur.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
