### PR TITLE
Add command to retire user data on old licenses

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -35,6 +35,7 @@ from license_manager.apps.subscriptions.tests.factories import (
 )
 from license_manager.apps.subscriptions.tests.utils import (
     assert_date_fields_correct,
+    assert_license_fields_cleared,
 )
 from license_manager.apps.subscriptions.utils import localized_utcnow
 
@@ -807,13 +808,9 @@ class LicenseViewSetActionTests(TestCase):
         # Verify all the attributes on the formerly deactivated license are correct
         deactivated_license.refresh_from_db()
         self._assert_licenses_assigned([self.test_email])
-        assert deactivated_license.lms_user_id is None
-        assert deactivated_license.last_remind_date is None
-        assert deactivated_license.activation_date is None
+        assert_license_fields_cleared(deactivated_license)
         # Verify the activation key has been switched
         assert deactivated_license.activation_key is not original_activation_key
-        assert deactivated_license.assigned_date is None
-        assert deactivated_license.revoked_date is None
         mock_activation_task.assert_called_with(
             {'greeting': '', 'closing': ''},
             [self.test_email],

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -263,14 +263,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
         # Flip all deactivated licenses that were associated with emails that we are assigning to unassigned, and clear
         # all the old data on the license.
         for deactivated_license in deactivated_licenses_for_assignment:
-            deactivated_license.status = constants.UNASSIGNED
-            deactivated_license.user_email = None
-            deactivated_license.lms_user_id = None
-            deactivated_license.last_remind_date = None
-            deactivated_license.activation_date = None
-            deactivated_license.activation_key = None
-            deactivated_license.assigned_date = None
-            deactivated_license.revoked_date = None
+            deactivated_license.reset_to_unassigned()
         License.objects.bulk_update(
             deactivated_licenses_for_assignment,
             [

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -34,3 +34,6 @@ LICENSE_DISCOUNT_VALUE = 100  # Represents a 100% off value
 
 # Salesforce constants
 SALESFORCE_ID_LENGTH = 18  # The salesforce_opportunity_id must be exactly 18 characters
+
+# User retirements constants
+DAYS_TO_RETIRE = 90

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -1,0 +1,92 @@
+import logging
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+
+from license_manager.apps.subscriptions.constants import (
+    ASSIGNED,
+    DAYS_TO_RETIRE,
+    DEACTIVATED,
+    UNASSIGNED,
+)
+from license_manager.apps.subscriptions.models import License
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        'Retire user data on licenses which have not been activated for over 90 days, have been revoked but not '
+        ' reassigned for over 90 days, or whose associated subscription has expired for over 90 days.'
+    )
+
+    def handle(self, *args, **options):
+        # Any license that was assigned but not activated or revoked but not reassigned before this date should
+        # have its data scrubbed.
+        ready_for_retirement_date = datetime.today().date() - timedelta(DAYS_TO_RETIRE)
+
+        expired_licenses_for_retirement = License.objects.filter(
+            user_email__isnull=False,
+            subscription_plan__expiration_date__lt=ready_for_retirement_date,
+        )
+        # Scrub all piii on licenses whose subscription expired over 90 days ago, and mark the licenses as revoked
+        for expired_license in expired_licenses_for_retirement:
+            expired_license.user_email = None
+            expired_license.lms_user_id = None
+            expired_license.status = DEACTIVATED
+            expired_license.revoked_date = datetime.now()
+        License.objects.bulk_update(
+            expired_licenses_for_retirement,
+            ['user_email', 'lms_user_id', 'status', 'revoked_date'],
+        )
+        expired_license_uuids = sorted([expired_license.uuid for expired_license in expired_licenses_for_retirement])
+        message = 'Retired {} expired licenses with uuids: {}'.format(len(expired_license_uuids), expired_license_uuids)
+        logger.info(message)
+
+        revoked_licenses_for_retirement = License.objects.filter(
+            status=DEACTIVATED,
+            user_email__isnull=False,
+            revoked_date__isnull=False,
+            revoked_date__date__lt=ready_for_retirement_date,
+        )
+        # Scrub all pii on the revoked licenses, but they should stay revoked and keep their other info as we currently
+        # add an unassigned license to the subscription's license pool whenever one is revoked.
+        for revoked_license in revoked_licenses_for_retirement:
+            revoked_license.user_email = None
+            revoked_license.lms_user_id = None
+        License.objects.bulk_update(revoked_licenses_for_retirement, ['user_email', 'lms_user_id'])
+        revoked_license_uuids = sorted([revoked_license.uuid for revoked_license in revoked_licenses_for_retirement])
+        message = 'Retired {} revoked licenses with uuids: {}'.format(len(revoked_license_uuids), revoked_license_uuids)
+        logger.info(message)
+
+        assigned_licenses_for_retirement = License.objects.filter(
+            status=ASSIGNED,
+            assigned_date__isnull=False,
+            assigned_date__date__lt=ready_for_retirement_date,
+        )
+        # We place previously assigned licenses that are now retired back into the unassigned license pool, so we scrub
+        # all data on them.
+        for assigned_license in assigned_licenses_for_retirement:
+            assigned_license.reset_to_unassigned()
+        License.objects.bulk_update(
+            assigned_licenses_for_retirement,
+            [
+                'status',
+                'user_email',
+                'lms_user_id',
+                'last_remind_date',
+                'activation_date',
+                'activation_key',
+                'assigned_date',
+                'revoked_date',
+            ],
+        )
+        assigned_license_uuids = sorted(
+            [assigned_license.uuid for assigned_license in assigned_licenses_for_retirement],
+        )
+        message = 'Retired {} previously assigned licenses with uuids: {}'.format(
+            len(assigned_license_uuids),
+            assigned_license_uuids,
+        )
+        logger.info(message)

--- a/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
@@ -1,0 +1,150 @@
+from datetime import datetime, timedelta
+
+from django.core.management import call_command
+from django.test import TestCase
+from faker import Factory as FakerFactory
+
+from license_manager.apps.subscriptions.constants import (
+    ACTIVATED,
+    ASSIGNED,
+    DAYS_TO_RETIRE,
+    DEACTIVATED,
+    UNASSIGNED,
+)
+from license_manager.apps.subscriptions.tests.factories import (
+    LicenseFactory,
+    SubscriptionPlanFactory,
+)
+from license_manager.apps.subscriptions.tests.utils import (
+    assert_date_fields_correct,
+    assert_license_fields_cleared,
+)
+
+
+faker = FakerFactory.create()
+
+
+class RetireOldLicensesCommandTests(TestCase):
+    command_name = 'retire_old_licenses'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        subscription_plan = SubscriptionPlanFactory()
+        day_before_retirement_deadline = datetime.today().date() - timedelta(DAYS_TO_RETIRE + 1)
+        cls.expired_subscription_plan = SubscriptionPlanFactory(expiration_date=day_before_retirement_deadline)
+
+        # Set up a bunch of licenses that should not be retired
+        LicenseFactory.create_batch(3, status=ACTIVATED, subscription_plan=subscription_plan)
+        LicenseFactory.create_batch(4, status=DEACTIVATED, subscription_plan=subscription_plan)
+        LicenseFactory.create_batch(
+            5,
+            status=DEACTIVATED,
+            subscription_plan=subscription_plan,
+            revoked_date=datetime.now(),
+        )
+        LicenseFactory.create_batch(
+            5,
+            status=DEACTIVATED,
+            subscription_plan=subscription_plan,
+            revoked_date=day_before_retirement_deadline,
+            user_email=None,  # The user_email is None to represent already retired licenses
+        )
+        LicenseFactory.create_batch(
+            2,
+            status=ASSIGNED,
+            subscription_plan=subscription_plan,
+            assigned_date=datetime.now(),
+        )
+
+        # Set up licenses that should be retired as either there subscription plan has been expired for long enough
+        # for retirement, or they were assigned/revoked a day before the current date to retire.
+        cls.num_revoked_licenses_to_retire = 6
+        cls.revoked_licenses_ready_for_retirement = LicenseFactory.create_batch(
+            cls.num_revoked_licenses_to_retire,
+            status=DEACTIVATED,
+            subscription_plan=subscription_plan,
+            revoked_date=day_before_retirement_deadline,
+        )
+        for revoked_license in cls.revoked_licenses_ready_for_retirement:
+            revoked_license.lms_user_id = faker.random_int()
+            revoked_license.user_email = faker.email()
+            revoked_license.save()
+
+        cls.num_assigned_licenses_to_retire = 7
+        cls.assigned_licenses_ready_for_retirement = LicenseFactory.create_batch(
+            cls.num_assigned_licenses_to_retire,
+            status=ASSIGNED,
+            subscription_plan=subscription_plan,
+            assigned_date=day_before_retirement_deadline,
+        )
+        for assigned_license in cls.assigned_licenses_ready_for_retirement:
+            assigned_license.lms_user_id = faker.random_int()
+            assigned_license.user_email = faker.email()
+            assigned_license.save()
+
+        # Create licenses of different statuses that should be retired from association with an old expired subscription
+        LicenseFactory.create(
+            status=ACTIVATED,
+            subscription_plan=cls.expired_subscription_plan,
+            lms_user_id=faker.random_int(),
+            user_email=faker.email(),
+        )
+        LicenseFactory.create(
+            status=ASSIGNED,
+            subscription_plan=cls.expired_subscription_plan,
+            lms_user_id=faker.random_int(),
+            user_email=faker.email(),
+        )
+        LicenseFactory.create(
+            status=DEACTIVATED,
+            lms_user_id=faker.random_int(),
+            user_email=faker.email(),
+            subscription_plan=cls.expired_subscription_plan,
+        )
+
+    def test_retire_old_licenses(self):
+        """
+        Verify that the command retires the correct licenses appropriately and logs messages about the retirement.
+        """
+        with self.assertLogs(level='INFO') as log:
+            call_command(self.command_name)
+
+            # Verify all expired licenses that were ready for retirement have been retired correctly
+            expired_licenses = self.expired_subscription_plan.licenses.all()
+            assert_date_fields_correct(expired_licenses, ['revoked_date'], True)
+            for expired_license in expired_licenses:
+                expired_license.refresh_from_db()
+                assert expired_license.user_email is None
+                assert expired_license.lms_user_id is None
+                assert expired_license.status == DEACTIVATED
+            message = 'Retired {} expired licenses with uuids: {}'.format(
+                expired_licenses.count(),
+                sorted([expired_license.uuid for expired_license in expired_licenses]),
+            )
+            assert message in log.output[0]
+
+            # Verify all revoked licenses that were ready for retirement have been retired correctly
+            for revoked_license in self.revoked_licenses_ready_for_retirement:
+                revoked_license.refresh_from_db()
+                assert revoked_license.user_email is None
+                assert revoked_license.lms_user_id is None
+            message = 'Retired {} revoked licenses with uuids: {}'.format(
+                self.num_revoked_licenses_to_retire,
+                sorted([revoked_license.uuid for revoked_license in self.revoked_licenses_ready_for_retirement]),
+            )
+            assert message in log.output[1]
+
+            # Verify all assigned licenses that were ready for retirement have been retired correctly
+            for assigned_license in self.assigned_licenses_ready_for_retirement:
+                assigned_license.refresh_from_db()
+                assert_license_fields_cleared(assigned_license)
+                assert assigned_license.user_email is None
+                assert assigned_license.activation_key is None
+                assert assigned_license.status == UNASSIGNED
+            message = 'Retired {} previously assigned licenses with uuids: {}'.format(
+                self.num_assigned_licenses_to_retire,
+                sorted([assigned_license.uuid for assigned_license in self.assigned_licenses_ready_for_retirement]),
+            )
+            assert message in log.output[2]

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -278,6 +278,22 @@ class License(TimeStampedModel):
             )
         )
 
