### PR TITLE
Add API field to account for renewal in expiration

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -27,6 +27,7 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
             'licenses',
             'revocations',
             'days_until_expiration',
+            'days_until_expiration_including_renewals',
         ]
 
     def get_licenses(self, obj):

--- a/license_manager/apps/api/v1/tests/constants.py
+++ b/license_manager/apps/api/v1/tests/constants.py
@@ -1,0 +1,2 @@
+# Constants for subscriptions API tests
+SUBSCRIPTION_RENEWAL_DAYS_OFFSET = 500

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -26,7 +26,10 @@ from license_manager.apps.subscriptions.constants import (
     SALESFORCE_ID_LENGTH,
     UNASSIGNED,
 )
-from license_manager.apps.subscriptions.utils import localized_utcnow
+from license_manager.apps.subscriptions.utils import (
+    days_until,
+    localized_utcnow,
+)
 
 
 class CustomerAgreement(TimeStampedModel):
@@ -108,9 +111,7 @@ class SubscriptionPlan(TimeStampedModel):
 
         Note: expiration_date is a required field so checking for None isn't needed.
         """
-        today = datetime.date.today()
-        diff = self.expiration_date - today
-        return diff.days
+        return days_until(self.expiration_date)
 
     enterprise_catalog_uuid = models.UUIDField(
         blank=True,
@@ -230,6 +231,48 @@ class SubscriptionPlan(TimeStampedModel):
             already allocated.
         """
         return self.licenses.filter(status__in=(ACTIVATED, ASSIGNED)).count()
+
+    @property
+    def future_renewals(self):
+        """
+        Returns all of the future renewals associated with a subscription.
+
+        The collected renewals are "future" renewals in that it does not return the renewal that might have created
+        this subscription or any renewals before that.
+        """
+        renewals = []
+        current_renewal = self.get_renewal()
+
+        # Traverse forwards through the renewals that are associated with this plan
+        while current_renewal:
+            renewals.append(current_renewal)
+            try:
+                current_renewal = current_renewal.renewed_subscription_plan.get_renewal()
+            except AttributeError:
+                current_renewal = None
+
+        return renewals
+
+    @property
+    def days_until_expiration_including_renewals(self):
+        """
+        Returns the number of days remaining until a subscription expires, accounting for its future renewals.
+        """
+        renewal_expiration_dates = [renewal.renewed_expiration_date for renewal in self.future_renewals]
+        try:
+            return days_until(max(renewal_expiration_dates))
+        except ValueError:
+            # A value error indicates that there were no renewals
+            return self.days_until_expiration
+
+    def get_renewal(self):
+        """
+        Helper to safely return the renewal associated with the subscription, or None if one does not exist.
+        """
+        try:
+            return self.renewal
+        except SubscriptionPlanRenewal.DoesNotExist:
+            return None
 
     def increase_num_licenses(self, num_new_licenses):
         """

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -37,6 +37,8 @@ class CustomerAgreementFactory(factory.django.DjangoModelFactory):
     """
     class Meta:
         model = CustomerAgreement
+        # Perform a `get_or_create` when an agreement already exists with the same unique identifiers
+        django_get_or_create = ('enterprise_customer_uuid', 'enterprise_customer_slug',)
 
     uuid = factory.LazyFunction(uuid4)
     enterprise_customer_uuid = factory.LazyFunction(uuid4)

--- a/license_manager/apps/subscriptions/tests/test_factories.py
+++ b/license_manager/apps/subscriptions/tests/test_factories.py
@@ -44,17 +44,16 @@ class SubscriptionsModelFactoryTests(TestCase):
         self.assertEqual(subscription.uuid, license.subscription_plan.uuid)
 
     def test_customer_agreement_factory(self):
-        with pytest.raises(IntegrityError):
-            """
-            Verify a customer agreement factory only creates unique customer agreement
-            """
-            customer_agreement = CustomerAgreementFactory()
-            self.assertTrue(customer_agreement)
-            customer_agreement_2 = CustomerAgreementFactory(
-                enterprise_customer_uuid=customer_agreement.enterprise_customer_uuid,
-                enterprise_customer_slug=customer_agreement.enterprise_customer_slug,
-            )
-            self.assertFalse(customer_agreement_2)
+        """
+        Verify the customer agreement factory performs a get_or_create when using the same unique identifiers
+        """
+        customer_agreement = CustomerAgreementFactory()
+        self.assertTrue(customer_agreement)
+        customer_agreement_2 = CustomerAgreementFactory(
+            enterprise_customer_uuid=customer_agreement.enterprise_customer_uuid,
+            enterprise_customer_slug=customer_agreement.enterprise_customer_slug,
+        )
+        assert customer_agreement == customer_agreement_2
 
     def test_subscription_plan_renewal_factory(self):
         """

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -1,5 +1,5 @@
 """ Utility functions for the subscriptions app. """
-from datetime import datetime
+from datetime import date, datetime
 
 from pytz import UTC
 
@@ -7,3 +7,11 @@ from pytz import UTC
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
     return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter
+
+
+def days_until(end_date):
+    """
+    Helper to return the number of days until the end date.
+    """
+    diff = end_date - date.today()
+    return diff.days


### PR DESCRIPTION
We're holding off on adding the associated `renewals` to the response
for now as we don't yet need them on the frontend.

ENT-3801

Example response:
```
{
            "title": "Subscription Plan for Test Enterprise",
            "uuid": "ba5cea4d-8e44-4fc4-bfb4-662c425e3c8b",
            "start_date": "2020-12-17",
            "expiration_date": "2021-12-17",
            "enterprise_customer_uuid": "8b666550-7c28-4ec8-814a-bad08da9364b",
            "enterprise_catalog_uuid": "c061cd7f-0d1f-4610-af74-d5f75bef5a7d",
            "is_active": true,
            "licenses": {
                "total": 100,
                "allocated": 0
            },
            "revocations": {
                "applied": 0,
                "remaining": 5
            },
            "days_until_expiration": 365,
            "days_until_expiration_including_renewals": 730
}
```