### PR TITLE
Include license activation key in serialized results if a feature toggle setting is enabled

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -1,5 +1,9 @@
+from django.conf import settings
 from rest_framework import serializers
 
+from license_manager.apps.subscriptions.constants import (
+    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API,
+)
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 
@@ -43,6 +47,8 @@ class LicenseSerializer(serializers.ModelSerializer):
             'activation_date',
             'last_remind_date',
         ]
+        if settings.FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API]:
+            fields.append('activation_key')
 
 
 class SingleEmailSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -44,3 +44,6 @@ MAX_NUM_LICENSES = 1000
 
 # SQL bulk operation constants
 LICENSE_BULK_OPERATION_BATCH_SIZE = 100
+
+# Feature Toggles
+EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API = 'expose_license_activation_key_over_api'

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -4,6 +4,7 @@ from os.path import abspath, dirname, join
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 
 from license_manager.apps.subscriptions.constants import (
+    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API,
     SUBSCRIPTIONS_ADMIN_ROLE,
     SUBSCRIPTIONS_LEARNER_ROLE,
     SYSTEM_ENTERPRISE_ADMIN_ROLE,
@@ -356,3 +357,8 @@ MOBILE_STORE_URLS = os.environ.get('MOBILE_STORE_URLS', '')
 
 # User retirement settings
 RETIREMENT_SERVICE_WORKER_USERNAME = "replace with valid username"
+
+# Feature Toggles
+FEATURES = {
+    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API: False,
+}

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -65,6 +65,9 @@ ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'http://localhost:8734'
 ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'
 LMS_URL = 'http://edx.devstack.lms:18000'
 
+# Feature Toggles
+FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API] = True
+
 # Make some loggers less noisy (useful during test failure)
 import logging
 


### PR DESCRIPTION
We need this for performance testing so that we can programmatically activate a new learner license.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3329

TODO: Tests.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
