### PR TITLE
Add endpoint to retire user data

### DIFF
--- a/license_manager/apps/api/permissions.py
+++ b/license_manager/apps/api/permissions.py
@@ -1,0 +1,15 @@
+"""
+Permission classes for Subscriptions API
+"""
+from django.conf import settings
+from rest_framework import permissions
+
+
+class CanRetireUser(permissions.BasePermission):
+    """
+    Grant access to the user retirement API for the service user, and to superusers. This mimics the
+    retirement permissions check in edx-platform.
+    """
+
+    def has_permission(self, request, view):
+        return request.user.username == settings.RETIREMENT_SERVICE_WORKER_USERNAME or request.user.is_superuser

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1520,7 +1520,6 @@ class UserRetirementViewTests(TestCase):
     """
     Tests for the user retirement view.
     """
-    NOW = localized_utcnow()
 
     def setUp(self):
         super().setUp()

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -7,7 +7,10 @@ from uuid import uuid4
 import ddt
 import mock
 import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import QueryDict
 from django.test import TestCase
 from django.urls import reverse
@@ -35,7 +38,9 @@ from license_manager.apps.subscriptions.tests.factories import (
 )
 from license_manager.apps.subscriptions.tests.utils import (
     assert_date_fields_correct,
+    assert_historical_pii_cleared,
     assert_license_fields_cleared,
+    assert_pii_cleared,
 )
 from license_manager.apps.subscriptions.utils import localized_utcnow
 
@@ -1508,3 +1513,160 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         assert constants.REVOKED == revoked_license.status
         assert self.lms_user_id == revoked_license.lms_user_id
         assert self.NOW == revoked_license.activation_date
+
+
+@ddt.ddt
+class UserRetirementViewTests(TestCase):
+    """
+    Tests for the user retirement view.
+    """
+    NOW = localized_utcnow()
+
+    def setUp(self):
+        super().setUp()
+
+        self.api_client = APIClient()
+        self.retirement_user = UserFactory(username=settings.RETIREMENT_SERVICE_WORKER_USERNAME)
+        self.api_client.force_authenticate(user=self.retirement_user)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.lms_user_id = 1
+        cls.original_username = 'edxBob'
+        cls.user_email = 'edxBob@example.com'
+        cls.user_to_retire = UserFactory(username=cls.original_username)
+
+        # Create some licenses associated with the user being retired
+        cls.revoked_license = cls._create_associated_license(constants.REVOKED)
+        cls.assigned_license = cls._create_associated_license(constants.ASSIGNED)
+        cls.activated_license = cls._create_associated_license(constants.ACTIVATED)
+
+    @classmethod
+    def _create_associated_license(cls, status):
+        """
+        Helper to create a license of the given status associated with the user being retired.
+        """
+        return LicenseFactory.create(
+            status=status,
+            lms_user_id=cls.lms_user_id,
+            user_email=cls.user_email,
+        )
+
+    def _post_request(self, lms_user_id, original_username):
+        """
+        Helper to make the POST request to the license activation endpoint.
+
+        Will update the test client's cookies to contain an lms_user_id and email,
+        which can be overridden from those defined in the class ``setUpTestData()``
+        method with the optional params provided here.
+        """
+        data = {
+            'lms_user_id': lms_user_id,
+            'original_username': original_username,
+        }
+        url = reverse('api:v1:user-retirement')
+        return self.api_client.post(url, data)
+
+    def test_retirement_no_auth(self):
+        """
+        Unauthenticated requests should result in a 401.
+        """
+        # Create a new client with no authentication present.
+        self.api_client = APIClient()
+
+        response = self._post_request(self.lms_user_id, self.original_username)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_retirement_missing_permission(self):
+        """
+        Requests from non-superusers that aren't the retirement worker should result in a 403.
+        """
+        user = UserFactory()
+        self.api_client = APIClient()
+        self.api_client.force_authenticate(user=user)
+
+        response = self._post_request(self.lms_user_id, self.original_username)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @ddt.data(
+        {'lms_user_id': None, 'original_username': None},
+        {'lms_user_id': 1, 'original_username': None},
+        {'lms_user_id': None, 'original_username': 'edxBob'},
+    )
+    @ddt.unpack
+    def test_retirement_missing_data(self, lms_user_id, original_username):
+        """
+        Requests that don't provide the lms_user_id or original_username should result in a 400.
+        """
+        response = self._post_request(lms_user_id, original_username)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_retirement_missing_user(self):
+        """
+        The endpoint should 404 if we attempt to retire a user who doesn't exist in license-manager.
+        """
+        response = self._post_request(1000, 'fake-username')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @mock.patch('license_manager.apps.api.v1.views.get_user_model')
+    def test_retirement_500_error(self, mock_get_user_model):
+        """
+        The endpoint should log an error message if we get an unexpected error retiring the user.
+        """
+        exception_message = 'blah'
+        mock_get_user_model.side_effect = Exception(exception_message)
+        with self.assertLogs(level='ERROR') as log:
+            response = self._post_request(self.lms_user_id, self.original_username)
+            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            message = '500 error retiring user with lms_user_id {}. Error: {}'.format(
+                self.lms_user_id,
+                exception_message,
+            )
+            assert message in log.output[0]
+
+    def test_retirement(self):
+        """
+        All licenses associated with the user being retired should have pii scrubbed, and the user should be deleted.
+        """
+        # Verify the request succeeds with the correct status and logs the appropriate messages
+        with self.assertLogs(level='INFO') as log:
+            response = self._post_request(self.lms_user_id, self.original_username)
+            assert response.status_code == status.HTTP_204_NO_CONTENT
+
+            license_message = 'Retired 3 licenses with uuids: {} for user with lms_user_id {}'.format(
+                sorted([self.revoked_license.uuid, self.assigned_license.uuid, self.activated_license.uuid]),
+                self.lms_user_id,
+            )
+            assert license_message in log.output[0]
+
+            user_retirement_message = 'Retiring user with id {} and lms_user_id {}'.format(
+                self.user_to_retire.id,
+                self.lms_user_id,
+            )
+            assert user_retirement_message in log.output[1]
+
+        # Verify the revoked license was cleared correctly
+        self.revoked_license.refresh_from_db()
+        assert_pii_cleared(self.revoked_license)
+        assert_historical_pii_cleared(self.revoked_license)
+        assert self.revoked_license.status == constants.REVOKED
+
+        # Verify the assigned & activated licenses were cleared correctly
+        self.assigned_license.refresh_from_db()
+        assert_pii_cleared(self.assigned_license)
+        assert_historical_pii_cleared(self.assigned_license)
+        assert_license_fields_cleared(self.assigned_license)
+        assert self.assigned_license.status == constants.UNASSIGNED
+
+        self.activated_license.refresh_from_db()
+        assert_pii_cleared(self.activated_license)
+        assert_historical_pii_cleared(self.activated_license)
+        assert_license_fields_cleared(self.activated_license)
+        assert self.activated_license.status == constants.UNASSIGNED
+
+        # Verify the user for retirement has been deleted
+        User = get_user_model()
+        with self.assertRaises(ObjectDoesNotExist):
+            User.objects.get(username=self.original_username)

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -89,5 +89,10 @@ urlpatterns = [
         views.LicenseActivationView.as_view(),
         name='license-activation',
     ),
