### PR TITLE
cast UUID to string when revoking course enrollments

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -381,7 +381,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
         if original_license_status == constants.ACTIVATED:
             revoke_course_enrollments_for_user_task.delay(
                 user_id=user_license.lms_user_id,
-                enterprise_id=subscription_plan.enterprise_customer_uuid,
+                enterprise_id=str(subscription_plan.enterprise_customer_uuid),
             )
 
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Description

The subscription UUID when passed into the delay function isn't JSON serializable, we need to cast it first.