### PR TITLE
Add specific fields to list_display, search_fields, and list_filter for SubscriptionPlan

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -32,11 +32,12 @@ class LicenseAdmin(admin.ModelAdmin):
         'status',
     )
     search_fields = (
+        'uuid__startswith',
         'user_email',
         'subscription_plan__title',
-        'subscription_plan__uuid',
-        'subscription_plan__enterprise_customer_uuid',
-        'subscription_plan__enterprise_catalog_uuid',
+        'subscription_plan__uuid__startswith',
+        'subscription_plan__enterprise_customer_uuid__startswith',
+        'subscription_plan__enterprise_catalog_uuid__startswith',
     )
 
     def get_subscription_plan_title(self, obj):
@@ -82,10 +83,10 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'for_internal_use_only',
     )
     search_fields = (
-        'uuid',
+        'uuid__startswith',
         'title',
-        'enterprise_customer_uuid',
-        'enterprise_catalog_uuid',
+        'enterprise_customer_uuid__startswith',
+        'enterprise_catalog_uuid__startswith',
     )
     ordering = (
         'title',

--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 from license_manager.apps.subscriptions.forms import SubscriptionPlanForm
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
@@ -10,6 +12,7 @@ class LicenseAdmin(admin.ModelAdmin):
     exclude = ['history']
     list_display = (
         'uuid',
+        'get_subscription_plan_title',
         'status',
         'assigned_date',
         'activation_date',
@@ -33,7 +36,15 @@ class LicenseAdmin(admin.ModelAdmin):
         'subscription_plan__title',
         'subscription_plan__uuid',
         'subscription_plan__enterprise_customer_uuid',
+        'subscription_plan__enterprise_catalog_uuid',
     )
+
+    def get_subscription_plan_title(self, obj):
+        return mark_safe('<a href="{}">{}</a>'.format(
+            reverse('admin:subscriptions_subscriptionplan_change', args=(obj.subscription_plan.uuid,)),
+            obj.subscription_plan.title,
+        ))
+    get_subscription_plan_title.short_description = 'Subscription Plan'
 
 
 @admin.register(SubscriptionPlan)
@@ -48,7 +59,7 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'enterprise_catalog_uuid',
         'salesforce_opportunity_id',
         'netsuite_product_id',
-        'num_revocations_remaining',
+        'get_num_revocations_remaining',
     )
     writable_fields = (
         'revoke_max_percentage',
@@ -57,6 +68,39 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'for_internal_use_only',
     )
     fields = read_only_fields + writable_fields
+    list_display = (
+        'title',
+        'is_active',
+        'start_date',
+        'expiration_date',
+        'enterprise_customer_uuid',
+        'enterprise_catalog_uuid',
+        'for_internal_use_only',
+    )
+    list_filter = (
+        'is_active',
+        'for_internal_use_only',
+    )
+    search_fields = (
+        'uuid',
+        'title',
+        'enterprise_customer_uuid',
+        'enterprise_catalog_uuid',
+    )
+    ordering = (
+        'title',
+        'start_date',
+        'expiration_date',
+    )
+    sortable_by = (
+        'title',
+        'start_date',
+        'expiration_date',
+    )
+
+    def get_num_revocations_remaining(self, obj):
+        return obj.num_revocations_remaining
+    get_num_revocations_remaining.short_description = "Number of Revocations Remaining"
 
     def save_model(self, request, obj, form, change):
         # Create licenses to be associated with the subscription plan after creating the subscription plan

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -88,7 +88,6 @@ class SubscriptionPlan(TimeStampedModel):
         """
         num_revocations_allowed = ceil(self.num_licenses * (self.revoke_max_percentage / 100))
         return num_revocations_allowed - self.num_revocations_applied
-    num_revocations_remaining.fget.short_description = "Number of Revocations Remaining"
 
     salesforce_opportunity_id = models.CharField(
         max_length=SALESFORCE_ID_LENGTH,


### PR DESCRIPTION
## Description

Makes the Django Admin screen for SubscriptionPlan list more useful by displaying specific fields, introducing filters and search.

![image](https://user-images.githubusercontent.com/2828721/95605745-633ee280-0a27-11eb-98ba-e7ecca87e44d.png)

Also adds a link to the appropriate SubscriptionPlan from the Licenses list view for ease of access.

![image](https://user-images.githubusercontent.com/2828721/95607638-0db80500-0a2a-11eb-8678-248e43a950f5.png)

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
