### PR TITLE
Added bulk validation and enrollment endpoint for enterprise learners

### DIFF
--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -90,6 +90,11 @@ subscription_router.register(
 
 urlpatterns = [
     url(
+        r'bulk-enrollment',
+        views.EnterpriseEnrollmentWithLicenseSubsidyView.as_view(),
+        name='bulk-license-enrollment',
+    ),
+    url(
         r'license-subsidy',
         views.LicenseSubsidyView.as_view(),
         name='license-subsidy',

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -147,3 +147,10 @@ class EnterpriseApiClient(BaseOAuthClient):
                 )
             )
             logger.error(msg)
+
+    def bulk_enroll_enterprise_learners(self, enterprise_id, options):
+        """
+        Calls the Enterprise Bulk Enrollment API to enroll learners in courses.
+        """
+        enrollment_url = '{}{}/enroll_learners_in_courses/'.format(self.enterprise_customer_endpoint, enterprise_id)
+        return self.client.post(enrollment_url, options)

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -64,7 +64,8 @@ class CustomerAgreement(TimeStampedModel):
         blank=True,
         null=True,
         help_text=_(
-            "The default enterprise catalog UUID must be from a catalog associated with the above Enterprise Customer UUID."
+            "The default enterprise catalog UUID must be from a catalog associated with the above Enterprise Customer "
+            "UUID."
         )
     )
 


### PR DESCRIPTION
This PR is dependent on https://openedx.atlassian.net/browse/ENT-4100- new enterprise bulk enrollment endpoint and updated frontend admin portal.

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
