### PR TITLE
Increase max number of licenses to 5000

### DIFF
--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -42,7 +42,7 @@ SALESFORCE_ID_LENGTH = 18  # The salesforce_opportunity_id must be exactly 18 ch
 DAYS_TO_RETIRE = 90
 
 # Subscription validation constants
-MAX_NUM_LICENSES = 1000
+MAX_NUM_LICENSES = 5000
 
 # SQL bulk operation constants
 LICENSE_BULK_OPERATION_BATCH_SIZE = 100


### PR DESCRIPTION
## Description

Increase the max number of licenses on a non internal subscription to 5000 

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3785

## Testing considerations

- Verified a non internal subscription with 5000 licenses can be created

## Post-review

Squash commits into discrete sets of changes
