### PR TITLE
dedupe emails being assigned licenses after lowercasing them

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -395,8 +395,8 @@ class LicenseViewSet(LearnerLicenseViewSet):
         """
         # Validate the user_emails and text sent in the data
         self._validate_data(request.data)
-        # Dedupe emails before turning back into a list for indexing
-        user_emails = list(set(request.data.get('user_emails', [])))
+        # Dedupe all lowercase emails before turning back into a list for indexing
+        user_emails = list(set([email.lower() for email in request.data.get('user_emails', [])]))
 
         subscription_plan = self._get_subscription_plan()
 
@@ -409,7 +409,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
         if already_associated_licenses:
             already_associated_emails = list(already_associated_licenses.values_list('user_email', flat=True))
             for email in already_associated_emails:
-                user_emails.remove(email)
+                user_emails.remove(email.lower())
 
         # Get the revoked licenses that are attempting to be assigned to
         revoked_licenses_for_assignment = subscription_plan.licenses.filter(


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

ENT-4015:
When assigning licenses to emails duplicate emails with different casing ("kselinka@edx.org" and "Kselinka@edx.org") were getting treated as different emails by python but as the same email by sql causing an integrity error when trying to assign a license to both.

ENT-4016:
When a license is already assigned to an email with upper case lettering it would be returned from the query as an "already assigned email" but would cause an error when trying to be removed from the list of emails to assign licenses to because the casing didn't match.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4015 and https://openedx.atlassian.net/browse/ENT-4016

## Testing considerations

- Tested that assigning licenses to "kselinka@edx.org" and "Kselinka@edx.org" no longer returns a 500 error and the result is a single license assigned to "kselinka@edx.org"
- Tested that a license with the assigned email "Kselinka@edx.org" is successfully removed from the list of emails to assign to when trying to assign a license to "kselinka@edx.org"

## Post-review

Squash commits into discrete sets of changes
