### PR TITLE
ENT-3871: expose learner licenses endpoint to support batch subscriptions

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1492,6 +1492,13 @@ class LicenseViewTestMixin:
 
 
 @ddt.ddt
+class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
+    """
+    Tests for the LearnerLicensesViewset
+    """
+
+
+@ddt.ddt
 class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
     """
     Tests for the LicenseSubsidyView.

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -383,7 +383,6 @@ def test_customer_agreement_list_superuser_200(api_client, superuser):
     _assert_customer_agreement_response_correct(response.data['results'][0], customer_agreement)
 
 
-
 @pytest.mark.django_db
 def test_customer_agreement_list_non_staff_user_200(api_client, non_staff_user, user_role, boolean_toggle):
     """

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1541,10 +1541,10 @@ class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
         },
     )
     @ddt.unpack
-    def test_endpoint_permissions_correct_customer(self, system_role, subs_role, customer_match):
+    def test_endpoint_permissions_with_customer_uuid(self, system_role, subs_role, customer_match):
         """
         Data-driven test to ensure permissions are correctly enforced when the user
-        does/doesn't have subs access to the specified customer as learner or admin.
+        does/doesn't have subs access to the specified customer as learner/admin.
         """
         customer_uuid = self.enterprise_customer_uuid if customer_match else uuid4()
         _assign_role_via_jwt_or_db(

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -52,6 +52,11 @@ class NestedSimpleRouter(NestedMixin, routers.SimpleRouter):
 
 router = routers.SimpleRouter()
 router.register(
+    prefix=r'learner-licenses',
+    viewset=views.LearnerLicensesViewSet,
+    basename='learner-licenses',
+)
+router.register(
     prefix=r'learner-subscriptions',
     viewset=views.LearnerSubscriptionViewSet,
     basename='learner-subscriptions',

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -296,7 +296,7 @@ class LearnerLicensesViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnl
         if not self.enterprise_customer_uuid:
             msg = 'missing enterprise_customer_uuid query param'
             return Response(msg, status=status.HTTP_400_BAD_REQUEST)
-        return super(LearnerLicensesViewSet).list(request)
+        return super().list(request)
 
     @property
     def base_queryset(self):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -9,7 +9,7 @@ from django.db.models import Count
 from django.utils.functional import cached_property
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rbac.decorators import permission_required
-from edx_rbac.mixins import PermissionRequiredForListingMixin, PermissionRequiredMixin
+from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1,4 +1,3 @@
-import datetime
 from math import ceil
 from operator import itemgetter
 from uuid import uuid4
@@ -291,6 +290,7 @@ class SubscriptionPlan(TimeStampedModel):
         Helper to safely return the renewal associated with the subscription, or None if one does not exist.
         """
         try:
+            # TODO: SubscriptionPlan has no 'renewal' member
             return self.renewal
         except SubscriptionPlanRenewal.DoesNotExist:
             return None

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -290,7 +290,6 @@ class SubscriptionPlan(TimeStampedModel):
         Helper to safely return the renewal associated with the subscription, or None if one does not exist.
         """
         try:
-            # TODO: SubscriptionPlan has no 'renewal' member
             return self.renewal
         except SubscriptionPlanRenewal.DoesNotExist:
             return None


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

- Added LearnerLicensesViewset to expose License data for a given user-customer pair
- Added tests for new Viewset

[Jira Ticket](https://openedx.atlassian.net/browse/ENT-3871)
[Associated Learner Portal PR](https://github.com/edx/frontend-app-learner-portal-enterprise/pull/176)

## Testing Instructions

- API endpoint uses the following devstack URL: `http://localhost:18170/api/v1/learner-licenses?enterprise_customer_uuid=<uuid>`
- Assign your enterprise learner to Licenses in multiple subscriptions for that customer
- Use Postman to make requests to this endpoint
  - Include your devstack customer UUID in the query params
  - Include the JWT for a learner (or admin) in the request header
- Verify the ordering of Licenses in the response matches that specified in the ticket
  - Order by status, then expiration date descending

## Post-review

Squash commits into discrete sets of changes
