### PR TITLE
add urls and subscription learner viewset

### DIFF
--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -52,19 +52,30 @@ class NestedSimpleRouter(NestedMixin, routers.SimpleRouter):
 
 router = routers.SimpleRouter()
 router.register(
-    prefix=r'subscriptions',
+    prefix=r'learner-subscriptions',
+    viewset=views.LearnerSubscriptionViewSet,
+    basename='learner-subscriptions',
+)
+router.register(
+    prefix=r'(?<!learner-)subscriptions',
     viewset=views.SubscriptionViewSet,
     basename='subscriptions',
 )
 
 subscription_router = NestedSimpleRouter(
     parent_router=router,
-    parent_prefix=r'subscriptions',
+    parent_prefix=r'(?<!learner-)subscriptions',
 )
 subscription_router.register(
     r'licenses',
     views.LicenseViewSet,
     basename='licenses',
+)
+
+subscription_router.register(
+    r'license(?![^\/])',
+    views.LearnerLicenseViewSet,
+    basename='license',
 )
 
 urlpatterns = [


### PR DESCRIPTION
## Description

Added endpoints to allow a learner to see their license on a subscription and view info about their enterprises active subscriptions.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3169

### New urls are: 

**Viewing enterprises subscriptions:** http://localhost:18170/api/v1/learner-subscriptions/

**Viewing own license on subscription:** http://localhost:18170/api/v1/subscriptions/4c847ed4-3e93-4fc4-9d53-ba2b66300378/license/