### PR TITLE
change the default ordering to be license status and then email alpha…

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -183,7 +183,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
         For non-list actions, this is what's returned by `get_queryset()`.
         For list actions, some non-strict subset of this is what's returned by `get_queryset()`.
         """
-        return License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('-activation_date')
+        return License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('status', 'user_email')
 
     def _get_custom_text(self, data):
         """


### PR DESCRIPTION
…betical

## Description

Change the fields licenses are ordered by to be by the license status (activated -> assigned -> deactivated) and then by emails within each of those license statuses.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3195

