### PR TITLE
ENT-3459: Email ECS when subs plan reached revocation limit

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -4,7 +4,10 @@ from celery import shared_task
 from celery_utils.logged_task import LoggedTask
 
 from license_manager.apps.api_client.enterprise import EnterpriseApiClient
-from license_manager.apps.subscriptions.emails import send_activation_emails
+from license_manager.apps.subscriptions.emails import (
+    send_activation_emails,
+    send_revocation_cap_notification_email,
+)
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 
@@ -28,7 +31,7 @@ def activation_task(custom_template_text, email_recipient_list, subscription_uui
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
     enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
-    send_activation_emails(custom_template_text, pending_licenses, subscription_plan, enterprise_slug)
+    send_activation_emails(custom_template_text, pending_licenses, enterprise_slug)
     License.set_date_fields_to_now(pending_licenses, ['last_remind_date', 'assigned_date'])
 
     for email_recipient in email_recipient_list:
@@ -59,12 +62,11 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
         send_activation_emails(
             custom_template_text,
             pending_licenses,
-            subscription_plan,
             enterprise_slug,
             is_reminder=True
         )
     except Exception:  # pylint: disable=broad-except
-        logger.warning('License manager activation email sending received an exception.', exc_info=True)
+        logger.error('License manager activation email sending received an exception.', exc_info=True)
         # Return without updating the last_remind_date for licenses
         return
 
@@ -91,3 +93,21 @@ def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
                 exc=exc,
             )
         )
