### PR TITLE
feat: exposing CustomerAgreement read-only API endpoint

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -4,14 +4,17 @@ from rest_framework import serializers
 from license_manager.apps.subscriptions.constants import (
     EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API,
 )
-from license_manager.apps.subscriptions.models import License, SubscriptionPlan, CustomerAgreement
+from license_manager.apps.subscriptions.models import (
+    CustomerAgreement,
+    License,
+    SubscriptionPlan,
+)
 
 
 class CustomerAgreementSerializer(serializers.ModelSerializer):
     """
     Serializer for the `CustomerAgreement` model.
     """
-    ordered_subscription_plan_expirations = serializers.SerializerMethodField()
     subscription_plans = serializers.SerializerMethodField()
 
     class Meta:
@@ -25,20 +28,8 @@ class CustomerAgreementSerializer(serializers.ModelSerializer):
             'subscription_plans',
         ]
 
-    def get_ordered_subscription_plan_expirations(self, obj):
-        subscriptions = SubscriptionPlan.objects.filter(
-            customer_agreement=obj,
-        ).order_by('-is_active')
-        serialized_subscriptions = list(map(lambda sub: SubscriptionPlanSerializer(sub).data, subscriptions))
-        ordered_subscription_plan_data = list(map(lambda subscription: {
-            'uuid': subscription['uuid'],
-            'days_until_expiration': subscription['days_until_expiration'],
-            'active': subscription['is_active'],
-        }, serialized_subscriptions))
-        return ordered_subscription_plan_data
-
     def get_subscription_plans(self, obj):
-        subscriptions = SubscriptionPlan.objects.filter(customer_agreement=obj)
+        subscriptions = obj.subscription_plans
         return list(map(lambda sub: SubscriptionPlanSerializer(sub).data, subscriptions))
 
 

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -11,28 +11,6 @@ from license_manager.apps.subscriptions.models import (
 )
 
 
-class CustomerAgreementSerializer(serializers.ModelSerializer):
-    """
-    Serializer for the `CustomerAgreement` model.
-    """
-    subscription_plans = serializers.SerializerMethodField()
-
-    class Meta:
-        model = CustomerAgreement
-        fields = [
-            'uuid',
-            'enterprise_customer_uuid',
-            'enterprise_customer_slug',
-            'default_enterprise_catalog_uuid',
-            'ordered_subscription_plan_expirations',
-            'subscription_plans',
-        ]
-
-    def get_subscription_plans(self, obj):
-        subscriptions = obj.subscription_plans
-        return list(map(lambda sub: SubscriptionPlanSerializer(sub).data, subscriptions))
-
-
 class SubscriptionPlanSerializer(serializers.ModelSerializer):
     """
     Serializer for the `SubscriptionPlan` model.
@@ -67,6 +45,24 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
             'applied': obj.num_revocations_applied,
             'remaining': obj.num_revocations_remaining,
         }
+
+
+class CustomerAgreementSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `CustomerAgreement` model.
+    """
+    subscriptions = SubscriptionPlanSerializer(many=True)
+
+    class Meta:
+        model = CustomerAgreement
+        fields = [
+            'uuid',
+            'enterprise_customer_uuid',
+            'enterprise_customer_slug',
+            'default_enterprise_catalog_uuid',
+            'ordered_subscription_plan_expirations',
+            'subscriptions',
+        ]
 
 
 class LicenseSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -5,19 +5,27 @@ from django.shortcuts import get_object_or_404
 from edx_rbac.utils import get_decoded_jwt
 from rest_framework.exceptions import ParseError
 
-from license_manager.apps.subscriptions.models import License, SubscriptionPlan
+from license_manager.apps.subscriptions.models import CustomerAgreement, License, SubscriptionPlan
 
 
-def get_subscription_plan_from_enterprise(request):
+def get_customer_agreement_from_request_enterprise_uuid(request):
     """
-    Helper function to return the active subscription from the `enterprise_customer_uuid` query param on a request.
+    Helper function to return the CustomerAgreement, if any, associated with the specified ``enterprise_customer_uuid``.
     """
     enterprise_customer_uuid = request.query_params.get('enterprise_customer_uuid')
     return get_object_or_404(
-        SubscriptionPlan,
-        customer_agreement__enterprise_customer_uuid=enterprise_customer_uuid,
-        is_active=True,
+        CustomerAgreement,
+        enterprise_customer_uuid=enterprise_customer_uuid,
     )
