### PR TITLE
update text on the activation email to remove the bookmark link to re…

### DIFF
--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -86,7 +86,6 @@ def _send_email_with_activation(email_activation_key_map, context, enterprise_sl
     for email_address in email_recipient_list:
         # Construct user specific context for each message
         context.update({
-            'LEARNER_PORTAL_LINK': _learner_portal_link(enterprise_slug),
             'LICENSE_ACTIVATION_LINK': _generate_license_activation_link(
                 enterprise_slug,
                 email_activation_key_map.get(email_address)

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -18,30 +18,6 @@ class EmailTests(TestCase):
         self.email_recipient_list = test_email_data['email_recipient_list']
         self.enterprise_name = 'Mock Enterprise'
 
-    def _assert_bookmark_content_is_present(self, message):
-        """
-        Helper that asserts bookmark/learner-portal home content is present in the email email content.
-        """
-        # Verify that the message about bookmarking the learner portal home is in the message body text
-        expected_learner_portal_link = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + self.enterprise_slug
-        expected_bookmark_message = (
-            "So you don't have to search for this link, bookmark your learning portal now to have easy access to your"
-            " subscription in the future: "
-        )
-        self.assertIn(expected_bookmark_message + expected_learner_portal_link, message.body)
-
-        # ...and the HTML
-        actual_html = message.alternatives[0][0]
-        expected_learner_portal_anchor = '<a href="{}/mock-enterprise"'.format(
-            settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
-        )
-        expected_bookmark_paragraph = (
-            "So you don't have to search for this link, bookmark your learning portal now to have easy access to your"
-            " subscription in the future: "
-        )
-        self.assertIn(expected_learner_portal_anchor, actual_html)
-        self.assertIn(expected_bookmark_paragraph, actual_html)
-
     def test_send_activation_emails(self):
         """
         Tests that activation emails are correctly sent.
@@ -60,7 +36,6 @@ class EmailTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(message.subject, constants.LICENSE_ACTIVATION_EMAIL_SUBJECT)
         self.assertTrue('Activate' in message.body)
-        self._assert_bookmark_content_is_present(message)
 
     def test_send_reminder_email(self):
         """
@@ -79,4 +54,3 @@ class EmailTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(message.subject, constants.LICENSE_REMINDER_EMAIL_SUBJECT)
         self.assertFalse('Activate' in message.body)
-        self._assert_bookmark_content_is_present(message)

--- a/license_manager/templates/email/activation.html
+++ b/license_manager/templates/email/activation.html
@@ -31,21 +31,13 @@
         </a>
     </p>
     <p>
-        {% trans "So you don't have to search for this link, bookmark your learning portal now to have easy access to your subscription in the future: " %}
+        <b>{% trans "About edX" %}</b>
     </p>
     <p>
-        <a href="{{ LEARNER_PORTAL_LINK }}"
-        style="
-            color: #0d7d4d;
-            text-decoration: none;
-            border-radius: 4px;
-            background-color: #ffffff;
-            border: 3px solid #0d7d4d;
-            display: inline-block;
-            padding: 12px 50px;
-        ">
-            <font color="#0d7d4d"><b>{% trans "My Learning Portal" %}</b></font>
-        </a>
+        {% trans "Since 2012, edX has been committed to increasing access to high-quality education for everyone, everywhere. By harnessing the transformative power of education through online learning, edX empowers learners to unlock their potential and become changemakers." %}
+    </p>
+    <p>
+        {% trans "We are excited to welcome you to our growing community of over 35 million users and 15 thousand instructors from 160 partner universities and organizations." %}
     </p>
     <p>
         {% filter force_escape %}

--- a/license_manager/templates/email/activation.txt
+++ b/license_manager/templates/email/activation.txt
@@ -10,8 +10,10 @@
 
 {% trans "Activate Your License " %}{{ LICENSE_ACTIVATION_LINK }}
 
-{% trans "So you don't have to search for this link, bookmark your learning portal now to have easy access to your subscription in the future: " %}{{ LEARNER_PORTAL_LINK }}
+{% trans "About edX" %}
 
-{% trans "My Learning Portal" %}
+{% trans "Since 2012, edX has been committed to increasing access to high-quality education for everyone, everywhere. By harnessing the transformative power of education through online learning, edX empowers learners to unlock their potential and become changemakers." %}
+
+{% trans "We are excited to welcome you to our growing community of over 35 million users and 15 thousand instructors from 160 partner universities and organizations." %}
 
 {{ TEMPLATE_CLOSING }}


### PR DESCRIPTION
…duce confusion

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Updated the text on the activation email to match the new design

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4076

## Testing considerations

- Verified that sent email contains the updated text and looks correct

![Screen Shot 2021-03-01 at 11 47 16 AM](https://user-images.githubusercontent.com/17459564/109534195-1072cf80-7a89-11eb-8cd3-8f5814454af2.png)

