### PR TITLE
Ignore health endpoint check in newrelic

### DIFF
--- a/license_manager/apps/core/views.py
+++ b/license_manager/apps/core/views.py
@@ -8,6 +8,7 @@ from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
+from edx_django_utils.monitoring import ignore_transaction
 
 from license_manager.apps.core.constants import Status
 
@@ -33,6 +34,8 @@ def health(_):
         >>> response.content
         '{"overall_status": "OK", "detailed_status": {"database_status": "OK", "lms_status": "OK"}}'
     """
+    # Ignores health check in performance monitoring so as to not artifically inflate our response time metrics
+    ignore_transaction()
 
     try:
         cursor = connection.cursor()

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -24,7 +24,7 @@ def get_random_salesforce_id():
                    for _ in range(SALESFORCE_ID_LENGTH))
 
 
-class SubscriptionPlanFactory(factory.DjangoModelFactory):
+class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `SubscriptionPlan` model.
 
@@ -45,7 +45,7 @@ class SubscriptionPlanFactory(factory.DjangoModelFactory):
     salesforce_opportunity_id = factory.LazyFunction(get_random_salesforce_id)
 
 
-class LicenseFactory(factory.DjangoModelFactory):
+class LicenseFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `License` model.
 
@@ -60,7 +60,7 @@ class LicenseFactory(factory.DjangoModelFactory):
     subscription_plan = factory.SubFactory(SubscriptionPlanFactory)
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `User` model.
     """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,33 +7,33 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.14.30            # via django-ses
-botocore==1.17.30         # via boto3, s3transfer
+boto3==1.14.44            # via django-ses
+botocore==1.17.44         # via boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
-cffi==1.14.1              # via cryptography
+cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==3.0         # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.in
-django-crum==0.7.6        # via edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.in
+django-crum==0.7.7        # via edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.2         # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.17.0           # via edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-celeryutils==0.5.1    # via -r requirements/base.in
-edx-django-utils==3.5.0   # via -r requirements/base.in, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.in, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.in
@@ -47,16 +47,16 @@ jsonfield2==4.0.0.post0   # via edx-celeryutils
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.14.1.144      # via edx-django-utils
+newrelic==5.16.1.146      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
-psutil==1.2.1             # via edx-django-utils
+psutil==5.7.2             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.10.1           # via edx-opaque-keys
+pymongo==3.11.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django, django-ses
@@ -68,12 +68,12 @@ rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger
-six==1.15.0               # via cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via -c requirements/constraints.txt, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via botocore, requests
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,15 +9,15 @@ anyjson==0.3.3            # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/validation.txt, pytest
 billiard==3.3.0.23        # via -r requirements/validation.txt, celery
-boto3==1.14.30            # via -r requirements/validation.txt, django-ses
-botocore==1.17.30         # via -r requirements/validation.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/validation.txt, django-ses
+botocore==1.17.44         # via -r requirements/validation.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/validation.txt, requests
-cffi==1.14.1              # via -r requirements/validation.txt, cryptography
+cffi==1.14.2              # via -r requirements/validation.txt, cryptography
 chardet==3.0.4            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.4.0   # via -r requirements/validation.txt
+code-annotations==0.5.0   # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
 coverage==5.2.1           # via -r requirements/validation.txt, pytest-cov
@@ -26,38 +26,39 @@ ddt==1.4.1                # via -r requirements/dev.in, -r requirements/validati
 defusedxml==0.6.0         # via -r requirements/validation.txt, python3-openid, social-auth-core
 diff-cover==3.0.1         # via -r requirements/dev.in
 django-cors-headers==3.4.0  # via -r requirements/validation.txt
-django-crum==0.7.6        # via -r requirements/validation.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/validation.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
-django-extensions==3.0.3  # via -r requirements/validation.txt
+django-extensions==3.0.5  # via -r requirements/validation.txt
 django-filter==2.3.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
 django-ses==1.0.2         # via -r requirements/validation.txt
 django-simple-history==2.11.0  # via -r requirements/validation.txt
 django-waffle==1.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/validation.txt, botocore
-drf-jwt==1.16.2           # via -r requirements/validation.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/validation.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
 edx-celeryutils==0.5.1    # via -r requirements/validation.txt
-edx-django-utils==3.5.0   # via -r requirements/validation.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/validation.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
 edx-lint==1.5.0           # via -r requirements/validation.txt
 edx-opaque-keys==2.1.1    # via -r requirements/validation.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/validation.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/validation.txt
-factory-boy==2.12.0       # via -r requirements/validation.txt
-faker==4.1.1              # via -r requirements/validation.txt, factory-boy
+factory-boy==3.0.1        # via -r requirements/validation.txt
+faker==4.1.2              # via -r requirements/validation.txt, factory-boy
 freezegun==0.3.15         # via -r requirements/validation.txt
 future==0.18.2            # via -r requirements/validation.txt, django-ses, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.10                # via -r requirements/validation.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/validation.txt, inflect, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/dev.in, jinja2-pluralize
+iniconfig==1.0.1          # via -r requirements/validation.txt, pytest
 isort==4.3.21             # via -r requirements/validation.txt, pylint
 itypes==1.2.0             # via -r requirements/validation.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -71,7 +72,7 @@ mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/validation.txt
 more-itertools==8.4.0     # via -r requirements/validation.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/validation.txt
-newrelic==5.14.1.144      # via -r requirements/validation.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/validation.txt, pytest
@@ -79,10 +80,10 @@ path.py==12.5.0           # via -r requirements/validation.txt, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, -r requirements/validation.txt, path.py
 pathlib2==2.3.5           # via -r requirements/validation.txt
 pbr==5.4.5                # via -r requirements/validation.txt, stevedore