+    url(
+        r'retire-user',
+        views.UserRetirementView.as_view(),
+        name='user-retirement',
+    )
 ]
 urlpatterns += router.urls + subscription_router.urls

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -584,8 +584,6 @@ class UserRetirementView(APIView):
         # Scrub all pii on licenses associated with the user
         associated_licenses = License.objects.filter(lms_user_id=lms_user_id)
         for associated_license in associated_licenses:
-            # Clear historical pii for all associated licenses
-            associated_license.clear_historical_pii()
             # Scrub all pii on the revoked licenses, but they should stay revoked and keep their other info as we
             # currently add an unassigned license to the subscription's license pool whenever one is revoked.
             if associated_license.status == constants.REVOKED:
@@ -594,6 +592,8 @@ class UserRetirementView(APIView):
                 # For all other types of licenses, we can just reset them to unassigned (which clears all fields)
                 associated_license.reset_to_unassigned()
             associated_license.save()
+            # Clear historical pii after removing pii from the license itself
+            associated_license.clear_historical_pii()
         associated_licenses_uuids = [license.uuid for license in associated_licenses]
         message = 'Retired {} licenses with uuids: {} for user with lms_user_id {}'.format(
             len(associated_licenses_uuids),

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -6,7 +6,6 @@ from django.core.management.base import BaseCommand
 from license_manager.apps.subscriptions.constants import (
     ASSIGNED,
     DAYS_TO_RETIRE,
-    LICENSE_BULK_OPERATION_BATCH_SIZE,
     REVOKED,
     UNASSIGNED,
 )
@@ -36,13 +35,8 @@ class Command(BaseCommand):
             expired_license.clear_pii()
             expired_license.status = REVOKED
             expired_license.revoked_date = datetime.now()
-        License.objects.bulk_update(
-            expired_licenses_for_retirement,
-            ['user_email', 'lms_user_id', 'status', 'revoked_date'],
-            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
-        )
-        # Clear historical pii after removing pii from the license itself
-        for expired_license in expired_licenses_for_retirement:
+            expired_license.save()
+            # Clear historical pii after removing pii from the license itself
             expired_license.clear_historical_pii()
         expired_license_uuids = sorted([expired_license.uuid for expired_license in expired_licenses_for_retirement])
         message = 'Retired {} expired licenses with uuids: {}'.format(len(expired_license_uuids), expired_license_uuids)
@@ -58,13 +52,8 @@ class Command(BaseCommand):
         # add an unassigned license to the subscription's license pool whenever one is revoked.
         for revoked_license in revoked_licenses_for_retirement:
             revoked_license.clear_pii()
-        License.objects.bulk_update(
-            revoked_licenses_for_retirement,
-            ['user_email', 'lms_user_id'],
-            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
-        )
-        # Clear historical pii after removing pii from the license itself
-        for revoked_license in revoked_licenses_for_retirement:
+            revoked_license.save()
+            # Clear historical pii after removing pii from the license itself
             revoked_license.clear_historical_pii()
         revoked_license_uuids = sorted([revoked_license.uuid for revoked_license in revoked_licenses_for_retirement])
         message = 'Retired {} revoked licenses with uuids: {}'.format(len(revoked_license_uuids), revoked_license_uuids)
@@ -79,22 +68,8 @@ class Command(BaseCommand):
         # all data on them.
         for assigned_license in assigned_licenses_for_retirement:
             assigned_license.reset_to_unassigned()
-        License.objects.bulk_update(
-            assigned_licenses_for_retirement,
-            [
-                'status',
-                'user_email',
-                'lms_user_id',
-                'last_remind_date',
-                'activation_date',
-                'activation_key',
-                'assigned_date',
-                'revoked_date',
-            ],
-            batch_size=LICENSE_BULK_OPERATION_BATCH_SIZE,
-        )
-        # Clear historical pii after removing pii from the license itself
-        for assigned_license in assigned_licenses_for_retirement:
+            assigned_license.save()
+            # Clear historical pii after removing pii from the license itself
             assigned_license.clear_historical_pii()
         assigned_license_uuids = sorted(
             [assigned_license.uuid for assigned_license in assigned_licenses_for_retirement],

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -279,6 +279,22 @@ class License(TimeStampedModel):
             )
         )
 
