### PR TITLE
BOM-2186 : Unpin social-auth-core

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,15 +7,15 @@
 amqp==2.6.1               # via kombu
 backoff==1.10.0           # via -r requirements/base.in
 billiard==3.6.3.0         # via celery
-boto3==1.16.35            # via django-ses
-botocore==1.19.35         # via boto3, s3transfer
+boto3==1.16.49            # via django-ses
+botocore==1.19.49         # via boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in, edx-celeryutils
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.3.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt, social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/base.in
 django-crum==0.7.9        # via edx-django-utils, edx-rbac
@@ -45,12 +45,12 @@ jmespath==0.10.0          # via boto3, botocore
 jsonfield2==4.0.0.post0   # via edx-celeryutils
 kombu==4.6.11             # via celery
 markupsafe==1.1.1         # via jinja2
-mysqlclient==2.0.2        # via -r requirements/base.in
-newrelic==5.22.1.152      # via edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.in
+newrelic==5.24.0.153      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.5.1                # via stevedore
-psutil==5.7.3             # via edx-django-utils
+psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
@@ -58,10 +58,10 @@ pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client,
 pymongo==3.11.2           # via edx-opaque-keys
 python-dateutil==2.8.1    # via botocore, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.4              # via -r requirements/base.in, celery, django, django-ses
+pytz==2020.5              # via -r requirements/base.in, celery, django, django-ses
 redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.25.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rules==2.2                # via -r requirements/base.in
 s3transfer==0.3.3         # via boto3
@@ -69,8 +69,8 @@ semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via edx-auth-backends
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via django
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,12 +15,6 @@ edx-rest-api-client==1.9.2
 
 PyYAML>=5.1
 
-# Upgrade to 3.3.0 triggered users to lose superuser status; see ARCHBOM-1078 for details
-social-auth-core==3.2.0
-
-# social-auth-app-django>=3.2.0 requires social-auth-core>=3.3.0
-social-auth-app-django==3.1.0
-
 zipp<2.0
 
 # Celery 5.0 has some breaking changes, as python 3.8 is priority so,

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,23 +5,23 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/validation.txt, kombu
-astroid==2.3.3            # via -r requirements/validation.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/validation.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/validation.txt, pytest
 backoff==1.10.0           # via -r requirements/validation.txt
 billiard==3.6.3.0         # via -r requirements/validation.txt, celery
-boto3==1.16.35            # via -r requirements/validation.txt, django-ses
-botocore==1.19.35         # via -r requirements/validation.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/validation.txt, django-ses
+botocore==1.19.49         # via -r requirements/validation.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/validation.txt, requests
 cffi==1.14.4              # via -r requirements/validation.txt, cryptography
-chardet==3.0.4            # via -r requirements/validation.txt, requests
+chardet==4.0.0            # via -r requirements/validation.txt, requests
 click-log==0.3.2          # via -r requirements/validation.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/validation.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.10.2  # via -r requirements/validation.txt
 coreapi==2.3.3            # via -r requirements/validation.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/validation.txt, coreapi
-coverage==5.3             # via -r requirements/validation.txt, pytest-cov
-cryptography==3.3.1       # via -r requirements/validation.txt, pyjwt
+coverage==5.3.1           # via -r requirements/validation.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/validation.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/dev.in, -r requirements/validation.txt
 defusedxml==0.6.0         # via -r requirements/validation.txt, python3-openid, social-auth-core
 diff-cover==4.0.1         # via -r requirements/dev.in
@@ -45,19 +45,19 @@ edx-celeryutils==0.5.2    # via -r requirements/validation.txt
 edx-django-utils==3.13.0  # via -r requirements/validation.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/validation.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.txt
-edx-lint==1.5.2           # via -r requirements/validation.txt
+edx-lint==1.6             # via -r requirements/validation.txt
 edx-opaque-keys==2.1.1    # via -r requirements/validation.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/validation.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/validation.txt
-factory-boy==3.1.0        # via -r requirements/validation.txt
-faker==5.0.1              # via -r requirements/validation.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/validation.txt
+faker==5.3.0              # via -r requirements/validation.txt, factory-boy
 freezegun==1.0.0          # via -r requirements/validation.txt
 future==0.18.2            # via -r requirements/validation.txt, django-ses, edx-celeryutils, pyjwkest
 gunicorn==20.0.4          # via -r requirements/dev.in
 idna==2.10                # via -r requirements/validation.txt, requests
 inflect==5.0.2            # via -r requirements/dev.in, jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/validation.txt, pytest
