### PR TITLE
change to audit mode upon revoke

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -69,3 +69,16 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
         return
 
     License.set_last_remind_date_to_now(pending_licenses)
+
+
+@shared_task(base=LoggedTask)
+def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
+    """
+    Sends revoking the user's enterprise licensed course enrollments asynchronously
+
+    Arguments:
+        user_id (str): The ID of the user who had an enterprise license revoked
+        enterprise_id (str): The ID of the enterprise to revoke course enrollments for
+    """
+    enterprise_api_client = EnterpriseApiClient()
+    enterprise_api_client.revoke_course_enrollments_for_user(user_id=user_id, enterprise_id=enterprise_id)

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -21,6 +21,7 @@ from license_manager.apps.api import serializers, utils
 from license_manager.apps.api.filters import LicenseStatusFilter
 from license_manager.apps.api.tasks import (
     activation_task,
+    revoke_course_enrollments_for_user_task,
     send_reminder_email_task,
 )
 from license_manager.apps.subscriptions import constants
@@ -370,10 +371,19 @@ class LicenseViewSet(LearnerLicenseViewSet):
             return Response(msg, status=status.HTTP_404_NOT_FOUND)
 
         # Deactivate the license being revoked
+        original_license_status = user_license.status
         user_license.status = constants.DEACTIVATED
         user_license.save()
         # Create new license to add to the unassigned license pool
         subscription_plan.increase_num_licenses(1)
+
+        # Revoke existing user's licensed course enrollments
+        if original_license_status == constants.ACTIVATED:
+            revoke_course_enrollments_for_user_task.delay(
+                user_id=user_license.lms_user_id,
+                enterprise_id=subscription_plan.enterprise_customer_uuid,
+            )
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=['get'])

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -15,6 +15,7 @@ class EnterpriseApiClient(BaseOAuthClient):
     api_base_url = settings.LMS_URL + '/enterprise/api/v1/'
     enterprise_customer_endpoint = api_base_url + 'enterprise-customer/'
     pending_enterprise_learner_endpoint = api_base_url + 'pending-enterprise-learner/'
+    course_enrollments_revoke_endpoint = api_base_url + 'licensed-enterprise-course-enrollment/license_revoke/'
 
     def get_enterprise_slug(self, enterprise_customer_uuid):
         """
@@ -47,5 +48,29 @@ class EnterpriseApiClient(BaseOAuthClient):
             msg = (
                 'Failed to create a pending enterprise user for enterprise with uuid: {uuid}. '
                 'Response: {response}'.format(uuid=enterprise_customer_uuid, response=response.json())
+            )
+            logger.error(msg)
+
+    def revoke_course_enrollments_for_user(self, user_id, enterprise_id):
+        """
+        Calls the Enterprise API Client to revoke the user's enterprise licensed course enrollments
+
+        Arguments:
+            user_id (str): The ID of the user who had an enterprise license revoked
+            enterprise_id (str): The ID of the enterprise to revoke course enrollments for
+        """
+        data = {
+            'user_id': user_id,
+            'enterprise_id': enterprise_id,
+        }
+        response = self.client.post(self.course_enrollments_revoke_endpoint, json=data)
+        if response.status_code >= 400:
+            msg = (
+                'Failed to revoke course enrollments for user "{user_id}" and enterprise "{enterprise_id}". '
+                'Response: {response}'.format(
+                    user_id=user_id,
+                    enterprise_id=enterprise_id,
+                    response=response.content,
+                )
             )
             logger.error(msg)

--- a/license_manager/apps/api_client/tests/test_enterprise_client.py
+++ b/license_manager/apps/api_client/tests/test_enterprise_client.py
@@ -6,6 +6,7 @@ import mock
 from django.test import TestCase
 
 from license_manager.apps.api_client.enterprise import EnterpriseApiClient
+from license_manager.apps.subscriptions import constants
 from license_manager.test_utils import MockResponse
 
 
@@ -21,6 +22,7 @@ class EnterpriseApiClientTests(TestCase):
 
         cls.uuid = uuid4()
         cls.user_email = 'test@example.com'
+        cls.user_id = 3
         cls.content_ids = ['demoX', 'testX']
 
     @mock.patch('license_manager.apps.api_client.enterprise.logger', return_value=mock.MagicMock())
@@ -33,4 +35,20 @@ class EnterpriseApiClientTests(TestCase):
         mock_oauth_client().post.return_value = MockResponse({'detail': 'Bad Request'}, 400)
 
         EnterpriseApiClient().create_pending_enterprise_user(self.uuid, self.user_email)
+        mock_logger.error.assert_called_once()
+
+    @mock.patch('license_manager.apps.api_client.enterprise.logger', return_value=mock.MagicMock())
+    @mock.patch('license_manager.apps.api_client.base_oauth.OAuthAPIClient', return_value=mock.MagicMock())
+    def test_revoke_course_enrollments_for_user_with_error(self, mock_oauth_client, mock_logger):
+        """
+        Verify the ``update_course_enrollment_mode_for_user`` method logs an error for a status code of >=400.
+        """
+        # Mock out the response from the lms
+        mock_oauth_client().post.return_value = MockResponse({'detail': 'Bad Request'}, 400)
+        mock_oauth_client().post.return_value.content = 'error response'
+
+        EnterpriseApiClient().revoke_course_enrollments_for_user(
+            user_id=self.user_id,
+            enterprise_id=self.uuid,
+        )
         mock_logger.error.assert_called_once()


### PR DESCRIPTION
## Description

Upon license revocation for a user, make an API call to change their licensed course enrollments to the "audit" course mode.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-2891