+
+
+def get_context_for_customer_agreement_from_request(request):
+    """
+    Helper function to return the permission context (i.e., EnterpriseCustomer uuid) for the
+    CustomerAgreement associated with the specified ``enterprise_customer_uuid`` query param.
+    """
+    customer_agreement = get_customer_agreement_from_request_enterprise_uuid(request)
+    return customer_agreement.enterprise_customer_uuid
 
 
 def get_activation_key_from_request(request):
@@ -27,6 +35,7 @@ def get_activation_key_from_request(request):
 
     Params:
         ``request`` - A DRF Request object.
+
     Returns: An activation_key UUID.
     """
     try:
@@ -56,14 +65,15 @@ def get_email_from_request(request):
     return get_key_from_jwt(decoded_jwt, 'email')
 
 
-def get_subscription_plan_by_activation_key(request):
+def get_context_from_subscription_plan_by_activation_key(request):
     """
-    Helper function to return the active subscription plan associated
-    with the license identified by the `activation_key` query param on a request
-    and the ``email`` provided in the renquest's JWT.
+    Helper function to return the permission context (i.e., enterprise customer uuid) from active
+    subscription plan associated with the license identified by the ``activation_key`` query param
+    on a request and the ``email`` provided in the request's JWT.
 
     Params:
         ``request`` - A DRF Request object.
+
     Returns: A ``SubscriptionPlan`` object.
     """
     user_license = get_object_or_404(
@@ -72,4 +82,4 @@ def get_subscription_plan_by_activation_key(request):
         user_email=get_email_from_request(request),
         subscription_plan__is_active=True,
     )
-    return user_license.subscription_plan
+    return user_license.subscription_plan.customer_agreement.enterprise_customer_uuid

--- a/license_manager/apps/api/v1/tests/constants.py
+++ b/license_manager/apps/api/v1/tests/constants.py
@@ -1,2 +1,13 @@
+from license_manager.apps.subscriptions import constants
+
 # Constants for subscriptions API tests
 SUBSCRIPTION_RENEWAL_DAYS_OFFSET = 500
+
+ADMIN_ROLES = {
+    'system_role': constants.SYSTEM_ENTERPRISE_ADMIN_ROLE,
+    'subscriptions_role': constants.SUBSCRIPTIONS_ADMIN_ROLE,
+}
+LEARNER_ROLES = {
+    'system_role': constants.SYSTEM_ENTERPRISE_LEARNER_ROLE,
+    'subscriptions_role': constants.SUBSCRIPTIONS_LEARNER_ROLE,
+}

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1589,21 +1589,21 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    @mock.patch('license_manager.apps.api.v1.views.SubscriptionPlan.contains_content')
+    @mock.patch('license_manager.apps.subscriptions.models.SubscriptionPlan.contains_content')
     @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
-    def test_get_subsidy_course_not_in_catalog(self, mock_get_decoded_jwt, mock_subscription_contains_content):
+    def test_get_subsidy_course_not_in_catalog(self, mock_get_decoded_jwt, mock_contains_content):
         """
         Verify the view returns a 404 if the subscription's catalog does not contain the given course.
         """
         self._assign_learner_roles()
         # Mock that the content was not found in the subscription's catalog
-        mock_subscription_contains_content.return_value = False
+        mock_contains_content.return_value = False
         mock_get_decoded_jwt.return_value = self._decoded_jwt
 
         url = self._get_url_with_params()
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        mock_subscription_contains_content.assert_called_with([self.course_key])
+        mock_contains_content.assert_called_with([self.course_key])
 
     def _assert_correct_subsidy_response(self, response):
         """
@@ -1619,21 +1619,21 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
             'expiration_date': str(self.active_subscription_for_customer.expiration_date),
         }
 
-    @mock.patch('license_manager.apps.api.v1.views.CustomerAgreement.contains_catalog_content')
+    @mock.patch('license_manager.apps.api.v1.views.SubscriptionPlan.contains_content')
     @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
-    def test_get_subsidy(self, mock_get_decoded_jwt, mock_customer_agreement_contains_content):
+    def test_get_subsidy(self, mock_get_decoded_jwt, mock_contains_content):
         """
         Verify the view returns the correct response for a course in the user's subscription's catalog.
         """
         self._assign_learner_roles()
         # Mock that the content was found in the subscription's catalog
