### PR TITLE
ENT-3505: adding days_until_expiration property to use in SubscriptionPlanSerializer

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -26,6 +26,7 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
             'is_active',
             'licenses',
             'revocations',
+            'days_until_expiration',
         ]
 
     def get_licenses(self, obj):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2,6 +2,7 @@
 """
 Tests for the Subscription and License V1 API view sets.
 """
+import datetime
 from uuid import uuid4
 
 import ddt
@@ -217,6 +218,7 @@ def _assert_subscription_response_correct(response, subscription):
         'total': subscription.num_licenses,
         'allocated': subscription.num_allocated_licenses,
     }
+    assert response['days_until_expiration'] == (subscription.expiration_date - datetime.date.today()).days
 
 
 def _assert_license_response_correct(response, subscription_license):

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1,3 +1,4 @@
+import datetime
 from math import ceil
 from uuid import uuid4
 
@@ -48,6 +49,19 @@ class SubscriptionPlan(TimeStampedModel):
     start_date = models.DateField()
 
     expiration_date = models.DateField()
+
+    @property
+    def days_until_expiration(self):
+        """
+        Returns the number of days remaining until a subscription expires.
+        """
+        if self.expiration_date:
+            today = datetime.date.today()
+            diff = self.expiration_date - today
+            return diff.days
+        # Return 0 if expiration_date doesn't exist.
+        # This is just to be safe, it's a required field.
+        return 0
 
     enterprise_customer_uuid = models.UUIDField(
         blank=True,

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -54,14 +54,12 @@ class SubscriptionPlan(TimeStampedModel):
     def days_until_expiration(self):
         """
         Returns the number of days remaining until a subscription expires.
+
+        Note: expiration_date is a required field so checking for None isn't needed.
         """
-        if self.expiration_date:
-            today = datetime.date.today()
-            diff = self.expiration_date - today
-            return diff.days
-        # Return 0 if expiration_date doesn't exist.
-        # This is just to be safe, it's a required field.
-        return 0
+        today = datetime.date.today()
+        diff = self.expiration_date - today
+        return diff.days
 
     enterprise_customer_uuid = models.UUIDField(
         blank=True,


### PR DESCRIPTION
## Description

- Added days_until_expiration property to the SubscriptionPlan model
- Added days_until_expiration to SubscriptionPlanSerializer 

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3505

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
