### PR TITLE
feat: updating validate_num_catalog_queries to print query-catalog ma…

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
@@ -48,8 +48,8 @@ class ValidateQueryMappingTaskTests(TestCase):
             for _ in range(num_queries_found):
                 catalog_query_ids[str(uuid.uuid4())] = [str(uuid.uuid4())]
             mock_api_client.return_value.get_distinct_catalog_queries.return_value = {
-                'count': num_queries_found,
-                'catalog_query_ids': catalog_query_ids,
+                'num_distinct_query_ids': num_queries_found,
+                'catalog_uuids_by_catalog_query_id': catalog_query_ids,
             }
             if is_valid:
                 call_command(self.command_name)

--- a/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
@@ -2,10 +2,12 @@ import uuid
 from unittest import mock
 
 import ddt
-from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
+from license_manager.apps.subscriptions.management.commands.validate_num_catalog_queries import (
+    InvalidCatalogQueryMappingError,
+)
 from license_manager.apps.subscriptions.tests.factories import (
     SubscriptionPlanFactory,
 )
@@ -42,13 +44,17 @@ class ValidateQueryMappingTaskTests(TestCase):
             log_level = 'ERROR'
             num_queries_found = num_subs - 1
         with self.assertLogs(level=log_level) as log:
-            catalog_query_ids = [str(uuid.uuid4()) for _ in range(num_queries_found)]
+            catalog_query_ids = {}
+            for _ in range(num_queries_found):
+                catalog_query_ids[str(uuid.uuid4())] = [str(uuid.uuid4())]
             mock_api_client.return_value.get_distinct_catalog_queries.return_value = {
                 'count': num_queries_found,
                 'catalog_query_ids': catalog_query_ids,
             }
-            call_command(self.command_name)
             if is_valid:
+                call_command(self.command_name)
                 assert 'SUCCESS' in log.output[0]
             else:
+                with self.assertRaises(InvalidCatalogQueryMappingError):
+                    call_command(self.command_name)
                 assert 'ERROR' in log.output[0]


### PR DESCRIPTION
…pping upon failure, raise exception upon failure

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

[ENT-4039](https://openedx.atlassian.net/browse/ENT-4039)

* Updates validate_catalog_query_mapping management command to handle the new response from the distinct-catalog-queries endpoint in enterprise-catalog
* Prints the CatalogQuery to CustomerCatalog mapping upon failure
* Raises an exception upon failure

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
