### PR TITLE
Make dev.up also start the redis service defined in devstack's docker-compose.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,14 @@ validate_translations: fake_translations detect_changed_source_translations ## i
 dev.provision:
 	bash ./provision-license-manager.sh
 
-dev.up: # Starts all containers
+dev.up: dev.up.redis  # Starts all of the services, will bring up the devstack-defined redis container if not running.
 	docker-compose up -d
 
 dev.up.build:
 	docker-compose up -d --build
+
+dev.up.redis:
+	docker-compose -f $(DEVSTACK_WORKSPACE)/devstack/docker-compose.yml up -d redis
 
 dev.down: # Kills containers and all of their data that isn't in volumes
 	docker-compose down


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description
This helps us guard against forgetting to run `dev.up.redis` or `dev.up.lms+redis` in devstack when brining up all of the license-manager services locally.

## Post-review

Squash commits into discrete sets of changes
