### PR TITLE
 Update celery autodiscover mechanism for celery 4

### DIFF
--- a/license_manager/celery.py
+++ b/license_manager/celery.py
@@ -2,7 +2,6 @@
 Defines the Celery application for the license_manager project
 """
 from celery import Celery
-from django.conf import settings
 
 
 app = Celery('license_manager', )
@@ -12,7 +11,7 @@ app = Celery('license_manager', )
 app.config_from_object('django.conf:settings', namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+app.autodiscover_tasks()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pulling in INSTALLED_APPS and passing it explicitly was more necessary before Celery 4.  In celery 4 and later,
celery introduces an autodiscovery mechanism for django apps.  Update to the Celery 4 way because the other way
introduces a race condition in Celery 4 that can result in not all tasks getting properly discovered.

See https://github.com/edx/edx-platform/pull/25467 for an example of where this had to be fixed in edx-platform.

## Post-review

Squash commits into discrete sets of changes