-isort==4.3.21             # via -r requirements/validation.txt, pylint
+isort==5.7.0              # via -r requirements/validation.txt, pylint
 itypes==1.2.0             # via -r requirements/validation.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/validation.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
@@ -67,8 +67,8 @@ kombu==4.6.11             # via -r requirements/validation.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/validation.txt, astroid
 markupsafe==1.1.1         # via -r requirements/validation.txt, jinja2
 mccabe==0.6.1             # via -r requirements/validation.txt, pylint
-mysqlclient==2.0.2        # via -r requirements/validation.txt
-newrelic==5.22.1.152      # via -r requirements/validation.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/validation.txt
+newrelic==5.24.0.153      # via -r requirements/validation.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/validation.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/validation.txt, django-rest-swagger
 packaging==20.8           # via -r requirements/validation.txt, pytest
@@ -76,10 +76,10 @@ path.py==12.5.0           # via -r requirements/validation.txt, edx-i18n-tools
 path==15.0.1              # via -r requirements/validation.txt, path.py
 pathlib2==2.3.5           # via -r requirements/validation.txt
 pbr==5.5.1                # via -r requirements/validation.txt, stevedore
-pip-tools==5.4.0          # via -r requirements/pip-tools.txt
+pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/validation.txt, diff-cover, pytest
 polib==1.1.0              # via -r requirements/validation.txt, edx-i18n-tools
-psutil==5.7.3             # via -r requirements/validation.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/validation.txt, edx-django-utils
 py==1.10.0                # via -r requirements/validation.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/validation.txt
 pycparser==2.20           # via -r requirements/validation.txt, cffi
@@ -89,41 +89,41 @@ pygments==2.7.3           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/validation.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/validation.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/validation.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/validation.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/validation.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/validation.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/validation.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/validation.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/validation.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/validation.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/validation.txt
 pytest-django==4.1.0      # via -r requirements/validation.txt
-pytest==6.2.0             # via -r requirements/validation.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/validation.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/validation.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/validation.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/validation.txt, social-auth-core
-pytz==2020.4              # via -r requirements/validation.txt, celery, django, django-ses
+pytz==2020.5              # via -r requirements/validation.txt, celery, django, django-ses
 pywatchman==1.4.1         # via -r requirements/dev.in
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/validation.txt, code-annotations, edx-i18n-tools
 redis==3.5.3              # via -r requirements/validation.txt
 requests-oauthlib==1.3.0  # via -r requirements/validation.txt, social-auth-core
-requests==2.25.0          # via -r requirements/validation.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/validation.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/validation.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/validation.txt
 s3transfer==0.3.3         # via -r requirements/validation.txt, boto3
 semantic-version==2.8.5   # via -r requirements/validation.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/validation.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/validation.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
+six==1.15.0               # via -r requirements/validation.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/validation.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/validation.txt, pydocstyle
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/validation.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via -r requirements/validation.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/validation.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/validation.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/validation.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/validation.txt, faker, python-slugify
-toml==0.10.2              # via -r requirements/validation.txt, pytest
+toml==0.10.2              # via -r requirements/validation.txt, pylint, pytest
 uritemplate==3.0.1        # via -r requirements/validation.txt, coreapi
 urllib3==1.26.2           # via -r requirements/validation.txt, botocore, requests
 vine==1.3.0               # via -r requirements/validation.txt, amqp, celery
-wrapt==1.11.2             # via -r requirements/validation.txt, astroid
+wrapt==1.12.1             # via -r requirements/validation.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/validation.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,25 +6,25 @@
 #
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test.txt, kombu
-astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 babel==2.9.0              # via sphinx
 backoff==1.10.0           # via -r requirements/test.txt
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
 bleach==3.2.1             # via readme-renderer
-boto3==1.16.35            # via -r requirements/test.txt, django-ses
-botocore==1.19.35         # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/test.txt, django-ses
+botocore==1.19.49         # via -r requirements/test.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/test.txt, requests
 cffi==1.14.4              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.3.1       # via -r requirements/test.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/test.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/test.txt
@@ -47,19 +47,19 @@ edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-celeryutils==0.5.2    # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-factory-boy==3.1.0        # via -r requirements/test.txt
-faker==5.0.1              # via -r requirements/test.txt, factory-boy
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.3.0              # via -r requirements/test.txt, factory-boy
 freezegun==1.0.0          # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
