### PR TITLE
revert how the `short_description` is applied to the `num_revocations_remaining` property

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -60,7 +60,7 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'enterprise_catalog_uuid',
         'salesforce_opportunity_id',
         'netsuite_product_id',
-        'get_num_revocations_remaining',
+        'num_revocations_remaining',
     )
     writable_fields = (
         'revoke_max_percentage',
@@ -98,10 +98,6 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
         'start_date',
         'expiration_date',
     )
-
-    def get_num_revocations_remaining(self, obj):
-        return obj.num_revocations_remaining
-    get_num_revocations_remaining.short_description = "Number of Revocations Remaining"
 
     def save_model(self, request, obj, form, change):
         # Create licenses to be associated with the subscription plan after creating the subscription plan

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -88,6 +88,7 @@ class SubscriptionPlan(TimeStampedModel):
         """
         num_revocations_allowed = ceil(self.num_licenses * (self.revoke_max_percentage / 100))
         return num_revocations_allowed - self.num_revocations_applied
+    num_revocations_remaining.fget.short_description = "Number of Revocations Remaining"
 
     salesforce_opportunity_id = models.CharField(
         max_length=SALESFORCE_ID_LENGTH,


### PR DESCRIPTION
## Description

I previously changed how the `short_description` for the `num_revocations_remaining` property is applied, which turns out causes a 500 on creation of a new SubscriptionPlan object.

This PR reverts it back to what it was.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
