### PR TITLE
ENT-3223 | Add a bookmarkable link to the license activation emails.

### DIFF
--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -72,6 +72,7 @@ def _send_email_with_activation(
     for email_address in email_recipient_list:
         # Construct user specific context for each message
         context.update({
+            'LEARNER_PORTAL_LINK': _learner_portal_link(enterprise_slug),
             'LICENSE_ACTIVATION_LINK': _generate_license_activation_link(
                 enterprise_slug,
                 email_activation_key_map.get(email_address)
@@ -93,8 +94,20 @@ def _generate_license_activation_link(enterprise_slug, activation_key):
     """
     Returns the activation link displayed in the activation email sent to a learner
     """
-    return settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_slug + '/licenses/' +\
-        activation_key + '/activate'
+    return '/'.join((
+        _learner_portal_link(enterprise_slug),
+        'licenses',
+        activation_key,
+        'activate'
+    ))
+
+
+def _learner_portal_link(enterprise_slug):
+    """
+    Returns the link to the learner portal, given an enterprise slug.
+    Does not contain a trailing slash.
+    """
+    return settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_slug
 
 
 def _get_rendered_template_content(template_name, extension, context):

--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -23,6 +23,12 @@
         {% trans "Expiration Date: " %}{{ EXPIRATION_DATE }}
     </p>
     <p>
+        {% trans "You can bookmark the following link to easily access your learning portal in the future." %}
+    </p>
+    <p>
+        <a href="{{ LEARNER_PORTAL_LINK }}">{% trans "Access your learning portal" %}</a>
+    </p>
+    <p>
         {% filter force_escape %}
             {{ TEMPLATE_CLOSING }}
         {% endfilter %}

--- a/license_manager/templates/email/activation.txt
+++ b/license_manager/templates/email/activation.txt
@@ -11,6 +11,8 @@
 {% trans "edX Login: " %}{{ USER_EMAIL }}
 {% trans "Expiration Date: " %}{{ EXPIRATION_DATE }}
 
+{% trans "You can bookmark the following link to easily access your learning portal in the future: " %}{{ LEARNER_PORTAL_LINK }}
+
 {{ TEMPLATE_CLOSING }}
 
 {% trans "Unsubscribe: " %}{{ UNSUBSCRIBE_LINK }}


### PR DESCRIPTION
## Description

Adds a message and link to the learner portal home page to license activation emails.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3223

## Testing considerations

- OK instructions: throw a breakpoint or `assert False` in the email unit tests and print the content of the `message` to see what the emails will look like (for either the text or the HTML).
- TODO: better manual testing instructions.

## Post-review

Squash commits into discrete sets of changes
