### PR TITLE
fix: list permission for CustomerAgreement endpoint

### DIFF
--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404
 from edx_rbac.utils import get_decoded_jwt
 from rest_framework.exceptions import ParseError
 
-from license_manager.apps.subscriptions.models import CustomerAgreement, License, SubscriptionPlan
+from license_manager.apps.subscriptions.models import CustomerAgreement, License
 
 
 def get_customer_agreement_from_request_enterprise_uuid(request):
@@ -74,7 +74,7 @@ def get_context_from_subscription_plan_by_activation_key(request):
     Params:
         ``request`` - A DRF Request object.
 
-    Returns: A ``SubscriptionPlan`` object.
+    Returns: The ``enterprise_customer_uuid`` associated with the user's license.
     """
     user_license = get_object_or_404(
         License,


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Fixing forward a permissions bug on the CustomerAgreementViewSet `list` action such that admins can only see the CustomerAgreement(s) for which they have access to.

Previously, admins could retrieve the data for CustomerAgreement associated with any enterprise.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3800

## Testing considerations

* Call the CustomerAgreement `list` endpoint, requesting an enterprise customer uuid for which the user _does not_ have access (e.g., not in their JWT roles).
* Verify the requested CustomerAgreement does not come back in the response.
* Call the CustomerAgreement `list` endpoint, requesting an enterprise customer uuid for which the user _does_ have access (e.g., in their JWT roles).
* Verify the requested CustomerAgreement comes back in the response.

## Post-review

Squash commits into discrete sets of changes
