### PR TITLE
Upgrade celery to 4.4.7

### DIFF
--- a/license_manager/celery.py
+++ b/license_manager/celery.py
@@ -9,7 +9,6 @@ app = Celery('license_manager', )
 
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.conf.task_protocol = 1
 app.config_from_object('django.conf:settings')
 
 # Load task modules from all registered Django app configs.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,48 +5,48 @@
 #    make upgrade
 #
 amqp==2.6.1               # via kombu
-billiard==3.5.0.5         # via celery
-boto3==1.14.55            # via django-ses
-botocore==1.17.55         # via boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
+billiard==3.6.3.0         # via celery
+boto3==1.15.5             # via django-ses
+botocore==1.18.5          # via boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.6.20        # via requests
-cffi==1.14.2              # via cryptography
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.1         # via pyjwt
+cryptography==3.1.1       # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.in
 django-crum==0.7.7        # via edx-rbac
-django-extensions==3.0.7  # via -r requirements/base.in
+django-extensions==3.0.9  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-ses==1.0.2         # via -r requirements/base.in
+django-ses==1.0.3         # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via botocore
-drf-jwt==1.17.1           # via edx-drf-extensions
+drf-jwt==1.17.2           # via edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-celeryutils==0.5.2    # via -r requirements/base.in
 edx-django-utils==3.8.0   # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/base.in, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.in
 future==0.18.2            # via django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via requests
+importlib-metadata==2.0.0  # via kombu
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==4.0.0.post0   # via edx-celeryutils
-kombu==4.3.0              # via celery
+kombu==4.6.11             # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.18.0.148      # via edx-django-utils
+newrelic==5.20.0.149      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.5.0                # via stevedore
@@ -59,7 +59,7 @@ pymongo==3.11.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, celery, django, django-ses
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.in
+redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -75,5 +75,5 @@ sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via botocore, requests
-vine==1.3.0               # via amqp
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.in
+vine==1.3.0               # via amqp, celery
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.in, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,8 +35,6 @@ stevedore<2.0.0
 
 zipp<2.0
 
-
-
-celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.
-
-redis==3.2.0   # celery 4.2.2 is working fine with the version. Further upgrades will be done in next PR.
+# Celery 5.0 has some breaking changes, as python 3.8 is priority so,
+# we will look at it after python 3.8 deployment
+celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,56 +6,55 @@
 #
 amqp==2.6.1               # via -r requirements/validation.txt, kombu
 astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
-attrs==20.1.0             # via -r requirements/validation.txt, pytest
-billiard==3.5.0.5         # via -r requirements/validation.txt, celery
-boto3==1.14.55            # via -r requirements/validation.txt, django-ses
-botocore==1.17.55         # via -r requirements/validation.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
+attrs==20.2.0             # via -r requirements/validation.txt, pytest
+billiard==3.6.3.0         # via -r requirements/validation.txt, celery
+boto3==1.15.5             # via -r requirements/validation.txt, django-ses
+botocore==1.18.5          # via -r requirements/validation.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/validation.txt, requests
-cffi==1.14.2              # via -r requirements/validation.txt, cryptography
+cffi==1.14.3              # via -r requirements/validation.txt, cryptography
 chardet==3.0.4            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.6.0   # via -r requirements/validation.txt
+code-annotations==0.8.0   # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
-coverage==5.2.1           # via -r requirements/validation.txt, pytest-cov
-cryptography==3.1         # via -r requirements/validation.txt, pyjwt
+coverage==5.3             # via -r requirements/validation.txt, pytest-cov
+cryptography==3.1.1       # via -r requirements/validation.txt, pyjwt
 ddt==1.4.1                # via -r requirements/dev.in, -r requirements/validation.txt
 defusedxml==0.6.0         # via -r requirements/validation.txt, python3-openid, social-auth-core
-diff-cover==4.0.0         # via -r requirements/dev.in
+diff-cover==4.0.1         # via -r requirements/dev.in
 django-cors-headers==3.5.0  # via -r requirements/validation.txt
 django-crum==0.7.7        # via -r requirements/validation.txt, edx-rbac
-django-debug-toolbar==2.2  # via -r requirements/dev.in
+django-debug-toolbar==3.1.1  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/validation.txt
-django-extensions==3.0.7  # via -r requirements/validation.txt
+django-extensions==3.0.9  # via -r requirements/validation.txt
 django-filter==2.3.0      # via -r requirements/validation.txt
 django-model-utils==4.0.0  # via -r requirements/validation.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/validation.txt
