### PR TITLE
Bulk create/update with history

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -291,7 +291,8 @@ class LicenseViewSet(LearnerLicenseViewSet):
         # all the old data on the license.
         for revoked_license in revoked_licenses_for_assignment:
             revoked_license.reset_to_unassigned()
-        License.objects.bulk_update(
+
+        License.bulk_update(
             revoked_licenses_for_assignment,
             [
                 'status',
@@ -303,7 +304,6 @@ class LicenseViewSet(LearnerLicenseViewSet):
                 'assigned_date',
                 'revoked_date',
             ],
-            batch_size=constants.LICENSE_BULK_OPERATION_BATCH_SIZE,
         )
 
         # Get a queryset of only the number of licenses we need to assign
@@ -314,11 +314,10 @@ class LicenseViewSet(LearnerLicenseViewSet):
             unassigned_license.status = constants.ASSIGNED
             activation_key = str(uuid4())
             unassigned_license.activation_key = activation_key
-        # Efficiently update the licenses in bulk
-        License.objects.bulk_update(
+
+        License.bulk_update(
             unassigned_licenses,
             ['user_email', 'status', 'activation_key'],
-            batch_size=constants.LICENSE_BULK_OPERATION_BATCH_SIZE,
         )
 
         # Send activation emails

--- a/license_manager/apps/subscriptions/tests/test_models.py
+++ b/license_manager/apps/subscriptions/tests/test_models.py
@@ -3,7 +3,8 @@ from unittest import mock
 import ddt
 from django.test import TestCase
 
-from license_manager.apps.subscriptions.models import SubscriptionPlan
+from license_manager.apps.subscriptions.constants import REVOKED, UNASSIGNED
+from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 from license_manager.apps.subscriptions.tests.factories import (
     SubscriptionPlanFactory,
 )
@@ -32,3 +33,62 @@ class SubscriptionsModelTests(TestCase):
             self.subscription_plan.enterprise_catalog_uuid,
             content_ids,
         )
+
+
+class LicenseModelTests(TestCase):
+    """
+    Tests for the License model.
+    """
+    CREATE_HISTORY_TYPE = '+'
+    UPDATE_HISTORY_TYPE = '~'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.subscription_plan = SubscriptionPlanFactory()
+
+    @classmethod
+    def tearDownClass(cls):  # pylint: disable=unused-argument
+        """
+        Removes all test instances of License that have been created.
+        """
+        License.objects.all().delete()
+
+    def test_bulk_create(self):
+        """
+        Test that bulk_create creates and saves objects, and creates an associated
+        historical record for the creation.
+        """
+        licenses = [License(subscription_plan=self.subscription_plan) for _ in range(3)]
+
+        License.bulk_create(licenses)
+
+        for user_license in licenses:
+            user_license.refresh_from_db()
+            assert UNASSIGNED == user_license.status
+            license_history = user_license.history.all()
+            assert 1 == len(license_history)
+            assert self.CREATE_HISTORY_TYPE == user_license.history.earliest().history_type
+
+    def test_bulk_update(self):
+        """
+        Test that bulk_update saves objects, and creates an associated
+        historical record for the update action
+        """
+        licenses = [License(subscription_plan=self.subscription_plan) for _ in range(3)]
+
+        License.bulk_create(licenses)
+
+        for user_license in licenses:
+            user_license.status = REVOKED
+
+        License.bulk_update(licenses, ['status'])
+
+        for user_license in licenses:
+            user_license.refresh_from_db()
+            assert REVOKED == user_license.status
+            license_history = user_license.history.all()
+            assert 2 == len(license_history)
+            assert self.CREATE_HISTORY_TYPE == user_license.history.earliest().history_type
+            assert self.UPDATE_HISTORY_TYPE == user_license.history.first().history_type


### PR DESCRIPTION
## Description
django-simple-history saves history based on a post_save signal that is sent each time an object with history is saved.  For bulk operations, like bulk_create and bulk_update, these signals are not sent.  However, django-simple-history provides some utility function to work around this.  This commit introduces License.bulk_create() and License.bulk_update() method that utilize these utility functions, and uses them in places that previously called License.objects.bulk_create() and License.objects.bulk_update().

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.


Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3740

## Testing considerations

I manually tested this by creating a new plan with 10 licenses, and saw in my local DB 10 historical creation records for that plan/licenses.  I then assigned three of those licenses (assignment uses `bulk_update`) and saw that there were also new historical entries for the modification of each of the three assigned licenses.

- Include unit and a11y tests as appropriate - unit tests added
- Consider performance issues - should be fine.
- Check that Database migrations are backwards-compatible - N/A

## Post-review

Squash commits into discrete sets of changes