+    def reset_to_unassigned(self):
+        """
+        Resets a license to unassigned and clears the previously set fields on it that no longer apply.
+
+        Note that this does NOT save the license. If you want the changes to persist you need to either explicitly save
+        the license after calling this, or use something like bulk_update which saves each object as part of its updates
+        """
+        self.status = UNASSIGNED
+        self.user_email = None
+        self.lms_user_id = None
+        self.last_remind_date = None
+        self.activation_date = None
+        self.activation_key = None
+        self.assigned_date = None
+        self.revoked_date = None
+
     @staticmethod
     def set_date_fields_to_now(licenses, date_field_names):
         """

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -96,3 +96,17 @@ def assert_date_fields_correct(licenses, date_field_names, should_be_updated):
         else:
             for field_name in date_field_names:
                 assert getattr(license_obj, field_name) is None
+
+
+def assert_license_fields_cleared(license_obj):
+    """
+    Helper function to verify that the appropriate fields on a license have been cleared out to None.
+
+    Does not check that the `user_email` or `activation_key` is None as some workflows reset these for reassignment.
+    """
+    license_obj.refresh_from_db()
+    assert license_obj.lms_user_id is None
+    assert license_obj.last_remind_date is None
+    assert license_obj.activation_date is None
+    assert license_obj.assigned_date is None
+    assert license_obj.revoked_date is None


### PR DESCRIPTION
This management command scrubs pii from any assigned license that has
not been activated for over 90 days, any revoked license that has
not been reassigned for over 90 days, or any license associated with a
subscription plan that expired more than 90 days ago in order to remain
GDPR compliant.

ENT-2957