### PR TITLE
Add batch_size of 100 to License bulk operations

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -276,6 +276,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
                 'assigned_date',
                 'revoked_date',
             ],
+            batch_size=constants.LICENSE_BULK_OPERATION_BATCH_SIZE,
         )
 
         # Get a queryset of only the number of licenses we need to assign
@@ -287,7 +288,11 @@ class LicenseViewSet(LearnerLicenseViewSet):
             activation_key = str(uuid4())
             unassigned_license.activation_key = activation_key
         # Efficiently update the licenses in bulk
-        License.objects.bulk_update(unassigned_licenses, ['user_email', 'status', 'activation_key'])
+        License.objects.bulk_update(
+            unassigned_licenses,
+            ['user_email', 'status', 'activation_key'],
+            batch_size=constants.LICENSE_BULK_OPERATION_BATCH_SIZE,
+        )
 
         # Send activation emails
         activation_task.delay(

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -40,3 +40,6 @@ DAYS_TO_RETIRE = 90
 
 # Subscription validation constants
 MAX_NUM_LICENSES = 1000
+
+# SQL bulk operation constants
+LICENSE_BULK_OPERATION_BATCH_SIZE = 100

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -7,6 +7,7 @@ from license_manager.apps.subscriptions.constants import (
     ASSIGNED,
     DAYS_TO_RETIRE,
     DEACTIVATED,
+    LICENSE_BULK_OPERATION_BATCH_SIZE,
     UNASSIGNED,
 )
 from license_manager.apps.subscriptions.models import License
@@ -46,6 +47,7 @@ class Command(BaseCommand):
         License.objects.bulk_update(
             expired_licenses_for_retirement,
             ['user_email', 'lms_user_id', 'status', 'revoked_date'],
+            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
         )
         expired_license_uuids = sorted([expired_license.uuid for expired_license in expired_licenses_for_retirement])
         message = 'Retired {} expired licenses with uuids: {}'.format(len(expired_license_uuids), expired_license_uuids)
@@ -63,7 +65,11 @@ class Command(BaseCommand):
             revoked_license.user_email = None
             revoked_license.lms_user_id = None
             self._clear_historical_pii(revoked_license)
-        License.objects.bulk_update(revoked_licenses_for_retirement, ['user_email', 'lms_user_id'])
+        License.objects.bulk_update(
+            revoked_licenses_for_retirement,
+            ['user_email', 'lms_user_id'],
+            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
+        )
         revoked_license_uuids = sorted([revoked_license.uuid for revoked_license in revoked_licenses_for_retirement])
         message = 'Retired {} revoked licenses with uuids: {}'.format(len(revoked_license_uuids), revoked_license_uuids)
         logger.info(message)
@@ -90,6 +96,7 @@ class Command(BaseCommand):
                 'assigned_date',
                 'revoked_date',
             ],
+            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
         )
         assigned_license_uuids = sorted(
             [assigned_license.uuid for assigned_license in assigned_licenses_for_retirement],

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -15,6 +15,7 @@ from license_manager.apps.subscriptions.constants import (
     ACTIVATED,
     ASSIGNED,
     DEACTIVATED,
+    LICENSE_BULK_OPERATION_BATCH_SIZE,
     LICENSE_STATUS_CHOICES,
     SALESFORCE_ID_LENGTH,
     UNASSIGNED,
@@ -131,7 +132,7 @@ class SubscriptionPlan(TimeStampedModel):
         Method to increase the number of licenses associated with an instance of SubscriptionPlan by num_new_licenses.
         """
         new_licenses = [License(subscription_plan=self) for _ in range(num_new_licenses)]
-        License.objects.bulk_create(new_licenses)
+        License.objects.bulk_create(new_licenses, batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE)
 
     def contains_content(self, content_ids):
         """
@@ -306,7 +307,7 @@ class License(TimeStampedModel):
         for subscription_license in licenses:
             for field_name in date_field_names:
                 setattr(subscription_license, field_name, localized_utcnow())
-        License.objects.bulk_update(licenses, date_field_names)
+        License.objects.bulk_update(licenses, date_field_names, batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE)
 
 
 class SubscriptionsFeatureRole(UserRole):


### PR DESCRIPTION
We're starting out with this somewhat arbitrary size of 100 just to
have some cap and prevent excessively large SQL statements from being
generated. We'll let our upcoming performance testing determine any
adjustments that need to be made.
Additionally, we considered making this a more reusable helper
function, but since batch_size seems fairly context dependent (and the
syntax is already pretty straight forward) we decided to just use a
constant for all bulk operations on licenses.

ENT-3326