-        mock_customer_agreement_contains_content.return_value = True
+        mock_contains_content.return_value = True
         mock_get_decoded_jwt.return_value = self._decoded_jwt
 
         url = self._get_url_with_params()
         response = self.api_client.get(url)
         self._assert_correct_subsidy_response(response)
-        mock_customer_agreement_contains_content.assert_called_with([self.course_key])
+        mock_contains_content.assert_called_with([self.course_key])
 
 
 class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -229,8 +229,8 @@ def _assert_customer_agreement_response_correct(response, customer_agreement):
     assert response['default_enterprise_catalog_uuid'] == str(customer_agreement.default_enterprise_catalog_uuid)
     assert response['ordered_subscription_plan_expirations'] == customer_agreement.ordered_subscription_plan_expirations
     for response_subscription, agreement_subscription in zip(
-        response['subscription_plans'],
-        customer_agreement.subscription_plans
+        response['subscriptions'],
+        customer_agreement.subscriptions.all()
     ):
         _assert_subscription_response_correct(response_subscription, agreement_subscription)
 
@@ -377,7 +377,7 @@ def test_subscription_plan_list_staff_user_200(api_client, staff_user, boolean_t
     specified by the query parameter.
     """
     enterprise_customer_uuid = uuid4()
-    first_subscription, second_subscription, _ = _create_subscription_plans(enterprise_customer_uuid)
+    first_subscription, second_subscription, __ = _create_subscription_plans(enterprise_customer_uuid)
     third_subscription = _create_subscription_with_renewal(enterprise_customer_uuid)
     _assign_role_via_jwt_or_db(api_client, staff_user, enterprise_customer_uuid, boolean_toggle)
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -28,6 +28,8 @@ from rest_framework.test import APIClient
 
 from license_manager.apps.api.v1.tests.constants import (
     SUBSCRIPTION_RENEWAL_DAYS_OFFSET,
+    ADMIN_ROLES,
+    LEARNER_ROLES,
 )
 from license_manager.apps.core.models import User
 from license_manager.apps.subscriptions import constants
@@ -134,14 +136,36 @@ def superuser():
     """
     return get_model_fixture(User, is_staff=True, is_superuser=True)
 
+@pytest.fixture(params=[ADMIN_ROLES, LEARNER_ROLES])
+def user_role(request):
+    """
+    Simple fixture that toggles between various user roles.
+    """
+    return request.param
 
-def _customer_agreement_detail_request(api_client, user, enterprise_customer_uuid):
+
+def _customer_agreement_detail_request(api_client, user, customer_agreement_uuid):
     """
     Helper method that requests details for a specific customer agreement.
     """
     api_client.force_authenticate(user=user)
+
+    url = reverse('api:v1:customer-agreement-detail', kwargs={
+        'customer_agreement_uuid': customer_agreement_uuid,
+    })
+
+    return api_client.get(url)
+
+
+def _customer_agreement_list_request(api_client, user, enterprise_customer_uuid):
+    """
+    Helper method that requests CustomerAgreement details for a specific enterprise customer uuid.
+    """
+    api_client.force_authenticate(user=user)
     url = reverse('api:v1:customer-agreement-list')
-    url += enterprise_customer_uuid + '/'
+    if enterprise_customer_uuid is not None:
+        url += f'?enterprise_customer_uuid={enterprise_customer_uuid}'
+
     return api_client.get(url)
 
 
@@ -268,26 +292,51 @@ def _assert_license_response_correct(response, subscription_license):
 
 
 @pytest.mark.django_db
-def test_customer_agreement_detail_unauthenticated_user_403(api_client):
+def test_customer_agreement_unauthenticated_user_403(api_client):
     """
     Verify that unauthenticated users receive a 403 from the customer agreement detail endpoint.
     """
-    response = _customer_agreement_detail_request(api_client, AnonymousUser(), str(uuid4()))
+    response = _customer_agreement_detail_request(api_client, AnonymousUser(), uuid4())
     assert status.HTTP_403_FORBIDDEN == response.status_code
 
 
 @pytest.mark.django_db
-def test_customer_agreement_detail_non_staff_user_403(api_client, non_staff_user):
+def test_customer_agreement_non_staff_user_403(api_client, non_staff_user):
     """
-    Verify that unauthenticated users receive a 403 from the customer agreement detail endpoint.
+    Verify that non-staff users without JWT roles receive a 403 from the customer agreement detail endpoint.
     """
-    response = _customer_agreement_detail_request(api_client, non_staff_user, str(uuid4()))
+    response = _customer_agreement_detail_request(api_client, non_staff_user, uuid4())
     assert status.HTTP_403_FORBIDDEN == response.status_code
 
 
 @pytest.mark.django_db
-def test_customer_agreement_detail_staff_user_403(api_client, staff_user):
-    response = _customer_agreement_detail_request(api_client, staff_user, str(uuid4()))
+def test_customer_agreement_detail_non_staff_user_200(api_client, non_staff_user, user_role, boolean_toggle):
+    """
+    Verify that non-staff users with JWT roles (admin + learners) receive a 200 from the
+    customer agreement detail endpoint.
+    """
+    enterprise_customer_uuid = uuid4()
+    __, __, customer_agreement = _create_subscription_plans(enterprise_customer_uuid)
+
+    _assign_role_via_jwt_or_db(
+        api_client,
+        non_staff_user,
+        enterprise_customer_uuid,
+        assign_via_jwt=boolean_toggle,
+        system_role=user_role['system_role'],
+        subscriptions_role=user_role['subscriptions_role'],
+    )
+
+    response = _customer_agreement_detail_request(api_client, non_staff_user, customer_agreement.uuid)
+    assert status.HTTP_200_OK == response.status_code
+
+
+@pytest.mark.django_db
+def test_customer_agreement_staff_user_403(api_client, staff_user):
+    """
+    Verify that staff users without any assigned roles receive a 403 from the customer agreement detail endpoint.
+    """
+    response = _customer_agreement_detail_request(api_client, staff_user, uuid4())
     assert status.HTTP_403_FORBIDDEN == response.status_code
 
 
@@ -298,12 +347,24 @@ def test_customer_agreement_detail_superuser_200(api_client, superuser):
     response for superusers.
     """
     enterprise_customer_uuid = uuid4()
-    _, _, customer_agreement = _create_subscription_plans(enterprise_customer_uuid)
-    response = _customer_agreement_detail_request(api_client, superuser, str(enterprise_customer_uuid))
+    __, __, customer_agreement = _create_subscription_plans(enterprise_customer_uuid)
+    response = _customer_agreement_detail_request(api_client, superuser, customer_agreement.uuid)
 
     assert status.HTTP_200_OK == response.status_code
     _assert_customer_agreement_response_correct(response.data, customer_agreement)
 
+@pytest.mark.django_db
+def test_customer_agreement_list_superuser_200(api_client, superuser):
+    """
+    Verify that the customer agreement list endpoint gives the correct
+    response for superusers.
+    """
+    enterprise_customer_uuid = uuid4()
+    __, __, customer_agreement = _create_subscription_plans(enterprise_customer_uuid)
+    response = _customer_agreement_list_request(api_client, superuser, customer_agreement.enterprise_customer_uuid)
+
+    assert status.HTTP_200_OK == response.status_code
+    _assert_customer_agreement_response_correct(response.data, customer_agreement)
 
 @pytest.mark.django_db
 def test_subscription_plan_list_unauthenticated_user_403(api_client):
@@ -1452,9 +1513,9 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
         assert status.HTTP_400_BAD_REQUEST == response.status_code
         assert '`user_id` is required and could not be found in your jwt' in str(response.content)
 
-    def test_get_subsidy_no_subscription_for_customer(self):
+    def test_get_subsidy_no_subscription_for_enterprise_customer(self):
         """
-        Verify the view returns a 404 if there is no subscription plan for the customer.
+        Verify the view returns a 404 if there is no subscription plan for the enterprise customer.
         """
         self._assign_learner_roles()
         # Pass in some random enterprise_customer_uuid that doesn't have a subscripttion
@@ -1465,22 +1526,15 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
     @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
     def test_get_subsidy_no_active_subscription_for_customer(self, mock_get_decoded_jwt):
         """
-        Verify the view returns a 404 if there is no active subscription plan for the customer.
+        Verify the view returns a 404 if there is no active license for the user.
         """
         mock_get_decoded_jwt.return_value = self._decoded_jwt
-        other_enterprise_uuid = uuid4()
-        customer_agreement = CustomerAgreementFactory.create(enterprise_customer_uuid=other_enterprise_uuid)
-        SubscriptionPlanFactory.create(customer_agreement=customer_agreement, is_active=False)
-        self._assign_learner_roles(alternate_customer=other_enterprise_uuid)
-        url = self._get_url_with_params(enterprise_customer_override=other_enterprise_uuid)
-        response = self.api_client.get(url)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
-    def test_get_subsidy_no_license_for_user(self, mock_get_decoded_jwt):
-        """
-        Verify the view returns a 404 if the subscription has no license for the user.
-        """
+        customer_agreement = CustomerAgreementFactory.create()
+        subscription_plan = SubscriptionPlanFactory.create(customer_agreement=customer_agreement)
+        non_activated_license = LicenseFactory.create(
+            subscription_plan=subscription_plan,
+            status=constants.ASSIGNED,
+        )
         self._assign_learner_roles()
         # Mock the lms_user_id to be one not associated with any licenses
         mock_get_decoded_jwt.return_value = {'user_id': 500}
@@ -1538,21 +1592,21 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
             'expiration_date': str(self.active_subscription_for_customer.expiration_date),
         }
 
-    @mock.patch('license_manager.apps.api.v1.views.SubscriptionPlan.contains_content')
+    @mock.patch('license_manager.apps.api.v1.views.CustomerAgreement.contains_catalog_content')
     @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
-    def test_get_subsidy(self, mock_get_decoded_jwt, mock_subscription_contains_content):
+    def test_get_subsidy(self, mock_get_decoded_jwt, mock_customer_agreement_contains_content):
         """
         Verify the view returns the correct response for a course in the user's subscription's catalog.
         """
         self._assign_learner_roles()
         # Mock that the content was found in the subscription's catalog
-        mock_subscription_contains_content.return_value = True
+        mock_customer_agreement_contains_content.return_value = True
         mock_get_decoded_jwt.return_value = self._decoded_jwt
 
         url = self._get_url_with_params()
         response = self.api_client.get(url)
         self._assert_correct_subsidy_response(response)
-        mock_subscription_contains_content.assert_called_with([self.course_key])
+        mock_customer_agreement_contains_content.assert_called_with([self.course_key])
 
 
 class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -86,7 +86,7 @@ subscription_router.register(
 urlpatterns = [
     url(
         r'license-subsidy',
-        views.LicenseSubidyView.as_view(),
+        views.LicenseSubsidyView.as_view(),
         name='license-subsidy',
     ),
     url(

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -61,6 +61,11 @@ router.register(
     viewset=views.SubscriptionViewSet,
     basename='subscriptions',
 )
+router.register(
+    prefix=r'customer-agreement(?![^\/])',
+    viewset=views.CustomerAgreementViewSet,
+    basename='customer-agreement',
+)
 
 subscription_router = NestedSimpleRouter(
     parent_router=router,

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -62,7 +62,7 @@ router.register(
     basename='subscriptions',
 )
 router.register(
-    prefix=r'customer-agreement(?![^\/])',
+    prefix=r'customer-agreement',
     viewset=views.CustomerAgreementViewSet,
     basename='customer-agreement',
 )

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 class CustomerAgreementViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyModelViewSet):
-    """ Viewset for read operations on  CustomerAgreements. """
+    """ Viewset for read operations on CustomerAgreements. """
 
     authentication_classes = [JwtAuthentication]
     permission_classes = [permissions.IsAuthenticated]

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -33,10 +33,10 @@ from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.api import revoke_license
 from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
+    CustomerAgreement,
     License,
     SubscriptionPlan,
     SubscriptionsRoleAssignment,
-    CustomerAgreement,
 )
 from license_manager.apps.subscriptions.utils import localized_utcnow
 

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -88,6 +88,27 @@ class CustomerAgreement(TimeStampedModel):
 
         return ordered_subscription_plan_data
 
+    def contains_catalog_content(self, content_ids):
+        """
+        Checks whether the subscriptions related to a CustomerAgreement contains the given content by
+        checking against its linked enterprise catalog(s).
+
+        If a CustomerAgreement "contains" a particular piece of content, that means a license for that
+        CustomerAgreement can be used to access the specified content.
+
+        Arguments:
+            content_ids (list of str): List of content ids to check against the subscriptions associated with the
+                CustomerAgreement.
+
+        Returns:
+            bool: Whether the given content_ids are part of the subscriptions related to the CustomerAgreement.
+        """
+        for subscription in self.subscriptions.all():
+            contains_content = subscription.contains_content(content_ids)
+            if contains_content:
+                return True
+        return False
+
     class Meta:
         verbose_name = _("Customer Agreement")
         verbose_name_plural = _("Customer Agreements")

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -64,6 +64,22 @@ class CustomerAgreement(TimeStampedModel):
 
     history = HistoricalRecords()
 
+    @property
+    def ordered_subscription_plan_expirations(self):
+        subscriptions = SubscriptionPlan.objects.filter(
+            customer_agreement=self,
+        ).order_by('-is_active', '-expiration_date')
+        ordered_subscription_plan_data = list(map(lambda subscription: {
+            'uuid': subscription.uuid,
+            'days_until_expiration': subscription.days_until_expiration,
+            'active': subscription.is_active,
+        }, subscriptions))
+        return ordered_subscription_plan_data
+
+    @property
+    def subscription_plans(self):
+        return list(SubscriptionPlan.objects.filter(customer_agreement=self))
+
     class Meta:
         verbose_name = _("Customer Agreement")
         verbose_name_plural = _("Customer Agreements")

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -88,27 +88,6 @@ class CustomerAgreement(TimeStampedModel):
 
         return ordered_subscription_plan_data
 
-    def contains_catalog_content(self, content_ids):
-        """
-        Checks whether the subscriptions related to a CustomerAgreement contains the given content by
-        checking against its linked enterprise catalog(s).
-
-        If a CustomerAgreement "contains" a particular piece of content, that means a license for that
-        CustomerAgreement can be used to access the specified content.
-
-        Arguments:
-            content_ids (list of str): List of content ids to check against the subscriptions associated with the
-                CustomerAgreement.
-
-        Returns:
-            bool: Whether the given content_ids are part of the subscriptions related to the CustomerAgreement.
-        """
-        for subscription in self.subscriptions.all():
-            contains_content = subscription.contains_content(content_ids)
-            if contains_content:
-                return True
-        return False
-
     class Meta:
         verbose_name = _("Customer Agreement")
         verbose_name_plural = _("Customer Agreements")

--- a/license_manager/apps/subscriptions/rules.py
+++ b/license_manager/apps/subscriptions/rules.py
@@ -16,39 +16,39 @@ from license_manager.apps.subscriptions.models import (
 
 
 @rules.predicate
-def has_implicit_access_to_subscriptions_admin(user, subscription_plan):  # pylint: disable=unused-argument
+def has_implicit_access_to_subscriptions_admin(user, enterprise_customer_uuid):  # pylint: disable=unused-argument
     """
-    Check that if request user has implicit access to the given SubscriptionPlan for the
+    Check that if request user has implicit access to the given enterprise UUID for the
     `SUBSCRIPTIONS_ADMIN_ROLE` feature role.
 
     Returns:
         boolean: whether the request user has access.
     """
-    if not subscription_plan:
+    if not enterprise_customer_uuid:
         return False
 
     return request_user_has_implicit_access_via_jwt(
         get_decoded_jwt(crum.get_current_request()),
         constants.SUBSCRIPTIONS_ADMIN_ROLE,
-        str(subscription_plan.enterprise_customer_uuid),
+        str(enterprise_customer_uuid),
     )
 
 
 @rules.predicate
-def has_explicit_access_to_subscriptions_admin(user, subscription_plan):
+def has_explicit_access_to_subscriptions_admin(user, enterprise_customer_uuid):
     """
     Check that if request user has explicit access to `SUBSCRIPTIONS_ADMIN_ROLE` feature role.
     Returns:
         boolean: whether the request user has access.
     """
-    if not subscription_plan:
+    if not enterprise_customer_uuid:
         return False
 
     return user_has_access_via_database(
         user,
         constants.SUBSCRIPTIONS_ADMIN_ROLE,
         SubscriptionsRoleAssignment,
-        str(subscription_plan.enterprise_customer_uuid),
+        str(enterprise_customer_uuid),
     )
 
 
@@ -60,40 +60,40 @@ rules.add_perm(
 
 
 @rules.predicate
-def has_implicit_access_to_subscriptions_learner(user, subscription_plan):  # pylint: disable=unused-argument
+def has_implicit_access_to_subscriptions_learner(user, enterprise_customer_uuid):  # pylint: disable=unused-argument
     """
-    Check that if request user has implicit access to the given SubscriptionPlan for the
+    Check that if request user has implicit access to the given enterprise UUID for the
     `SUBSCRIPTIONS_LEARNER_ROLE` feature role.
 
     Returns:
         boolean: whether the request user has access.
     """
-    if not subscription_plan:
+    if not enterprise_customer_uuid:
         return False
 
     return request_user_has_implicit_access_via_jwt(
         get_decoded_jwt(crum.get_current_request()),
         constants.SUBSCRIPTIONS_LEARNER_ROLE,
-        str(subscription_plan.enterprise_customer_uuid),
+        str(enterprise_customer_uuid),
     )
 
 
 @rules.predicate
-def has_explicit_access_to_subscriptions_learner(user, subscription_plan):
+def has_explicit_access_to_subscriptions_learner(user, enterprise_customer_uuid):
     """
     Check that if request user has explicit access to `SUBSCRIPTIONS_LEARNER_ROLE` feature role.
 
     Returns:
         boolean: whether the request user has access.
     """
-    if not subscription_plan:
+    if not enterprise_customer_uuid:
         return False
 
     return user_has_access_via_database(
         user,
         constants.SUBSCRIPTIONS_LEARNER_ROLE,
         SubscriptionsRoleAssignment,
-        str(subscription_plan.enterprise_customer_uuid),
+        str(enterprise_customer_uuid),
     )
 
 


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Exposed a read-only API endpoint to retrieve CustomerAgreement records by specifying the associated EnterpriseCustomer UUID. 

[Associated ticket](https://openedx.atlassian.net/browse/ENT-3800)

## Testing considerations

To test this, use the following URL formats: 
* `/api/v1/customer-agreement/{customer_agreement_uuid}/`
* `/api/v1/customer-agreement/?enterprise_customer_uuid={enterprise_customer_uuid}`

JWT authentication is needed, include the following `key:value` pair in your request header:
`'Authorization' : 'JWT {edx-jwt-cookie-header-payload}.{edx-jwt-cookie-signature}'`

Obtain JWT cookie payload/signature using developer tools in a browser session that has authenticated as a staff user.

## Example response

```json
{
    "uuid": "6a8d9f21-0ae6-4f83-9a0b-dc9925b57b59",
    "enterprise_customer_uuid": "bdd488ad-3f6e-49b7-9fb4-99443afad65f",
    "enterprise_customer_slug": "test-enterprise",
    "default_enterprise_catalog_uuid": null,
    "ordered_subscription_plan_expirations": [
        {
            "uuid": "f99e4f1f-ddc7-46c7-ac91-0accb0a1f5a7",
            "days_until_expiration": 1790,
            "days_until_expiration_including_renewals": 1790,
            "is_active": true
        },
        {
            "uuid": "4693a1db-990c-468d-87f8-622271644753",
            "days_until_expiration": 339,
            "days_until_expiration_including_renewals": 339,
            "is_active": true
        }
    ],
    "subscriptions": [
        {
            "title": "Test Enterprise Subscription 2",
            "uuid": "4693a1db-990c-468d-87f8-622271644753",
            "start_date": "2020-12-10",
            "expiration_date": "2021-12-10",
            "enterprise_customer_uuid": "bdd488ad-3f6e-49b7-9fb4-99443afad65f",
            "enterprise_catalog_uuid": "d0e5d354-205c-4cae-85c2-eb9abdf5b382",
            "is_active": true,
            "licenses": {
                "total": 10,
                "allocated": 1
            },
            "revocations": {
                "applied": 0,
                "remaining": 10
            },
            "days_until_expiration": 339,
            "days_until_expiration_including_renewals": 339
        },
        {
            "title": "Test Enterprise Subscription",
            "uuid": "f99e4f1f-ddc7-46c7-ac91-0accb0a1f5a7",
            "start_date": "2020-11-30",
            "expiration_date": "2025-11-30",
            "enterprise_customer_uuid": "bdd488ad-3f6e-49b7-9fb4-99443afad65f",
            "enterprise_catalog_uuid": "d0e5d354-205c-4cae-85c2-eb9abdf5b382",
            "is_active": true,
            "licenses": {
                "total": 25,
                "allocated": 1
            },
            "revocations": {
                "applied": 0,
                "remaining": 2
            },
            "days_until_expiration": 1790,
            "days_until_expiration_including_renewals": 1790
        }
    ]
}
```

## Post-review

Squash commits into discrete sets of changes
