### PR TITLE
increase default page_size for LicenseViewSet

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -188,7 +188,6 @@ class LicensePagination(PageNumberPagination):
     """
     page_size_query_param = 'page_size'
     max_page_size = 500
-    page_size = 100
 
 
 class LicenseViewSet(LearnerLicenseViewSet):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -182,7 +182,18 @@ class LearnerLicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnly
             return None
 
 
-class LicensePagination(PageNumberPagination):
+class PageNumberPaginationWithCount(PageNumberPagination):
+    """
+    A PageNumber paginator that adds the total number of pages to the paginated response.
+    """
+    def get_paginated_response(self, data):
+        """ Adds a ``num_pages`` field into the paginated response. """
+        response = super().get_paginated_response(data)
+        response.data['num_pages'] = self.page.paginator.num_pages
+        return response
+
+
+class LicensePagination(PageNumberPaginationWithCount):
     """
     A PageNumber paginator that allows the client to specify the page size, up to some maximum.
     """

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -188,6 +188,7 @@ class LicensePagination(PageNumberPagination):
     """
     page_size_query_param = 'page_size'
     max_page_size = 500
+    page_size = 100
 
 
 class LicenseViewSet(LearnerLicenseViewSet):

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -126,7 +126,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAdminUser',
     ],
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 


### PR DESCRIPTION
## Description

Increases the default `page_size` to 100, and adds a `num_pages` field to the LicenseViewSet paginated response so the frontend no longer has to calculate the total page count.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3441

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