-django-ses==1.0.2         # via -r requirements/validation.txt
+django-ses==1.0.3         # via -r requirements/validation.txt
 django-simple-history==2.11.0  # via -r requirements/validation.txt
 django-waffle==2.0.0      # via -r requirements/validation.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/validation.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via -r requirements/validation.txt, botocore
-drf-jwt==1.17.1           # via -r requirements/validation.txt, edx-drf-extensions
+drf-jwt==1.17.2           # via -r requirements/validation.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/validation.txt
 edx-auth-backends==3.1.0  # via -r requirements/validation.txt
 edx-celeryutils==0.5.2    # via -r requirements/validation.txt
 edx-django-utils==3.8.0   # via -r requirements/validation.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/validation.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
 edx-lint==1.5.2           # via -r requirements/validation.txt
 edx-opaque-keys==2.1.1    # via -r requirements/validation.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/validation.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/validation.txt
 factory-boy==3.0.1        # via -r requirements/validation.txt
-faker==4.1.2              # via -r requirements/validation.txt, factory-boy
-freezegun==0.3.15         # via -r requirements/validation.txt
+faker==4.1.3              # via -r requirements/validation.txt, factory-boy
+freezegun==1.0.0          # via -r requirements/validation.txt
 future==0.18.2            # via -r requirements/validation.txt, django-ses, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.10                # via -r requirements/validation.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/validation.txt, inflect, path, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/validation.txt, inflect, kombu, path, pluggy, pytest
 inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/dev.in, jinja2-pluralize
 iniconfig==1.0.1          # via -r requirements/validation.txt, pytest
 isort==4.3.21             # via -r requirements/validation.txt, pylint
@@ -64,14 +63,14 @@ jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/validation.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jmespath==0.10.0          # via -r requirements/validation.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/validation.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/validation.txt, celery
+kombu==4.6.11             # via -r requirements/validation.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/validation.txt, astroid
 markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/validation.txt
 more-itertools==8.5.0     # via -r requirements/validation.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/validation.txt
-newrelic==5.18.0.148      # via -r requirements/validation.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/validation.txt, pytest
@@ -88,7 +87,7 @@ pycodestyle==2.6.0        # via -r requirements/validation.txt
 pycparser==2.20           # via -r requirements/validation.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/validation.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/validation.txt
-pygments==2.6.1           # via diff-cover
+pygments==2.7.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/validation.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/validation.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/validation.txt, edx-lint
@@ -98,15 +97,15 @@ pylint==2.4.4             # via -r requirements/validation.txt, edx-lint, pylint
 pymongo==3.11.0           # via -r requirements/validation.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/validation.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/validation.txt
-pytest-django==3.9.0      # via -r requirements/validation.txt
-pytest==6.0.1             # via -r requirements/validation.txt, pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/validation.txt
+pytest==6.0.2             # via -r requirements/validation.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/validation.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
 pytz==2020.1              # via -r requirements/validation.txt, celery, django, django-ses
 pywatchman==1.4.1         # via -r requirements/dev.in
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-i18n-tools
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/validation.txt
+redis==3.5.3              # via -r requirements/validation.txt
 requests-oauthlib==1.3.0  # via -r requirements/validation.txt, social-auth-core
 requests==2.24.0          # via -r requirements/validation.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/validation.txt, edx-drf-extensions
@@ -114,7 +113,7 @@ rules==2.2                # via -r requirements/validation.txt
 s3transfer==0.3.3         # via -r requirements/validation.txt, boto3
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends
@@ -126,7 +125,7 @@ toml==0.10.1              # via -r requirements/validation.txt, pytest
 typed-ast==1.4.1          # via -r requirements/validation.txt, astroid
 uritemplate==3.0.1        # via -r requirements/validation.txt, coreapi
 urllib3==1.25.10          # via -r requirements/validation.txt, botocore, requests