+    def clear_pii(self):
+        """
+        Helper function to remove pii (user_email & lms_user_id) from the license.
+
+        Note that this does NOT save the license. If you want the changes to persist you need to either explicitly save
+        the license after calling this, or use something like bulk_update which saves each object as part of its updates
+        """
+        self.user_email = None
+        self.lms_user_id = None
+
+    def clear_historical_pii(self):
+        """
+        Helper function to remove pii (user_email & lms_user_id) from the license's historical records.
+        """
+        self.history.update(user_email=None, lms_user_id=None)  # pylint: disable=no-member
+
     def reset_to_unassigned(self):
         """
         Resets a license to unassigned and clears the previously set fields on it that no longer apply.

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -112,3 +112,20 @@ def assert_license_fields_cleared(license_obj):
     assert license_obj.activation_date is None
     assert license_obj.assigned_date is None
     assert license_obj.revoked_date is None
+
+
+def assert_pii_cleared(license_obj):
+    """
+    Helper to verify that pii on a license has been cleared.
+    """
+    assert license_obj.user_email is None
+    assert license_obj.lms_user_id is None
+
+
+def assert_historical_pii_cleared(license_obj):
+    """
+    Helper to verify that pii from the license's history records has been cleared.
+    """
+    for history_record in license_obj.history.all():
+        assert history_record.user_email is None
+        assert history_record.lms_user_id is None

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -349,3 +349,6 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
 
 SOCIAL_MEDIA_FOOTER_URLS = os.environ.get('SOCIAL_MEDIA_FOOTER_URLS', '')
 MOBILE_STORE_URLS = os.environ.get('MOBILE_STORE_URLS', '')
+
+# User retirement settings
+RETIREMENT_SERVICE_WORKER_USERNAME = "replace with valid username"


### PR DESCRIPTION
This will be hooked into the retirement pipeline so that whenever a
user deletes their edX account their pii is scrubbed from all of their
associated licenses, and their User in the system is deleted if it
exists.

ENT-2956