### PR TITLE
fix: only return active subscriptions to admins

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -175,6 +175,7 @@ class SubscriptionViewSet(LearnerSubscriptionViewSet):
         if self.requested_enterprise_uuid:
             queryset = SubscriptionPlan.objects.filter(
                 customer_agreement__enterprise_customer_uuid=self.requested_enterprise_uuid,
+                is_active=True,
             )
         return queryset.order_by('-start_date')
 

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -57,6 +57,7 @@ class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
 
     title = factory.Faker('word')
     uuid = factory.LazyFunction(uuid4)
+    is_active = True
     start_date = date.today()
     # Make the subscription expire in roughly a year and a day
     expiration_date = date.today() + timedelta(days=366)


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Similar to the `LearnerSubscriptionViewSet`, we should only be returning SubscriptionPlans that has `is_active=True`.

This is causing a bug on Subscriptions page in Admin Portal where we'll show the "Back to subscriptions" button when the Enterprise has 2 subscription plans, one of which is inactive.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
