### PR TITLE
Docker stuff and make license admin page better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ MAINTAINER devops@edx.org
 # libmysqlclient-dev; to install header files needed to use native C implementation for
 # MySQL-python for performance gains.
 
+# wget to download a watchman binary archive
+
+# unzip to unzip a watchman binary archive
+
 # If you add a package here please include a comment above describing what it is used for
-RUN apt-get update && apt-get upgrade -qy && apt-get install language-pack-en locales git python3.5 python3-pip libmysqlclient-dev libssl-dev python3-dev -qy && \
+RUN apt-get update && apt-get upgrade -qy && apt-get install language-pack-en locales git python3.5 python3-pip libmysqlclient-dev libssl-dev python3-dev wget unzip -qy && \
 pip3 install --upgrade pip setuptools && \
 rm -rf /var/lib/apt/lists/*
 
@@ -36,6 +40,16 @@ EXPOSE 18170
 EXPOSE 18171
 RUN useradd -m --shell /bin/false app
 
+# Install watchman
+RUN wget https://github.com/facebook/watchman/releases/download/v2020.08.17.00/watchman-v2020.08.17.00-linux.zip
+RUN unzip watchman-v2020.08.17.00-linux.zip
+RUN mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
+RUN cp watchman-v2020.08.17.00-linux/bin/* /usr/local/bin
+RUN cp watchman-v2020.08.17.00-linux/lib/* /usr/local/lib
+RUN chmod 755 /usr/local/bin/watchman
+RUN chmod 2777 /usr/local/var/run/watchman
+
+# Now install license-manager
 WORKDIR /edx/app/license_manager
 
 # Copy the requirements explicitly even though we copy everything below
@@ -57,7 +71,6 @@ CMD gunicorn --workers=2 --name license_manager -c /edx/app/license_manager/lice
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/license_manager
-
 
 FROM app as newrelic
 RUN pip install newrelic

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,12 @@ dev.stop: # Stops containers so they can be restarted
 %-attach:
 	docker attach license_manager.$*
 
+app-restart-devserver: ## Kill the license-manager development server. Watcher should restart it.
+	docker-compose exec app bash -c 'kill $$(ps aux | egrep "manage.py ?\w* runserver" | egrep -v "while|grep" | awk "{print \$$2}")'
+
+dev.stats: ## Get per-container CPU and memory utilization data.
+	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+
 docker_build:
 	docker build . -f Dockerfile -t openedx/license-manager
 	docker build . -f Dockerfile -t openedx/license-manager.worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,8 @@ services:
     volumes:
       - .:/edx/app/license_manager/
       - ../src:/edx/src:cached
-    # This should be the same as the `CMD` in the devapp build stage
-    # of the Dockerfile
-    command: bash -c 'while true; do gunicorn --reload --workers=2 --name license_manager -b :18170 -c /edx/app/license_manager/license_manager/docker_gunicorn_configuration.py --log-file - --max-requests=1000 license_manager.wsgi:application; sleep 2; done'
+    # Use the Django devserver, so that we can hot-reload code changes
+    command: bash -c 'while true; do python /edx/app/license_manager/manage.py runserver 0.0.0.0:18170; sleep 2; done'
     ports:
       - "18170:18170"
     depends_on:
@@ -41,6 +40,7 @@ services:
       CELERY_BROKER_VHOST: 0
       CELERY_BROKER_PASSWORD: password
       DJANGO_SETTINGS_MODULE: license_manager.settings.devstack
+      DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
 
   memcached:

--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -8,6 +8,32 @@ from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 class LicenseAdmin(admin.ModelAdmin):
     readonly_fields = ['activation_key']
     exclude = ['history']
+    list_display = (
+        'uuid',
+        'status',
+        'assigned_date',
+        'activation_date',
+        'user_email',
+    )
+    ordering = (
+        'assigned_date',
+        'status',
+        'user_email',
+    )
+    sortable_by = (
+        'assigned_date',
+        'status',
+        'user_email',
+    )
+    list_filter = (
+        'status',
+    )
+    search_fields = (
+        'user_email',
+        'subscription_plan__title',
+        'subscription_plan__uuid',
+        'subscription_plan__enterprise_customer_uuid',
+    )
 
 
 @admin.register(SubscriptionPlan)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,29 +7,29 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.14.44            # via django-ses
-botocore==1.17.44         # via boto3, s3transfer
+boto3==1.14.52            # via django-ses
+botocore==1.17.52         # via boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.0         # via pyjwt
+cryptography==3.1         # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/base.in
+django-cors-headers==3.5.0  # via -r requirements/base.in
 django-crum==0.7.7        # via edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.in
+django-extensions==3.0.6  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.2         # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
-drf-jwt==1.17.0           # via edx-drf-extensions
+drf-jwt==1.17.1           # via edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-celeryutils==0.5.1    # via -r requirements/base.in
@@ -47,7 +47,7 @@ jsonfield2==4.0.0.post0   # via edx-celeryutils
 kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.16.1.146      # via edx-django-utils
+newrelic==5.18.0.148      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,3 +10,4 @@ diff-cover                # Changeset diff test coverage
 django-debug-toolbar      # For debugging Django
 gunicorn
 inflect
+pywatchman                # More effecient checking for runserver reload trigger events

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,46 +7,46 @@
 amqp==1.4.9               # via -r requirements/validation.txt, kombu
 anyjson==0.3.3            # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/validation.txt, pytest
+attrs==20.1.0             # via -r requirements/validation.txt, pytest
 billiard==3.3.0.23        # via -r requirements/validation.txt, celery
-boto3==1.14.44            # via -r requirements/validation.txt, django-ses
-botocore==1.17.44         # via -r requirements/validation.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/validation.txt, django-ses
+botocore==1.17.52         # via -r requirements/validation.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/validation.txt, requests
 cffi==1.14.2              # via -r requirements/validation.txt, cryptography
 chardet==3.0.4            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.5.0   # via -r requirements/validation.txt
+code-annotations==0.5.1   # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
 coverage==5.2.1           # via -r requirements/validation.txt, pytest-cov
-cryptography==3.0         # via -r requirements/validation.txt, pyjwt
+cryptography==3.1         # via -r requirements/validation.txt, pyjwt
 ddt==1.4.1                # via -r requirements/dev.in, -r requirements/validation.txt
 defusedxml==0.6.0         # via -r requirements/validation.txt, python3-openid, social-auth-core
-diff-cover==3.0.1         # via -r requirements/dev.in
-django-cors-headers==3.4.0  # via -r requirements/validation.txt
+diff-cover==4.0.0         # via -r requirements/dev.in
+django-cors-headers==3.5.0  # via -r requirements/validation.txt
 django-crum==0.7.7        # via -r requirements/validation.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
-django-extensions==3.0.5  # via -r requirements/validation.txt
+django-extensions==3.0.6  # via -r requirements/validation.txt
 django-filter==2.3.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
 django-ses==1.0.2         # via -r requirements/validation.txt
 django-simple-history==2.11.0  # via -r requirements/validation.txt
 django-waffle==1.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/validation.txt, botocore
-drf-jwt==1.17.0           # via -r requirements/validation.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/validation.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
 edx-celeryutils==0.5.1    # via -r requirements/validation.txt
 edx-django-utils==3.7.3   # via -r requirements/validation.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
-edx-lint==1.5.0           # via -r requirements/validation.txt
+edx-lint==1.5.2           # via -r requirements/validation.txt
 edx-opaque-keys==2.1.1    # via -r requirements/validation.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/validation.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/validation.txt
@@ -70,9 +70,9 @@ lazy-object-proxy==1.4.3  # via -r requirements/validation.txt, astroid
 markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/validation.txt
-more-itertools==8.4.0     # via -r requirements/validation.txt, pytest
+more-itertools==8.5.0     # via -r requirements/validation.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/validation.txt
-newrelic==5.16.1.146      # via -r requirements/validation.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/validation.txt, pytest
@@ -88,7 +88,7 @@ py==1.9.0                 # via -r requirements/validation.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/validation.txt
 pycparser==2.20           # via -r requirements/validation.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/validation.txt, pyjwkest
-pydocstyle==5.0.2         # via -r requirements/validation.txt
+pydocstyle==5.1.1         # via -r requirements/validation.txt
 pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/validation.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/validation.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
@@ -105,6 +105,7 @@ python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-dr
 python-slugify==4.0.1     # via -r requirements/validation.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
 pytz==2020.1              # via -r requirements/validation.txt, celery, django, django-ses
+pywatchman==1.4.1         # via -r requirements/dev.in
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-i18n-tools
 redis==2.8                # via -c requirements/constraints.txt, -r requirements/validation.txt
 requests-oauthlib==1.3.0  # via -r requirements/validation.txt, social-auth-core
@@ -114,7 +115,7 @@ rules==2.2                # via -r requirements/validation.txt
 s3transfer==0.3.3         # via -r requirements/validation.txt, boto3
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,46 +8,46 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==20.1.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-boto3==1.14.44            # via -r requirements/test.txt, django-ses
-botocore==1.17.44         # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/test.txt, django-ses
+botocore==1.17.52         # via -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.5.0   # via -r requirements/test.txt
+code-annotations==0.5.1   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
-cryptography==3.0         # via -r requirements/test.txt, pyjwt
+cryptography==3.1         # via -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/test.txt
+django-cors-headers==3.5.0  # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.5  # via -r requirements/test.txt
+django-extensions==3.0.6  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.15.2          # via -r requirements/test.txt, botocore, doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.17.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/test.txt
 edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
-edx-lint==1.5.0           # via -r requirements/test.txt
+edx-lint==1.5.2           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
@@ -70,9 +70,9 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.16.1.146      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,29 +7,29 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.44            # via -r requirements/base.txt, django-ses
-botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/base.txt, django-ses
+botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.0         # via -r requirements/base.txt, pyjwt
+cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/base.txt
+django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
@@ -50,7 +50,7 @@ jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
 kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,8 +8,8 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.44            # via -r requirements/base.txt, django-ses
-botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/base.txt, django-ses
+botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
@@ -18,27 +18,27 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.0         # via -r requirements/base.txt, pyjwt
+cryptography==3.1         # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/base.txt
+django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-ses==1.0.2         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.0           # via -r requirements/quality.in
+edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -54,7 +54,7 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
@@ -62,7 +62,7 @@ psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.in
+pydocstyle==5.1.1         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,27 +7,27 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0             # via pytest
+attrs==20.1.0             # via pytest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto3==1.14.44            # via -r requirements/base.txt, django-ses
-botocore==1.17.44         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/base.txt, django-ses
+botocore==1.17.52         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.5.0   # via -r requirements/test.in
+code-annotations==0.5.1   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.in, pytest-cov
-cryptography==3.0         # via -r requirements/base.txt, pyjwt
+cryptography==3.1         # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/base.txt
+django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.5  # via -r requirements/base.txt
+django-extensions==3.0.6  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
@@ -36,13 +36,13 @@ django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/base.txt
 edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.0           # via -r requirements/test.in
+edx-lint==1.5.2           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
@@ -63,9 +63,9 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.4.0     # via pytest
+more-itertools==8.5.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.16.1.146      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -7,44 +7,44 @@
 amqp==1.4.9               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==20.1.0             # via -r requirements/test.txt, pytest
 billiard==3.3.0.23        # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.44            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.44         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+boto3==1.14.52            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.17.52         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
 cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.5.0   # via -r requirements/test.txt
+code-annotations==0.5.1   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
-cryptography==3.0         # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
+cryptography==3.1         # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, python3-openid, social-auth-core
-django-cors-headers==3.4.0  # via -r requirements/quality.txt, -r requirements/test.txt
+django-cors-headers==3.5.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.5  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.6  # via -r requirements/quality.txt, -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-ses==1.0.2         # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==1.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via -r requirements/quality.txt, -r requirements/test.txt, botocore
-drf-jwt==1.17.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-celeryutils==0.5.1    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.7.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
-edx-lint==1.5.0           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-lint==1.5.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
@@ -65,9 +65,9 @@ lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/tes
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.16.1.146      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.18.0.148      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest
@@ -82,7 +82,7 @@ py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/quality.txt, -r requirements/test.txt, pyjwkest
-pydocstyle==5.0.2         # via -r requirements/quality.txt
+pydocstyle==5.1.1         # via -r requirements/quality.txt
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint


### PR DESCRIPTION
* Switch docker-compose app command to the django devserver so we can hot-reload code. 
* Install watchman/pywatchman to watch files more efficiently.  
* Add make target to restart only the app devserver (without restarting the container).  
* Add make target to watch docker stats.
* Make the license admin page more useful.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
