### PR TITLE
Remove the 1 year min. validation on subscriptions

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -1,8 +1,6 @@
 """
 Forms to be used in the subscriptions django app.
 """
-import datetime as dt
-
 from django import forms
 
 from license_manager.apps.subscriptions.models import SubscriptionPlan
@@ -25,14 +23,6 @@ class SubscriptionPlanForm(forms.ModelForm):
         if self.cleaned_data.get('num_licenses', 0) < self.instance.num_licenses:
             self.add_error('num_licenses', 'Number of Licenses cannot be decreased.')
             return False
-
-        # Ensure the expiration date is at least one year after start date if has been submitted
-        expiration_date = self.cleaned_data.get('expiration_date')
-        start_date = self.cleaned_data.get('start_date')
-        if expiration_date and start_date:
-            if expiration_date < start_date + dt.timedelta(days=365):
-                self.add_error('expiration_date', 'Expiration Date must be at least a year after the Start Date.')
-                return False
 
         return True
 

--- a/license_manager/apps/subscriptions/tests/test_forms.py
+++ b/license_manager/apps/subscriptions/tests/test_forms.py
@@ -1,4 +1,3 @@
-from datetime import date, timedelta
 from unittest import TestCase
 
 import ddt
@@ -29,17 +28,4 @@ class TestSubscriptionPlanForm(TestCase):
         Test to check validation conditions for the num_licenses field
         """
         form = make_bound_subscription_form(num_licenses=num_licenses)
-        assert form.is_valid() is is_valid
-
-    @ddt.data(
-        (date.today() - timedelta(days=1), False),  # Validation fails when expiration is before start_date
-        (date.today(), False),                      # Validation fails when expiration_date is start_date
-        (date.today() + timedelta(days=365), True)  # Validation passes when expiration_date is 1 year after start_date
-    )
-    @ddt.unpack
-    def test_expiration_date(self, expiration_date, is_valid):
-        """
-        Test to check validation conditions for the expiration_date field
-        """
-        form = make_bound_subscription_form(expiration_date=expiration_date)
         assert form.is_valid() is is_valid


### PR DESCRIPTION
Removing this as we will have customers signing deals for 6 month
subscriptions for the pilot.

ENT-3291