-pip-tools==5.3.0          # via -r requirements/pip-tools.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/validation.txt, diff-cover, pytest
 polib==1.1.0              # via -r requirements/validation.txt, edx-i18n-tools
-psutil==1.2.1             # via -r requirements/validation.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/validation.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/validation.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/validation.txt
 pycparser==2.20           # via -r requirements/validation.txt, cffi
@@ -95,11 +96,11 @@ pylint-celery==0.3        # via -r requirements/validation.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/validation.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/validation.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/validation.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/validation.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/validation.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/validation.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/validation.txt
+pytest-cov==2.10.1        # via -r requirements/validation.txt
 pytest-django==3.9.0      # via -r requirements/validation.txt
-pytest==5.4.3             # via -r requirements/validation.txt, pytest-cov, pytest-django
+pytest==6.0.1             # via -r requirements/validation.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/validation.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
@@ -113,18 +114,18 @@ rules==2.2                # via -r requirements/validation.txt
 s3transfer==0.3.3         # via -r requirements/validation.txt, boto3
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/validation.txt, django, django-debug-toolbar
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/validation.txt, faker, python-slugify
+toml==0.10.1              # via -r requirements/validation.txt, pytest
 typed-ast==1.4.1          # via -r requirements/validation.txt, astroid
 uritemplate==3.0.1        # via -r requirements/validation.txt, coreapi
 urllib3==1.25.10          # via -r requirements/validation.txt, botocore, requests
-wcwidth==0.2.5            # via -r requirements/validation.txt, pytest
 wrapt==1.11.2             # via -r requirements/validation.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/validation.txt, importlib-metadata
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,15 +12,15 @@ attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-boto3==1.14.30            # via -r requirements/test.txt, django-ses
-botocore==1.17.30         # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/test.txt, django-ses
+botocore==1.17.44         # via -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.1              # via -r requirements/test.txt, cryptography
+cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.4.0   # via -r requirements/test.txt
+code-annotations==0.5.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
@@ -28,37 +28,38 @@ cryptography==3.0         # via -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/test.txt
-django-crum==0.7.6        # via -r requirements/test.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.3  # via -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.15.2          # via -r requirements/test.txt, botocore, doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/test.txt
-edx-django-utils==3.5.0   # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.1              # via -r requirements/test.txt, factory-boy
+factory-boy==3.0.1        # via -r requirements/test.txt
+faker==4.1.2              # via -r requirements/test.txt, factory-boy
 freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
@@ -71,13 +72,13 @@ mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
@@ -88,11 +89,11 @@ pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
@@ -108,12 +109,12 @@ rules==2.2                # via -r requirements/test.txt
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.2.1             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -121,12 +122,12 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
+toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.0          # via -r requirements/pip-tools.in
+pip-tools==5.3.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,33 +7,33 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.30            # via -r requirements/base.txt, django-ses
-botocore==1.17.30         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/base.txt, django-ses
+botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.1              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 cryptography==3.0         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.5.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
@@ -50,16 +50,16 @@ jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
@@ -73,12 +73,12 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,11 +8,11 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.30            # via -r requirements/base.txt, django-ses
-botocore==1.17.30         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/base.txt, django-ses
+botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.1              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
@@ -21,22 +21,22 @@ coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 cryptography==3.0         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.5.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
@@ -54,11 +54,11 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -69,7 +69,7 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
@@ -81,13 +81,13 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,15 +9,15 @@ anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.30            # via -r requirements/base.txt, django-ses
-botocore==1.17.30         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/base.txt, django-ses
+botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.1              # via -r requirements/base.txt, cryptography
+cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.4.0   # via -r requirements/test.in
+code-annotations==0.5.0   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.in, pytest-cov
@@ -25,33 +25,34 @@ cryptography==3.0         # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-crum==0.7.6        # via -r requirements/base.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.3  # via -r requirements/base.txt
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.5.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.0           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
-factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.1              # via factory-boy
+factory-boy==3.0.1        # via -r requirements/test.in
+faker==4.1.2              # via factory-boy
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via pluggy, pytest
+iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
@@ -64,13 +65,13 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -80,11 +81,11 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
+pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov, pytest-django
+pytest==6.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
@@ -98,16 +99,16 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
+toml==0.10.1              # via pytest
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
-wcwidth==0.2.5            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,15 +9,15 @@ anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/tes
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.30            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.30         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.44            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.17.44         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
-cffi==1.14.1              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
+cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.4.0   # via -r requirements/test.txt
+code-annotations==0.5.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
@@ -25,35 +25,36 @@ cryptography==3.0         # via -r requirements/quality.txt, -r requirements/tes
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-crum==0.7.6        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.3  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/quality.txt, -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
-djangorestframework==3.11.0  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
+django==2.2.15            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/quality.txt, -r requirements/test.txt, botocore
-drf-jwt==1.16.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.5.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
 edx-lint==1.5.0           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
-factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.1              # via -r requirements/test.txt, factory-boy
+factory-boy==3.0.1        # via -r requirements/test.txt
+faker==4.1.2              # via -r requirements/test.txt, factory-boy
 freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/test.txt, path, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema
@@ -66,7 +67,7 @@ mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/tes
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.16.1.146      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest
@@ -76,7 +77,7 @@ pathlib2==2.3.5           # via -r requirements/validation.in
 pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
@@ -88,11 +89,11 @@ pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/tes
 pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
@@ -106,17 +107,17 @@ rules==2.2                # via -r requirements/quality.txt, -r requirements/tes
 s3transfer==0.3.3         # via -r requirements/quality.txt, -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/quality.txt, -r requirements/test.txt, django
-stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-opaque-keys
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
+toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, botocore, requests
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata


### PR DESCRIPTION
Performance monitoring was being thrown off by many successful & fast
health check calls which was hiding the application's true performance.

ENT-3292