### PR TITLE
Make sure our validate.sh script exits when any command therein fails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['py38']
-        django-version: ['django22', 'django30']
+        django-version: ['django22']
 
     steps:
     - uses: actions/checkout@v2

--- a/validate.sh
+++ b/validate.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 export DJANGO_SETTINGS_MODULE=license_manager.settings.test
 
 source /edx/app/license-manager/venvs/license-manager/bin/activate


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Without this, we can merge PRs even though tests/lint/other validation might have failed.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
