### PR TITLE
try installing requirements before lint

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -7,14 +7,17 @@ cd /edx/app/license_manager
 make ci_requirements
 pip install -r requirements/pip.txt
 pip install -r requirements/travis.txt
+make requirements
+pip freeze | grep 'astroid\|lint'
 
-make validate_translations
+make lint
+#make validate_translations
 
 # TODO: enable pylint once we figure out mysterious AssignAttr attribute error.
 # When that's fixed, we can replace all of the below with `make validate`
 
 # make validate
-make test
-make style
-make isort_check
-make pii_check
+# make test
+# make style
+# make isort_check
+# make pii_check


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3789

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