-vine==1.3.0               # via -r requirements/validation.txt, amqp
+vine==1.3.0               # via -r requirements/validation.txt, amqp, celery
 wrapt==1.11.2             # via -r requirements/validation.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/validation.txt, importlib-metadata
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,71 +7,71 @@
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.1.0             # via -r requirements/test.txt, pytest
+attrs==20.2.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.5.0.5         # via -r requirements/test.txt, celery
-bleach==3.1.5             # via readme-renderer
-boto3==1.14.55            # via -r requirements/test.txt, django-ses
-botocore==1.17.55         # via -r requirements/test.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/test.txt, celery
+bleach==3.2.1             # via readme-renderer
+boto3==1.15.5             # via -r requirements/test.txt, django-ses
+botocore==1.18.5          # via -r requirements/test.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.2              # via -r requirements/test.txt, cryptography
+cffi==1.14.3              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.6.0   # via -r requirements/test.txt
+code-annotations==0.8.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
-cryptography==3.1         # via -r requirements/test.txt, pyjwt
+coverage==5.3             # via -r requirements/test.txt, pytest-cov
+cryptography==3.1.1       # via -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.7  # via -r requirements/test.txt
+django-extensions==3.0.9  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-ses==1.0.2         # via -r requirements/test.txt
+django-ses==1.0.3         # via -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
-docutils==0.15.2          # via -r requirements/test.txt, botocore, doc8, readme-renderer, restructuredtext-lint, sphinx
-drf-jwt==1.17.1           # via -r requirements/test.txt, edx-drf-extensions
+docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-celeryutils==0.5.2    # via -r requirements/test.txt
 edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/test.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==3.0.1        # via -r requirements/test.txt
-faker==4.1.2              # via -r requirements/test.txt, factory-boy
-freezegun==0.3.15         # via -r requirements/test.txt
+faker==4.1.3              # via -r requirements/test.txt, factory-boy
+freezegun==1.0.0          # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, kombu, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
@@ -81,7 +81,7 @@ psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
-pygments==2.6.1           # via doc8, readme-renderer, sphinx
+pygments==2.7.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
@@ -91,15 +91,15 @@ pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celer
 pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/test.txt
+pytest==6.0.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 readme-renderer==26.0     # via -r requirements/doc.in
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/test.txt
+redis==3.5.3              # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
@@ -108,7 +108,7 @@ rules==2.2                # via -r requirements/test.txt
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, mock, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends
@@ -127,7 +127,7 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp
+vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,51 +5,51 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/base.txt, kombu
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-boto3==1.14.55            # via -r requirements/base.txt, django-ses
-botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+boto3==1.15.5             # via -r requirements/base.txt, django-ses
+botocore==1.18.5          # via -r requirements/base.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.2              # via -r requirements/base.txt, cryptography
+cffi==1.14.3              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1         # via -r requirements/base.txt, pyjwt
+cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.7  # via -r requirements/base.txt
+django-extensions==3.0.9  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-ses==1.0.2         # via -r requirements/base.txt
+django-ses==1.0.3         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
-gevent==20.6.2            # via -r requirements/production.in
-greenlet==0.4.16          # via gevent
+gevent==20.9.0            # via -r requirements/production.in
+greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.5.0                # via -r requirements/base.txt, stevedore
@@ -64,7 +64,7 @@ python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/production.in
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -80,9 +80,9 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt
-zope.event==4.4           # via gevent
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata
+zope.event==4.5.0         # via gevent
 zope.interface==5.1.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,54 +6,54 @@
 #
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-boto3==1.14.55            # via -r requirements/base.txt, django-ses
-botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+boto3==1.15.5             # via -r requirements/base.txt, django-ses
+botocore==1.18.5          # via -r requirements/base.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.2              # via -r requirements/base.txt, cryptography
+cffi==1.14.3              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1         # via -r requirements/base.txt, pyjwt
+cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.7  # via -r requirements/base.txt
+django-extensions==3.0.9  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-ses==1.0.2         # via -r requirements/base.txt
+django-ses==1.0.3         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.5.0                # via -r requirements/base.txt, stevedore
@@ -72,7 +72,7 @@ pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -90,6 +90,6 @@ stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,65 +6,64 @@
 #
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==20.1.0             # via pytest
-billiard==3.5.0.5         # via -r requirements/base.txt, celery
-boto3==1.14.55            # via -r requirements/base.txt, django-ses
-botocore==1.17.55         # via -r requirements/base.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+attrs==20.2.0             # via pytest
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+boto3==1.15.5             # via -r requirements/base.txt, django-ses
+botocore==1.18.5          # via -r requirements/base.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.2              # via -r requirements/base.txt, cryptography
+cffi==1.14.3              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.6.0   # via -r requirements/test.in
+code-annotations==0.8.0   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.2.1           # via -r requirements/test.in, pytest-cov
-cryptography==3.1         # via -r requirements/base.txt, pyjwt
+coverage==5.3             # via -r requirements/test.in, pytest-cov
+cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.7  # via -r requirements/base.txt
+django-extensions==3.0.9  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-ses==1.0.2         # via -r requirements/base.txt
+django-ses==1.0.3         # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via -r requirements/base.txt, botocore
-drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
 edx-lint==1.5.2           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 factory-boy==3.0.1        # via -r requirements/test.in
