### PR TITLE
allow editing of enterprise uuid on CustomerAgreement admin form

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -145,10 +145,10 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
 
 @admin.register(CustomerAgreement)
 class CustomerAgreementAdmin(admin.ModelAdmin):
-    read_only_fields = (
-        'enterprise_customer_uuid',
-    )
+    # TODO: remove ``enterprise_customer_uuid`` as a writeable field, as this is meant to be temporary.
+    read_only_fields = ()
     writable_fields = (
+        'enterprise_customer_uuid',
         'enterprise_customer_slug',
         'default_enterprise_catalog_uuid',
     )


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Allows editing of enterprise customer uuid field on the Django admin form for the `CustomerAgreement` model.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4164

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