+isort==5.7.0              # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
@@ -68,14 +68,14 @@ kombu==4.6.11             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mysqlclient==2.0.2        # via -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
@@ -83,23 +83,23 @@ pygments==2.7.3           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.2.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.4              # via -r requirements/test.txt, babel, celery, django, django-ses
+pytz==2020.5              # via -r requirements/test.txt, babel, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations
 readme-renderer==28.0     # via -r requirements/doc.in
 redis==3.5.3              # via -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.25.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
+requests==2.25.1          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.2  # via doc8
 rules==2.2                # via -r requirements/test.txt
@@ -109,9 +109,9 @@ simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-simple-history, doc8, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, edx-sphinx-theme, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sphinx==3.4.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -121,12 +121,12 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.2              # via -r requirements/test.txt, pytest
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/test.txt, botocore, requests
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2             # via -r requirements/test.txt, astroid
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.4.0          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,15 +7,15 @@
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 backoff==1.10.0           # via -r requirements/base.txt
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
-boto3==1.16.35            # via -r requirements/base.txt, django-ses
-botocore==1.19.35         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/base.txt, django-ses
+botocore==1.19.49         # via -r requirements/base.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 cffi==1.14.4              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+chardet==4.0.0            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.3.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/base.txt
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
@@ -38,7 +38,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
-gevent==20.9.0            # via -r requirements/production.in
+gevent==20.12.1           # via -r requirements/production.in
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
@@ -48,12 +48,12 @@ jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
 kombu==4.6.11             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==2.0.2        # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
@@ -62,11 +62,11 @@ pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, celery, django, django-ses
+pytz==2020.5              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
@@ -74,8 +74,8 @@ semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,20 +5,20 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/base.txt, kombu
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 backoff==1.10.0           # via -r requirements/base.txt
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
-boto3==1.16.35            # via -r requirements/base.txt, django-ses
-botocore==1.19.35         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/base.txt, django-ses
+botocore==1.19.49         # via -r requirements/base.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 cffi==1.14.4              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.3.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/base.txt
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-rbac
@@ -37,13 +37,13 @@ edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/quality.in
+edx-lint==1.6             # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
-isort==4.3.21             # via -r requirements/quality.in, pylint
+isort==5.7.0              # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
@@ -52,12 +52,12 @@ kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==2.0.2        # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
@@ -65,16 +65,16 @@ pydocstyle==5.1.1         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, celery, django, django-ses
+pytz==2020.5              # via -r requirements/base.txt, celery, django, django-ses
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
@@ -83,12 +83,13 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+toml==0.10.2              # via pylint
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.26.2           # via -r requirements/base.txt, botocore, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-wrapt==1.11.2             # via astroid
+wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,23 +5,23 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/base.txt, kombu
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 attrs==20.3.0             # via pytest
 backoff==1.10.0           # via -r requirements/base.txt
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
-boto3==1.16.35            # via -r requirements/base.txt, django-ses
-botocore==1.19.35         # via -r requirements/base.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/base.txt, django-ses
+botocore==1.19.49         # via -r requirements/base.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 cffi==1.14.4              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.3             # via -r requirements/test.in, pytest-cov
-cryptography==3.3.1       # via -r requirements/base.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/base.txt
@@ -41,17 +41,17 @@ edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
-edx-lint==1.5.2           # via -r requirements/test.in
+edx-lint==1.6             # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
-factory-boy==3.1.0        # via -r requirements/test.in
-faker==5.0.1              # via factory-boy
+factory-boy==3.2.0        # via -r requirements/test.in
+faker==5.3.0              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/base.txt, requests
 iniconfig==1.1.1          # via pytest
-isort==4.3.21             # via pylint
+isort==5.7.0              # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
@@ -60,36 +60,36 @@ kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==2.0.2        # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.8           # via pytest
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
-psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 py==1.10.0                # via pytest
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.2.0             # via pytest-cov, pytest-django
+pytest==6.2.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, celery, django, django-ses
+pytz==2020.5              # via -r requirements/base.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, code-annotations
 redis==3.5.3              # via -r requirements/base.txt
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.25.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/base.txt
 s3transfer==0.3.3         # via -r requirements/base.txt, boto3
@@ -97,14 +97,14 @@ semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-rbac, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
-toml==0.10.2              # via pytest
+toml==0.10.2              # via pylint, pytest
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.26.2           # via -r requirements/base.txt, botocore, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-wrapt==1.11.2             # via astroid
+wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,9 +6,9 @@
 #
 appdirs==1.4.4            # via virtualenv
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
-codecov==2.1.10           # via -r requirements/travis.in
-coverage==5.3             # via codecov
+chardet==4.0.0            # via requests
+codecov==2.1.11           # via -r requirements/travis.in
+coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
@@ -16,7 +16,7 @@ packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
 py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.25.0          # via codecov
