### PR TITLE
increase the time limit for tasks that could be used on a large dataset

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -13,8 +13,12 @@ from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 
 logger = logging.getLogger(__name__)
 
+# Soft time out of 15 minutes, max time out of 16 minutes
+SOFT_TIME_LIMIT = 900
+MAX_TIME_LIMIT = 960
 
-@shared_task(base=LoggedTask)
+
+@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def activation_task(custom_template_text, email_recipient_list, subscription_uuid):
     """
     Sends license activation email(s) asynchronously, and creates pending enterprise users to link the email recipients
@@ -51,7 +55,7 @@ def activation_task(custom_template_text, email_recipient_list, subscription_uui
         )
 
 
-@shared_task(base=LoggedTask)
+@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def send_reminder_email_task(custom_template_text, email_recipient_list, subscription_uuid):
     """
     Sends license activation reminder email(s) asynchronously.
@@ -88,7 +92,7 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
     License.set_date_fields_to_now(pending_licenses, ['last_remind_date'])
 
 
-@shared_task(base=LoggedTask)
+@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
     """
     Sends revoking the user's enterprise licensed course enrollments asynchronously
@@ -110,7 +114,7 @@ def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
         )
 
 
-@shared_task(base=LoggedTask)
+@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def license_expiration_task(license_uuids):
     """
     Sends terminating the licensed course enrollments for the submitted license_uuids asynchronously

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -49,7 +49,7 @@ MAX_NUM_LICENSES = 5000
 # Number of license uuids enrollments are expired for in each batch
 LICENSE_EXPIRATION_BATCH_SIZE = 200
 
-# SQL bulk operation constants
+# Bulk operation constants
 LICENSE_BULK_OPERATION_BATCH_SIZE = 100
 
 # Feature Toggles


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Batching up sending the emails didn't fix the time out errors happening when inviting a large number of learners to a subscription. Stackoverflow recommended increasing the time out limits for the celery tasks: https://stackoverflow.com/questions/51310414/celery-task-getting-softtimelimitexceeded-calling-api/55913669

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3965

## Testing considerations

Verified that increasing the time limits doesn't impact emails being sent/the tasks being completed

## Post-review

Squash commits into discrete sets of changes
