### PR TITLE
add logging when sending the activation email fails

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -32,7 +32,16 @@ def activation_task(custom_template_text, email_recipient_list, subscription_uui
     enterprise_api_client = EnterpriseApiClient()
     enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
     enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
-    send_activation_emails(custom_template_text, pending_licenses, enterprise_slug, enterprise_name)
+
+    try:
+        send_activation_emails(custom_template_text, pending_licenses, enterprise_slug, enterprise_name)
+    except Exception:  # pylint: disable=broad-except
+        msg = 'License manager activation email sending received an exception for enterprise: {}.'.format(
+            enterprise_name
+        )
+        logger.error(msg, exc_info=True)
+        return
+
     License.set_date_fields_to_now(pending_licenses, ['last_remind_date', 'assigned_date'])
 
     for email_recipient in email_recipient_list:
@@ -69,7 +78,10 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
             is_reminder=True
         )
     except Exception:  # pylint: disable=broad-except
-        logger.error('License manager activation email sending received an exception.', exc_info=True)
+        msg = 'License manager reminder email sending received an exception for enterprise: {}.'.format(
+            enterprise_name
+        )
+        logger.error(msg, exc_info=True)
         # Return without updating the last_remind_date for licenses
         return
 


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Adding a logging statement to sending the activation emails to match there being a logging statement for the reminder emails

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3965