+requests==2.25.1          # via codecov
 six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/travis.in

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -5,23 +5,23 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/quality.txt, -r requirements/test.txt, kombu
-astroid==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 backoff==1.10.0           # via -r requirements/quality.txt, -r requirements/test.txt
 billiard==3.6.3.0         # via -r requirements/quality.txt, -r requirements/test.txt, celery
-boto3==1.16.35            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
-botocore==1.19.35         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
+boto3==1.16.49            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses
+botocore==1.19.49         # via -r requirements/quality.txt, -r requirements/test.txt, boto3, s3transfer
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/test.txt, requests
 cffi==1.14.4              # via -r requirements/quality.txt, -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/test.txt, requests
+chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/quality.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.3.1       # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/quality.txt, -r requirements/test.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/quality.txt, -r requirements/test.txt, python3-openid, social-auth-core
 django-cors-headers==3.6.0  # via -r requirements/quality.txt, -r requirements/test.txt
@@ -43,17 +43,17 @@ edx-celeryutils==0.5.2    # via -r requirements/quality.txt, -r requirements/tes
 edx-django-utils==3.13.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==6.2.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-rbac
 edx-i18n-tools==0.5.3     # via -r requirements/validation.in
-edx-lint==1.5.2           # via -r requirements/quality.txt, -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/quality.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/quality.txt, -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt
-factory-boy==3.1.0        # via -r requirements/test.txt
-faker==5.0.1              # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.3.0              # via -r requirements/test.txt, factory-boy
 freezegun==1.0.0          # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/quality.txt, -r requirements/test.txt, django-ses, edx-celeryutils, pyjwkest
 idna==2.10                # via -r requirements/quality.txt, -r requirements/test.txt, requests
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
+isort==5.7.0              # via -r requirements/quality.txt, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, coreschema
 jmespath==0.10.0          # via -r requirements/quality.txt, -r requirements/test.txt, boto3, botocore
@@ -62,8 +62,8 @@ kombu==4.6.11             # via -r requirements/quality.txt, -r requirements/tes
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, -r requirements/test.txt, pylint
-mysqlclient==2.0.2        # via -r requirements/quality.txt, -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/quality.txt, -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, -r requirements/test.txt, django-rest-swagger
 packaging==20.8           # via -r requirements/test.txt, pytest
@@ -73,7 +73,7 @@ pathlib2==2.3.5           # via -r requirements/validation.in
 pbr==5.5.1                # via -r requirements/quality.txt, -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 polib==1.1.0              # via edx-i18n-tools
-psutil==5.7.3             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/quality.txt, -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, -r requirements/test.txt, cffi
@@ -82,22 +82,22 @@ pydocstyle==5.1.1         # via -r requirements/quality.txt
 pyjwkest==1.4.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/quality.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/quality.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.2.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, -r requirements/test.txt, botocore, edx-drf-extensions, faker, freezegun
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-pytz==2020.4              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-ses
+pytz==2020.5              # via -r requirements/quality.txt, -r requirements/test.txt, celery, django, django-ses
 pyyaml==5.3.1             # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, edx-i18n-tools
 redis==3.5.3              # via -r requirements/quality.txt, -r requirements/test.txt
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/test.txt, social-auth-core
-requests==2.25.0          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.25.1          # via -r requirements/quality.txt, -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/quality.txt, -r requirements/test.txt, edx-drf-extensions
 rules==2.2                # via -r requirements/quality.txt, -r requirements/test.txt
 s3transfer==0.3.3         # via -r requirements/quality.txt, -r requirements/test.txt, boto3
@@ -106,14 +106,14 @@ simplejson==3.17.2        # via -r requirements/quality.txt, -r requirements/tes
 six==1.15.0               # via -r requirements/quality.txt, -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-simple-history, edx-auth-backends, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-rbac, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/quality.txt, -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
-social-auth-app-django==3.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-app-django==4.0.0  # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/quality.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/quality.txt, -r requirements/test.txt, django
 stevedore==3.3.0          # via -r requirements/quality.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.2              # via -r requirements/test.txt, pytest
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/test.txt, pylint, pytest
 uritemplate==3.0.1        # via -r requirements/quality.txt, -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/test.txt, botocore, requests
 vine==1.3.0               # via -r requirements/quality.txt, -r requirements/test.txt, amqp, celery
-wrapt==1.11.2             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
+wrapt==1.12.1             # via -r requirements/quality.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/test.txt


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2186