### PR TITLE
Point the gh-find-current-pr action at a version that does not filter…

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@v1.0.2
         id: findPr
         with:
           github-token: ${{ secrets.EDX_DEPLOYMENT_GH_TOKEN }}


### PR DESCRIPTION
… for only open pull requests (which changed in version 1.0.3, and the v1 tag now points at the 1.0.3 version).

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

A commit got merged into this action yesterday and it breaks our workflow: https://github.com/jwalton/gh-find-current-pr/commit/da4a054ae0ae9ea25d8228736058c36180d3461f

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
