### PR TITLE
Remove enterprise_customer_uuid from subscription

### DIFF
--- a/license_manager/apps/subscriptions/migrations/0018_remove_enterprise_customer_uuid_subscriptionplan.py
+++ b/license_manager/apps/subscriptions/migrations/0018_remove_enterprise_customer_uuid_subscriptionplan.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscriptions', '0017_support_customer_agreements'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalsubscriptionplan',
+            name='enterprise_customer_uuid',
+        ),
+        migrations.RemoveField(
+            model_name='subscriptionplan',
+            name='enterprise_customer_uuid',
+        ),
+    ]

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -108,8 +108,6 @@ class SubscriptionPlan(TimeStampedModel):
         diff = self.expiration_date - today
         return diff.days
 
-    # TODO: Drop `enterprise_customer_uuid` column in separate PR
-
     enterprise_catalog_uuid = models.UUIDField(
         blank=True,
         null=False,


### PR DESCRIPTION
This is removed in favor of using the customer uuid on the linked
CustomerAgreement. The code referencing this column was removed in a
previous PR and this just drops it.

ENT-3737

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.