### PR TITLE
Upgrading celery to 4.2.2

### DIFF
--- a/license_manager/celery.py
+++ b/license_manager/celery.py
@@ -9,7 +9,8 @@ app = Celery('license_manager', )
 
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object(settings)
+app.conf.task_protocol = 1
+app.config_from_object('django.conf:settings')
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/license_manager/settings/test.py
+++ b/license_manager/settings/test.py
@@ -1,6 +1,7 @@
 import os
 
 from license_manager.settings.base import *
+import tempfile
 
 
 # IN-MEMORY TEST DATABASE
@@ -18,6 +19,8 @@ DATABASES = {
 
 # BEGIN CELERY
 CELERY_ALWAYS_EAGER = True
+results_dir = tempfile.TemporaryDirectory()
+CELERY_RESULT_BACKEND = 'file://{}'.format(results_dir.name)
 # END CELERY
 
 # Make some loggers less noisy (useful during test failure)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,6 +23,6 @@ edx-rbac
 edx-rest-api-client
 mysqlclient
 pytz
-redis==2.8
+redis
 rules
 zipp

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,12 +4,11 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-boto3==1.14.52            # via django-ses
-botocore==1.17.52         # via boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
+amqp==2.6.1               # via kombu
+billiard==3.5.0.5         # via celery
+boto3==1.14.55            # via django-ses
+botocore==1.17.55         # via boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
@@ -19,22 +18,22 @@ cryptography==3.1         # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.in
 django-crum==0.7.7        # via edx-rbac
-django-extensions==3.0.6  # via -r requirements/base.in
+django-extensions==3.0.7  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.2         # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
-django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
 drf-jwt==1.17.1           # via edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
-edx-celeryutils==0.5.1    # via -r requirements/base.in
-edx-django-utils==3.7.3   # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/base.in
+edx-django-utils==3.8.0   # via -r requirements/base.in, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.in
@@ -44,13 +43,13 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==4.0.0.post0   # via edx-celeryutils
-kombu==3.0.37             # via celery
+kombu==4.3.0              # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
 newrelic==5.18.0.148      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
-pbr==5.4.5                # via stevedore
+pbr==5.5.0                # via stevedore
 psutil==5.7.2             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
@@ -60,7 +59,7 @@ pymongo==3.11.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django, django-ses
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.in
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -76,4 +75,5 @@ sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via botocore, requests
+vine==1.3.0               # via amqp
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,7 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-celery==3.1.26.post2
 
 Django>=2.2,<2.3
 
@@ -25,8 +24,6 @@ path<13.2.0
 
 PyYAML>=5.1
 
-redis==2.8
-
 # Upgrade to 3.3.0 triggered users to lose superuser status; see ARCHBOM-1078 for details
 social-auth-core==3.2.0
 
@@ -37,3 +34,9 @@ social-auth-app-django==3.1.0
 stevedore<2.0.0
 
 zipp<2.0
+
+
+
+celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.
+
+redis==3.2.0   # celery 4.2.2 is working fine with the version. Further upgrades will be done in next PR.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,20 +4,19 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/validation.txt, kombu
-anyjson==0.3.3            # via -r requirements/validation.txt, kombu
+amqp==2.6.1               # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/validation.txt, pytest
-billiard==3.3.0.23        # via -r requirements/validation.txt, celery
-boto3==1.14.52            # via -r requirements/validation.txt, django-ses
-botocore==1.17.52         # via -r requirements/validation.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/validation.txt, celery
+boto3==1.14.55            # via -r requirements/validation.txt, django-ses
+botocore==1.17.55         # via -r requirements/validation.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/validation.txt, requests
 cffi==1.14.2              # via -r requirements/validation.txt, cryptography
 chardet==3.0.4            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.5.1   # via -r requirements/validation.txt
+code-annotations==0.6.0   # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
 coverage==5.2.1           # via -r requirements/validation.txt, pytest-cov
@@ -29,22 +28,22 @@ django-cors-headers==3.5.0  # via -r requirements/validation.txt
 django-crum==0.7.7        # via -r requirements/validation.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
-django-extensions==3.0.6  # via -r requirements/validation.txt
+django-extensions==3.0.7  # via -r requirements/validation.txt
 django-filter==2.3.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
 django-ses==1.0.2         # via -r requirements/validation.txt
 django-simple-history==2.11.0  # via -r requirements/validation.txt
-django-waffle==1.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/validation.txt, botocore
 drf-jwt==1.17.1           # via -r requirements/validation.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
-edx-celeryutils==0.5.1    # via -r requirements/validation.txt
-edx-django-utils==3.7.3   # via -r requirements/validation.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/validation.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/validation.txt
+edx-django-utils==3.8.0   # via -r requirements/validation.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
 edx-lint==1.5.2           # via -r requirements/validation.txt
 edx-opaque-keys==2.1.1    # via -r requirements/validation.txt, edx-drf-extensions
@@ -65,7 +64,7 @@ jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/validation.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jmespath==0.10.0          # via -r requirements/validation.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/validation.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/validation.txt, celery
+kombu==4.3.0              # via -r requirements/validation.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/validation.txt, astroid
 markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
@@ -79,7 +78,7 @@ packaging==20.4           # via -r requirements/validation.txt, pytest
 path.py==12.5.0           # via -r requirements/validation.txt, edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, -r requirements/validation.txt, path.py
 pathlib2==2.3.5           # via -r requirements/validation.txt
-pbr==5.4.5                # via -r requirements/validation.txt, stevedore
+pbr==5.5.0                # via -r requirements/validation.txt, stevedore
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/validation.txt, diff-cover, pytest
 polib==1.1.0              # via -r requirements/validation.txt, edx-i18n-tools
@@ -107,7 +106,7 @@ python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
 pytz==2020.1              # via -r requirements/validation.txt, celery, django, django-ses
 pywatchman==1.4.1         # via -r requirements/dev.in
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-i18n-tools
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/validation.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/validation.txt
 requests-oauthlib==1.3.0  # via -r requirements/validation.txt, social-auth-core
 requests==2.24.0          # via -r requirements/validation.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/validation.txt, edx-drf-extensions
@@ -127,6 +126,7 @@ toml==0.10.1              # via -r requirements/validation.txt, pytest
 typed-ast==1.4.1          # via -r requirements/validation.txt, astroid
 uritemplate==3.0.1        # via -r requirements/validation.txt, coreapi
 urllib3==1.25.10          # via -r requirements/validation.txt, botocore, requests
+vine==1.3.0               # via -r requirements/validation.txt, amqp
 wrapt==1.11.2             # via -r requirements/validation.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/validation.txt, importlib-metadata
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,22 +5,21 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9               # via -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23        # via -r requirements/test.txt, celery
+billiard==3.5.0.5         # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-boto3==1.14.52            # via -r requirements/test.txt, django-ses
-botocore==1.17.52         # via -r requirements/test.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+boto3==1.14.55            # via -r requirements/test.txt, django-ses
+botocore==1.17.55         # via -r requirements/test.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.5.1   # via -r requirements/test.txt
+code-annotations==0.6.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
@@ -30,13 +29,13 @@ defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social
 django-cors-headers==3.5.0  # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.6  # via -r requirements/test.txt
+django-extensions==3.0.7  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
-django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
@@ -44,9 +43,9 @@ docutils==0.15.2          # via -r requirements/test.txt, botocore, doc8, readme
 drf-jwt==1.17.1           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
-edx-celeryutils==0.5.1    # via -r requirements/test.txt
-edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/test.txt
+edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/test.txt
@@ -65,7 +64,7 @@ itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
@@ -76,7 +75,7 @@ newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
-pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pbr==5.5.0                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
@@ -100,7 +99,7 @@ python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 readme-renderer==26.0     # via -r requirements/doc.in
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/test.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
@@ -128,6 +127,7 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
+vine==1.3.0               # via -r requirements/test.txt, amqp
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,12 +4,11 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.52            # via -r requirements/base.txt, django-ses
-botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+amqp==2.6.1               # via -r requirements/base.txt, kombu
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+boto3==1.14.55            # via -r requirements/base.txt, django-ses
+botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -19,22 +18,22 @@ cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.6  # via -r requirements/base.txt
+django-extensions==3.0.7  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
-django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/base.txt
+edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -47,13 +46,13 @@ itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
 psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -65,7 +64,7 @@ python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/production.in
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -81,6 +80,7 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,13 +4,12 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.52            # via -r requirements/base.txt, django-ses
-botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+boto3==1.14.55            # via -r requirements/base.txt, django-ses
+botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -22,22 +21,22 @@ cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.6  # via -r requirements/base.txt
+django-extensions==3.0.7  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
-django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/base.txt
+edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
@@ -49,7 +48,7 @@ itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
@@ -57,7 +56,7 @@ mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
 psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
@@ -73,7 +72,7 @@ pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -91,5 +90,6 @@ stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,20 +4,19 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.1.0             # via pytest
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.52            # via -r requirements/base.txt, django-ses
-botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+boto3==1.14.55            # via -r requirements/base.txt, django-ses
+botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.5.1   # via -r requirements/test.in
+code-annotations==0.6.0   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.in, pytest-cov
@@ -27,21 +26,21 @@ defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.6  # via -r requirements/base.txt
+django-extensions==3.0.7  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
-django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
 drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
-edx-celeryutils==0.5.1    # via -r requirements/base.txt
-edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/base.txt
+edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
@@ -58,7 +57,7 @@ itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
@@ -69,7 +68,7 @@ newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
 psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest
@@ -91,7 +90,7 @@ python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, code-annotations
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -110,5 +109,6 @@ toml==0.10.1              # via pytest
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -4,20 +4,19 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
-billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.52            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.52         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/quality.txt, -r requirements/test.txt, celery
+boto3==1.14.55            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.17.55         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.5.1   # via -r requirements/test.txt
+code-annotations==0.6.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
@@ -27,22 +26,22 @@ defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/tes
 django-cors-headers==3.5.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.6  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.7  # via -r requirements/quality.txt, -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-waffle==1.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/quality.txt, -r requirements/test.txt, botocore
 drf-jwt==1.17.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
-edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
-edx-django-utils==3.7.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-celeryutils==0.5.2    # via -r requirements/quality.txt, -r requirements/test.txt
+edx-django-utils==3.8.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+edx-drf-extensions==6.1.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
 edx-lint==1.5.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -60,7 +59,7 @@ itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/tes
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/quality.txt, -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/quality.txt, -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
@@ -74,7 +73,7 @@ packaging==20.4           # via -r requirements/test.txt, pytest
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, path.py
 pathlib2==2.3.5           # via -r requirements/validation.in
-pbr==5.4.5                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
+pbr==5.5.0                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==5.7.2             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
@@ -99,7 +98,7 @@ python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
-redis==2.8                # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
+redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -119,5 +118,6 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, botocore, requests
+vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata


### PR DESCRIPTION
Upgrading redis to 3.2.0
Upgrading celery to 4.2.2

Merge this https://github.com/edx/license-manager/pull/112 first and deploy on prod to avoid any loss of messages.