### PR TITLE
change to audit mode upon revoke

### DIFF
--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -15,6 +15,7 @@ class EnterpriseApiClient(BaseOAuthClient):
     api_base_url = settings.LMS_URL + '/enterprise/api/v1/'
     enterprise_customer_endpoint = api_base_url + 'enterprise-customer/'
     pending_enterprise_learner_endpoint = api_base_url + 'pending-enterprise-learner/'
+    license_revoke_endpoint = api_base_url + 'licensed-enterprise-course-enrollment/license_revoke/'
 
     def get_enterprise_slug(self, enterprise_customer_uuid):
         """
@@ -47,5 +48,29 @@ class EnterpriseApiClient(BaseOAuthClient):
             msg = (
                 'Failed to create a pending enterprise user for enterprise with uuid: {uuid}. '
                 'Response: {response}'.format(uuid=enterprise_customer_uuid, response=response.json())
+            )
+            logger.error(msg)
+
+    def update_course_enrollment_mode_for_user(self, user_id, mode):
+        """
+        Call the enrollment API to update a user's course enrollment to the specified mode, e.g. "audit".
+
+        Args:
+            user_id (int): The user_id for the user
+            mode (str): The string value of the course mode, e.g. "audit"
+
+        Returns:
+            dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
+        """
+        data = {'user_id': user_id, 'mode': mode}
+        response = self.client.post(self.license_revoke_endpoint, json=data)
+        if response.status_code >= 400:
+            msg = (
+                'Failed to update enrollment mode to "{mode}" for user "{user_id}". '
+                'Response: {response}'.format(
+                    mode=mode,
+                    user_id=user_id,
+                    response=response.content,
+                )
             )
             logger.error(msg)

--- a/license_manager/apps/api_client/tests/test_enterprise_client.py
+++ b/license_manager/apps/api_client/tests/test_enterprise_client.py
@@ -6,6 +6,7 @@ import mock
 from django.test import TestCase
 
 from license_manager.apps.api_client.enterprise import EnterpriseApiClient
+from license_manager.apps.subscriptions import constants
 from license_manager.test_utils import MockResponse
 
 
@@ -21,6 +22,7 @@ class EnterpriseApiClientTests(TestCase):
 
         cls.uuid = uuid4()
         cls.user_email = 'test@example.com'
+        cls.user_id = 3
         cls.content_ids = ['demoX', 'testX']
 
     @mock.patch('license_manager.apps.api_client.enterprise.logger', return_value=mock.MagicMock())
@@ -33,4 +35,20 @@ class EnterpriseApiClientTests(TestCase):
         mock_oauth_client().post.return_value = MockResponse({'detail': 'Bad Request'}, 400)
 
         EnterpriseApiClient().create_pending_enterprise_user(self.uuid, self.user_email)
+        mock_logger.error.assert_called_once()
+
+    @mock.patch('license_manager.apps.api_client.enterprise.logger', return_value=mock.MagicMock())
+    @mock.patch('license_manager.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_update_course_enrollment_mode_for_user_with_error(self, mock_oauth_client, mock_logger):
+        """
+        Verify the ``update_course_enrollment_mode_for_user`` method logs an error for a status code of >=400.
+        """
+        # Mock out the response from the lms
+        mock_oauth_client().post.return_value = MockResponse({'detail': 'Bad Request'}, 400)
+        mock_oauth_client().post.return_value.content = 'error response'
+
+        EnterpriseApiClient().update_course_enrollment_mode_for_user(
+            user_id=self.user_id,
+            mode=constants.AUDIT_COURSE_MODE,
+        )
         mock_logger.error.assert_called_once()

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -36,3 +36,6 @@ LICENSE_DISCOUNT_VALUE = 100  # Represents a 100% off value
 
 # Salesforce constants
 SALESFORCE_ID_LENGTH = 18  # The salesforce_opportunity_id must be exactly 18 characters
+
+# Audit course mode
+AUDIT_COURSE_MODE = 'audit'


### PR DESCRIPTION
## Description

Upon license revocation for a user, make an API call to change their licensed course enrollments to the "audit" course mode.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-2891

Tests still coming.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