+
+
+@shared_task(base=LoggedTask)
+def send_revocation_cap_notification_email_task(subscription_uuid):
+    """
+    TODO:
+    """
+    subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
+    enterprise_api_client = EnterpriseApiClient()
+    enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
+
+    try:
+        send_revocation_cap_notification_email(
+            subscription_plan,
+            enterprise_name,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.error('Revocation cap notification email sending received an exception.', exc_info=True)

--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -44,7 +44,7 @@ def activation_task(custom_template_text, email_recipient_list, subscription_uui
 @shared_task(base=LoggedTask)
 def send_reminder_email_task(custom_template_text, email_recipient_list, subscription_uuid):
     """
-    Sends license activation reminder email(s) asynchronously
+    Sends license activation reminder email(s) asynchronously.
 
     Arguments:
         custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
@@ -98,7 +98,10 @@ def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
 @shared_task(base=LoggedTask)
 def send_revocation_cap_notification_email_task(subscription_uuid):
     """
-    TODO:
+    Sends revocation cap email notification to ECS asynchronously.
+
+    Arguments:
+        subscription_uuid (str): UUID (string representation) of the subscription that has reached its recovation cap.
     """
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     enterprise_api_client = EnterpriseApiClient()

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -97,11 +97,9 @@ class LicenseManagerCeleryTaskTests(TestCase):
         (
             actual_template_text,
             actual_licenses,
-            actual_subscription_plan,
             actual_enterprise_slug,
         ) = send_email_args[:4]
 
         assert list(self.assigned_licenses) == list(actual_licenses)
-        assert self.subscription_plan == actual_subscription_plan
         assert self.custom_template_text == actual_template_text
         assert self.enterprise_slug == actual_enterprise_slug

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -32,6 +32,20 @@ class EnterpriseApiClient(BaseOAuthClient):
         response = self.client.get(endpoint).json()
         return response.get('slug', None)
 
+    def get_enterprise_name(self, enterprise_customer_uuid):
+        """
+        Gets the enterprise name for the enterprise associated with a customer.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the enterprise customer associated with an enterprise
+
+        Returns:
+            string: The enterprise_name for the enterprise
+        """
+        endpoint = self.enterprise_customer_endpoint + str(enterprise_customer_uuid) + '/'
+        response = self.client.get(endpoint).json()
+        return response.get('name', None)
+
     @backoff.on_predicate(
         # Use an exponential backoff algorithm
         backoff.expo,

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -14,9 +14,11 @@ LICENSE_STATUS_CHOICES = (
 # Subject lines used for emails
 LICENSE_ACTIVATION_EMAIL_SUBJECT = 'edX License Activation'
 LICENSE_REMINDER_EMAIL_SUBJECT = 'Your edX License is pending'
+REVOCATION_CAP_NOTIFICATION_EMAIL_SUBJECT = 'REVOCATION CAP REACHED: {}'
 
 # Template names used for emails
 LICENSE_ACTIVATION_EMAIL_TEMPLATE = 'activation'
+REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE = 'revocation_cap'
 
 # Role-based access control
 SUBSCRIPTIONS_ADMIN_ROLE = 'enterprise_subscriptions_admin'

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -6,13 +6,31 @@ from license_manager.apps.subscriptions.constants import (
     LICENSE_ACTIVATION_EMAIL_SUBJECT,
     LICENSE_ACTIVATION_EMAIL_TEMPLATE,
     LICENSE_REMINDER_EMAIL_SUBJECT,
+    REVOCATION_CAP_NOTIFICATION_EMAIL_SUBJECT,
+    REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE,
 )
+
+
+def send_revocation_cap_notification_email(subscription_plan, enterprise_name):
+    """
+    TODO:
+    """
+    context = {
+        'template_name': REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE,
+        'subject': REVOCATION_CAP_NOTIFICATION_EMAIL_SUBJECT.format(subscription_plan.title),
+        'SUBSCRIPTION_TITLE': subscription_plan.title,
+        'ENTERPRISE_NAME': enterprise_name,
+        'NUM_REVOCATIONS_APPLIED': subscription_plan.num_revocations_applied,
+        'RECIPIENT_EMAIL': settings.CUSTOMER_SUCCESS_EMAIL,
+        'HIDE_EMAIL_FOOTER_MARKETING': True,
+    }
+    email = _message_from_context_and_template(context)
+    email.send()
 
 
 def send_activation_emails(
     custom_template_text,
     pending_licenses,
-    subscription_plan,
     enterprise_slug,
     is_reminder=False
 ):
@@ -32,39 +50,30 @@ def send_activation_emails(
         'template_name': LICENSE_ACTIVATION_EMAIL_TEMPLATE,
         'subject': (LICENSE_ACTIVATION_EMAIL_SUBJECT, LICENSE_REMINDER_EMAIL_SUBJECT)[is_reminder],
         'REMINDER': is_reminder,
+        'TEMPLATE_CLOSING': custom_template_text['closing'],
+        'TEMPLATE_GREETING': custom_template_text['greeting'],
     }
     email_activation_key_map = {}
     for pending_license in pending_licenses:
         email_activation_key_map.update({pending_license.user_email: str(pending_license.activation_key)})
 
     _send_email_with_activation(
-        custom_template_text,
         email_activation_key_map,
-        subscription_plan.expiration_date,
         context,
-        enterprise_slug
+        enterprise_slug,
     )
 
 
-def _send_email_with_activation(
-    custom_template_text,
-    email_activation_key_map,
-    subscription_expiration_date,
-    context,
-    enterprise_slug
-):
+def _send_email_with_activation(email_activation_key_map, context, enterprise_slug):
     """
     Helper that sends emails with the given template with an activation link to the the given list of emails.
 
     Args:
-        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
-            the email template.
         email_activation_key_map (dict): Dictionary containing the emails of each recipient and the activation key that
-            is unique to the email. Recipient emails are the keys in the dictionary
-        subscription_expiration_date (datetime): When the subscription expires
+            is unique to the email. Recipient emails are the keys in the dictionary.
         context (dict): Dictionary of context variables for template rendering. Context takes an optional `REMINDER`
             key. If `REMINDER` is provided, a reminder message is added to the email.
-        enterprise_slug (str): The slug associated with an enterprise to uniquely identify it
+        enterprise_slug (str): The slug associated with an enterprise to uniquely identify it.
     """
     # Construct each message to be sent and appended onto the email list
     email_recipient_list = email_activation_key_map.keys()
@@ -77,15 +86,11 @@ def _send_email_with_activation(
                 enterprise_slug,
                 email_activation_key_map.get(email_address)
             ),
-            'USER_EMAIL': email_address,
+            'RECIPIENT_EMAIL': email_address,
             'SOCIAL_MEDIA_FOOTER_URLS': settings.SOCIAL_MEDIA_FOOTER_URLS,
             'MOBILE_STORE_URLS': settings.MOBILE_STORE_URLS,
         })
-        emails.append(_message_from_context_and_template(
-            context,
-            custom_template_text,
-            subscription_expiration_date,
-        ))
+        emails.append(_message_from_context_and_template(context))
 
     # Use a single connection to send all messages
     with mail.get_connection() as connection:
@@ -120,24 +125,18 @@ def _get_rendered_template_content(template_name, extension, context):
     return get_template(message_template).render(context)
 
 
-def _message_from_context_and_template(context, custom_template_text, subscription_expiration_date):
+def _message_from_context_and_template(context):
     """
     Creates a message about the subscription_plan in the template specified by the context, with custom_template_text.
 
     Args:
         context (dict): Dictionary of context variables for template rendering.
-        custom_template_text (dict): Dictionary containing `greeting` and `closing` keys to be used for customizing
-            the email template.
-        subscription_expiration_date (datetime): When the subscription expires
 
     Returns:
         EmailMultiAlternative: an individual message constructed from the information provided, not yet sent
     """
     # Update context to be used for Django template rendering
     context.update({
-        'EXPIRATION_DATE': subscription_expiration_date,
-        'TEMPLATE_CLOSING': custom_template_text['closing'],
-        'TEMPLATE_GREETING': custom_template_text['greeting'],
         'UNSUBSCRIBE_LINK': settings.EMAIL_UNSUBSCRIBE_LINK,
     })
 
@@ -162,9 +161,9 @@ def _message_from_context_and_template(context, custom_template_text, subscripti
         subject=context['subject'],
         body=txt_content,
         from_email=from_email_string,
-        to=[context['USER_EMAIL']],
+        to=[context['RECIPIENT_EMAIL']],
         bcc=[],
-        headers=message_headers
+        headers=message_headers,
     )
     message.attach_alternative(html_content, 'text/html')
     return message

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -21,7 +21,7 @@ def send_revocation_cap_notification_email(subscription_plan, enterprise_name):
         'SUBSCRIPTION_TITLE': subscription_plan.title,
         'ENTERPRISE_NAME': enterprise_name,
         'NUM_REVOCATIONS_APPLIED': subscription_plan.num_revocations_applied,
-        'RECIPIENT_EMAIL': settings.CUSTOMER_SUCCESS_EMAIL,
+        'RECIPIENT_EMAIL': settings.CUSTOMER_SUCCESS_EMAIL_ADDRESS,
         'HIDE_EMAIL_FOOTER_MARKETING': True,
     }
     email = _message_from_context_and_template(context)

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -13,7 +13,8 @@ from license_manager.apps.subscriptions.constants import (
 
 def send_revocation_cap_notification_email(subscription_plan, enterprise_name):
     """
-    TODO:
+    Sends an email to inform ECS that a subscription plan for a customer has reached its
+    revocation cap, and that action may be necessary to help the customer add more licenses.
     """
     context = {
         'template_name': REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE,

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -48,7 +48,6 @@ class EmailTests(TestCase):
         emails.send_activation_emails(
             self.custom_template_text,
             [license for license in self.licenses if license.status == constants.ASSIGNED],
-            self.subscription_plan,
             self.enterprise_slug
         )
         self.assertEqual(
@@ -69,7 +68,6 @@ class EmailTests(TestCase):
         emails.send_activation_emails(
             self.custom_template_text,
             [lic],
-            lic.subscription_plan,
             self.enterprise_slug,
             True
         )

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -338,7 +338,7 @@ EMAIL_FILE_PATH = './emails'
 """
 EMAIL_UNSUBSCRIBE_LINK = 'https://www.edx.org'  # Dummy unsubscribe link for development use
 SUBSCRIPTIONS_FROM_EMAIL = 'from@example.com'  # Dummy from email address for development use
-CUSTOMER_SUCCESS_EMAIL = 'ecs@example.com'  # Dummy ECS email address for development use
+CUSTOMER_SUCCESS_EMAIL_ADDRESS = 'ecs@example.com'  # Dummy ECS email address for development use
 # End email configuration
 
 ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', '')

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -338,6 +338,7 @@ EMAIL_FILE_PATH = './emails'
 """
 EMAIL_UNSUBSCRIBE_LINK = 'https://www.edx.org'  # Dummy unsubscribe link for development use
 SUBSCRIPTIONS_FROM_EMAIL = 'from@example.com'  # Dummy from email address for development use
+CUSTOMER_SUCCESS_EMAIL = 'ecs@example.com'  # Dummy ECS email address for development use
 # End email configuration
 
 ENTERPRISE_CATALOG_URL = os.environ.get('ENTERPRISE_CATALOG_URL', '')

--- a/license_manager/templates/email/email_base.html
+++ b/license_manager/templates/email/email_base.html
@@ -66,66 +66,68 @@
             <!-- FOOTER -->
             <td class="footer" style="padding: 20px;">
                 <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
-                    <tr>
-                        <td style="padding-bottom: 20px;">
-                            <!-- SOCIAL -->
-                            <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
-                                <tr>
-                                    {% if SOCIAL_MEDIA_FOOTER_URLS.linkedin %}
-                                        <td height="32" width="42">
-                                            <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.linkedin|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}LinkedIn{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if SOCIAL_MEDIA_FOOTER_URLS.twitter %}
-                                        <td height="32" width="42">
-                                            <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.twitter|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Twitter{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if SOCIAL_MEDIA_FOOTER_URLS.facebook %}
-                                        <td height="32" width="42">
-                                            <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.facebook|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Facebook{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if SOCIAL_MEDIA_FOOTER_URLS.reddit %}
-                                        <td height="32" width="42">
-                                            <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.reddit|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Reddit{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-                    <tr>
-                        <!-- APP BUTTONS -->
-                        <td style="padding-bottom: 20px;">
-                            {% if MOBILE_STORE_URLS.apple %}
-                                <a href="{{ MOBILE_STORE_URLS.apple|safe }}" style="text-decoration: none">
-                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
-                                         alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
-                                         width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
-                                </a>
-                            {% endif %}
-                            {% if MOBILE_STORE_URLS.google %}
-                                <a href="{{ MOBILE_STORE_URLS.google|safe }}" style="text-decoration: none">
-                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
-                                         alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
-                                         width="136" height="50"/>
-                                </a>
-                            {% endif %}
-                        </td>
-                    </tr>
+                    {% if not HIDE_EMAIL_FOOTER_MARKETING %}
+                        <tr>
+                            <td style="padding-bottom: 20px;">
+                                <!-- SOCIAL -->
+                                <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
+                                    <tr>
+                                        {% if SOCIAL_MEDIA_FOOTER_URLS.linkedin %}
+                                            <td height="32" width="42">
+                                                <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.linkedin|safe }}">
+                                                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
+                                                        width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}LinkedIn{% endblocktrans %}{% endfilter %}"/>
+                                                </a>
+                                            </td>
+                                        {% endif %}
+                                        {% if SOCIAL_MEDIA_FOOTER_URLS.twitter %}
+                                            <td height="32" width="42">
+                                                <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.twitter|safe }}">
+                                                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
+                                                        width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Twitter{% endblocktrans %}{% endfilter %}"/>
+                                                </a>
+                                            </td>
+                                        {% endif %}
+                                        {% if SOCIAL_MEDIA_FOOTER_URLS.facebook %}
+                                            <td height="32" width="42">
+                                                <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.facebook|safe }}">
+                                                    <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
+                                                        width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Facebook{% endblocktrans %}{% endfilter %}"/>
+                                                </a>
+                                            </td>
+                                        {% endif %}
+                                        {% if SOCIAL_MEDIA_FOOTER_URLS.reddit %}
+                                            <td height="32" width="42">
+                                                <a href="{{ SOCIAL_MEDIA_FOOTER_URLS.reddit|safe }}">
+                                                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
+                                                        width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}Reddit{% endblocktrans %}{% endfilter %}"/>
+                                                </a>
+                                            </td>
+                                        {% endif %}
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr>
+                            <!-- APP BUTTONS -->
+                            <td style="padding-bottom: 20px;">
+                                {% if MOBILE_STORE_URLS.apple %}
+                                    <a href="{{ MOBILE_STORE_URLS.apple|safe }}" style="text-decoration: none">
+                                        <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
+                                            alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
+                                            width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
+                                    </a>
+                                {% endif %}
+                                {% if MOBILE_STORE_URLS.google %}
+                                    <a href="{{ MOBILE_STORE_URLS.google|safe }}" style="text-decoration: none">
+                                        <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
+                                            alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
+                                            width="136" height="50"/>
+                                    </a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
                     <tr>
                         <!-- COPYRIGHT -->
                         <td>

--- a/license_manager/templates/email/revocation_cap.html
+++ b/license_manager/templates/email/revocation_cap.html
@@ -17,8 +17,8 @@
         {% blocktrans trimmed %}
         Having now used {{ NUM_REVOCATIONS_APPLIED }} revocations, this enterprise will be unable to
         revoke additional activated licenses from learners, and this feature will be disabled within
-        their administration portal. They will still be able to revoke and reassign pending licenses,
-        which have never been previously activated.
+        their administration portal. They will still be able to revoke and reassign pending licenses
+        that have never been previously activated.
         {% endblocktrans %}
     </p>
     <p>

--- a/license_manager/templates/email/revocation_cap.html
+++ b/license_manager/templates/email/revocation_cap.html
@@ -1,14 +1,16 @@
 {% extends "email/email_base.html" %}
 {% load i18n %}
+
 {% block body %}
     <!-- Message Body -->
     <h1>
         {% trans "Revocation Cap Reached" %}
     </h1>
     <p>
+        {% now "F j, Y, h:i a T" as revoke_limit_reached_date %}
         {% blocktrans trimmed %}
-        As of October 9, 2020, {{ ENTERPRISE_NAME }} has used all allotted license revocations for their 
-        subscription plan: {{ SUBSCRIPTION_TITLE }}.
+        As of {{ revoke_limit_reached_date }}, {{ ENTERPRISE_NAME }} has used all allotted license revocations
+        for their subscription plan: {{ SUBSCRIPTION_TITLE }}.
         {% endblocktrans %}
     </p>
     <p>

--- a/license_manager/templates/email/revocation_cap.html
+++ b/license_manager/templates/email/revocation_cap.html
@@ -1,0 +1,29 @@
+{% extends "email/email_base.html" %}
+{% load i18n %}
+{% block body %}
+    <!-- Message Body -->
+    <h1>
+        {% trans "Revocation Cap Reached" %}
+    </h1>
+    <p>
+        {% blocktrans trimmed %}
+        As of October 9, 2020, {{ ENTERPRISE_NAME }} has used all allotted license revocations for their 
+        subscription plan: {{ SUBSCRIPTION_TITLE }}.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+        Having now used {{ NUM_REVOCATIONS_APPLIED }} revocations, this enterprise will be unable to
+        revoke additional activated licenses from learners, and this feature will be disabled within
+        their administration portal. They will still be able to revoke and reassign pending licenses,
+        which have never been previously activated.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+        Please alert Account Management (if applicable) and take appropriate steps to ensure the customer
+        continues to have a positive experience with edX.
+        {% endblocktrans %}
+    </p>
+    <!-- End Message Body -->
+{% endblock body %}

--- a/license_manager/templates/email/revocation_cap.txt
+++ b/license_manager/templates/email/revocation_cap.txt
@@ -11,7 +11,7 @@ for their subscription plan: {{ SUBSCRIPTION_TITLE }}.
 {% blocktrans trimmed %}
 Having now used {{ NUM_REVOCATIONS_APPLIED }} revocations, this enterprise will be unable to revoke additional activated
 licenses from learners, and this feature will be disabled within their administration portal. They will still be able to
-revoke and reassign pending licenses, which have never been previously activated.
+revoke and reassign pending licenses that have never been previously activated.
 {% endblocktrans %}
 
 {% blocktrans trimmed %}

--- a/license_manager/templates/email/revocation_cap.txt
+++ b/license_manager/templates/email/revocation_cap.txt
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+{% trans "Revocation Cap Reached" %}
+
+{% blocktrans trimmed %}
+As of October 9, 2020, {{ ENTERPRISE_NAME }} has used all allotted license revocations for their subscription plan: {{ SUBSCRIPTION_TITLE }}.
+{% endblocktrans %}
+
+{% blocktrans trimmed %}
+Having now used {{ NUM_REVOCATIONS_APPLIED }} revocations, this enterprise will be unable to revoke additional activated
+licenses from learners, and this feature will be disabled within their administration portal. They will still be able to
+revoke and reassign pending licenses, which have never been previously activated.
+{% endblocktrans %}
+
+{% blocktrans trimmed %}
+Please alert Account Management (if applicable) and take appropriate steps to ensure the customer continues to have a positive experience with edX.
+{% endblocktrans %}

--- a/license_manager/templates/email/revocation_cap.txt
+++ b/license_manager/templates/email/revocation_cap.txt
@@ -2,8 +2,10 @@
 
 {% trans "Revocation Cap Reached" %}
 
+{% now "F j, Y, h:i a T" as revoke_limit_reached_date %}
 {% blocktrans trimmed %}
-As of October 9, 2020, {{ ENTERPRISE_NAME }} has used all allotted license revocations for their subscription plan: {{ SUBSCRIPTION_TITLE }}.
+As of {{ revoke_limit_reached_date }}, {{ ENTERPRISE_NAME }} has used all allotted license revocations
+for their subscription plan: {{ SUBSCRIPTION_TITLE }}.
 {% endblocktrans %}
 
 {% blocktrans trimmed %}


### PR DESCRIPTION
## Description

After a user revokes a license, check whether there are any revocations remaining; if not, this means they've reached their revocation cap limit. At this point, we must send an email to ECS about reaching the revocation cap for the subscription plan.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3459

**Example email**

<img src="https://user-images.githubusercontent.com/2828721/95887664-20924880-0d4e-11eb-9fc5-a8c996238773.png" width="400" />

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