-faker==4.1.2              # via factory-boy
-freezegun==0.3.15         # via -r requirements/test.in
+faker==4.1.3              # via factory-boy
+freezegun==1.0.0          # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.5.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest
@@ -83,14 +82,14 @@ pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==6.0.1             # via pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/test.in
+pytest==6.0.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, code-annotations
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/base.txt
+redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
@@ -98,7 +97,7 @@ rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
@@ -109,6 +108,6 @@ toml==0.10.1              # via pytest
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -6,67 +6,66 @@
 #
 amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
 astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
-attrs==20.1.0             # via -r requirements/test.txt, pytest
-billiard==3.5.0.5         # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.14.55            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.17.55         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
+attrs==20.2.0             # via -r requirements/test.txt, pytest
+billiard==3.6.3.0         # via -r requirements/quality.txt, -r requirements/test.txt, celery
+boto3==1.15.5             # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.18.5          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/test.txt, requests
-cffi==1.14.2              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
+cffi==1.14.3              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.6.0   # via -r requirements/test.txt
+code-annotations==0.8.0   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
-cryptography==3.1         # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
+coverage==5.3             # via -r requirements/test.txt, pytest-cov
+cryptography==3.1.1       # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.5.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.7  # via -r requirements/quality.txt, -r requirements/test.txt
+django-extensions==3.0.9  # via -r requirements/quality.txt, -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils, edx-rbac
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt, -r requirements/test.txt
-django-ses==1.0.2         # via -r requirements/quality.txt, -r requirements/test.txt
+django-ses==1.0.3         # via -r requirements/quality.txt, -r requirements/test.txt
 django-simple-history==2.11.0  # via -r requirements/quality.txt, -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-model-utils, django-ses, djangorestframework, drf-jwt, drf-nested-routers, edx-auth-backends, edx-celeryutils, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, rest-condition
 djangorestframework==3.11.1  # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, drf-jwt, drf-nested-routers, edx-drf-extensions, rest-condition
-docutils==0.15.2          # via -r requirements/quality.txt, -r requirements/test.txt, botocore
-drf-jwt==1.17.1           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 drf-nested-routers==0.91  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt, -r requirements/test.txt
 edx-celeryutils==0.5.2    # via -r requirements/quality.txt, -r requirements/test.txt
 edx-django-utils==3.8.0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
+edx-drf-extensions==6.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
 edx-lint==1.5.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
 factory-boy==3.0.1        # via -r requirements/test.txt
-faker==4.1.2              # via -r requirements/test.txt, factory-boy
-freezegun==0.3.15         # via -r requirements/test.txt
+faker==4.1.3              # via -r requirements/test.txt, factory-boy
+freezegun==1.0.0          # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, path, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, kombu, path, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/quality.txt, -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/quality.txt, -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.18.0.148      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+newrelic==5.20.0.149      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest
@@ -91,14 +90,14 @@ pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/tes
 pymongo==3.11.0           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/test.txt
+pytest==6.0.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
-redis==3.2.0              # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
+redis==3.5.3              # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
@@ -106,7 +105,7 @@ rules==2.2                # via -r requirements/quality.txt, -r requirements/tes
 s3transfer==0.3.3         # via -r requirements/quality.txt, -r requirements/test.txt, boto3
 semantic-version==2.8.5   # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, freezegun, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
@@ -118,6 +117,6 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/test.txt, botocore, requests
-vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp
+vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp, celery
 wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, importlib-metadata


### PR DESCRIPTION
## Description

Upgraded celery to 4.4.7

Link to the associated ticket: https://openedx.atlassian.net/browse/BOM-2029

**Celery 5.0 has some breaking changes, as python 3.8 is priority so, we will look at it after python 3.8 deployment**