### PR TITLE
ENT-4058: Sender Alias on Django Customer Profile updates alias for license emails

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -36,9 +36,14 @@ def activation_email_task(custom_template_text, email_recipient_list, subscripti
     enterprise_api_client = EnterpriseApiClient()
     enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
     enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
+    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
+        subscription_plan.enterprise_customer_uuid
+    )
 
     try:
-        send_activation_emails(custom_template_text, pending_licenses, enterprise_slug, enterprise_name)
+        send_activation_emails(
+            custom_template_text, pending_licenses, enterprise_slug, enterprise_name, enterprise_sender_alias
+        )
     except Exception:  # pylint: disable=broad-except
         msg = 'License manager activation email sending received an exception for enterprise: {}.'.format(
             enterprise_name
@@ -81,6 +86,9 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
     enterprise_api_client = EnterpriseApiClient()
     enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
     enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
+    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
+        subscription_plan.enterprise_customer_uuid
+    )
 
     try:
         send_activation_emails(
@@ -88,6 +96,7 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
             pending_licenses,
             enterprise_slug,
             enterprise_name,
+            enterprise_sender_alias,
             is_reminder=True
         )
     except Exception:  # pylint: disable=broad-except
@@ -154,11 +163,15 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     enterprise_api_client = EnterpriseApiClient()
     enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
+    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
+        subscription_plan.enterprise_customer_uuid
+    )
 
     try:
         send_revocation_cap_notification_email(
             subscription_plan,
             enterprise_name,
+            enterprise_sender_alias,
         )
     except Exception:  # pylint: disable=broad-except
         logger.error('Revocation cap notification email sending received an exception.', exc_info=True)

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -24,6 +24,7 @@ class LicenseManagerCeleryTaskTests(TestCase):
         self.assigned_licenses = self.subscription_plan.licenses.filter(status=constants.ASSIGNED).order_by('uuid')
         self.enterprise_slug = 'mock-enterprise'
         self.enterprise_name = 'Mock Enterprise'
+        self.enterprise_sender_alias = 'Mock Enterprise Alias'
 
     @mock.patch('license_manager.apps.api.tasks.EnterpriseApiClient', return_value=mock.MagicMock())
     @mock.patch('license_manager.apps.api.tasks.send_activation_emails')
@@ -33,6 +34,8 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
         mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
+        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+
         tasks.activation_email_task(
             self.custom_template_text,
             self.email_recipient_list,
@@ -54,6 +57,8 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
         mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
+        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+
         with mock_send_emails:
             tasks.activation_email_task(
                 self.custom_template_text,
@@ -71,6 +76,7 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
         mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
+        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
         tasks.send_reminder_email_task(
             self.custom_template_text,
             self.email_recipient_list,
@@ -93,6 +99,7 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
         mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
+        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
         with mock_send_emails:
             tasks.send_reminder_email_task(
                 self.custom_template_text,
@@ -111,9 +118,11 @@ class LicenseManagerCeleryTaskTests(TestCase):
             actual_licenses,
             actual_enterprise_slug,
             actual_enterprise_name,
+            actual_enterprise_sender_alias,
         ) = send_email_args[:5]
 
         assert list(self.assigned_licenses) == list(actual_licenses)
         assert self.custom_template_text == actual_template_text
         assert self.enterprise_slug == actual_enterprise_slug
         assert self.enterprise_name == actual_enterprise_name
+        assert self.enterprise_sender_alias == actual_enterprise_sender_alias

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 import backoff
 from django.conf import settings
@@ -47,6 +48,21 @@ class EnterpriseApiClient(BaseOAuthClient):
         endpoint = self.enterprise_customer_endpoint + str(enterprise_customer_uuid) + '/'
         response = self.client.get(endpoint).json()
         return response.get('name', None)
+
+    def get_enterprise_sender_alias(self, enterprise_customer_uuid):
+        """
+        Gets the sender alias for the enterprise associated with a customer.
+
+        Arguments:
+            enterprise_customer_uuid (UUID): UUID of the enterprise customer associated with an enterprise
+
+        Returns:
+            string: The sender alias for the enterprise, if sender alias for the enterprise is None or not present
+                then the default alias `edX Support Team` is returned.
+        """
+        endpoint = urljoin(self.enterprise_customer_endpoint, str(enterprise_customer_uuid)) + '/'
+        response = self.client.get(endpoint).json()
+        return response.get('sender_alias', None) or 'edX Support Team'
 
     @backoff.on_predicate(
         # Use an exponential backoff algorithm

--- a/license_manager/apps/subscriptions/tests/test_emails.py
+++ b/license_manager/apps/subscriptions/tests/test_emails.py
@@ -17,6 +17,7 @@ class EmailTests(TestCase):
         self.enterprise_slug = 'mock-enterprise'
         self.email_recipient_list = test_email_data['email_recipient_list']
         self.enterprise_name = 'Mock Enterprise'
+        self.enterprise_sender_alias = 'Mock Enterprise Alias'
 
     def test_send_activation_emails(self):
         """
@@ -27,6 +28,7 @@ class EmailTests(TestCase):
             [license for license in self.licenses if license.status == constants.ASSIGNED],
             self.enterprise_slug,
             self.enterprise_name,
+            self.enterprise_sender_alias,
         )
         self.assertEqual(
             len(mail.outbox),
@@ -47,6 +49,7 @@ class EmailTests(TestCase):
             [lic],
             self.enterprise_slug,
             self.enterprise_name,
+            self.enterprise_sender_alias,
             is_reminder=True,
         )
         self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

"Sender Alias" set in enterprise customer model in the enterprise app updates alias value in license email communications as well.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4058

## Testing Instructions:
1. Update the `sender_alias` field of any enterprise customer using enterprise Django admin
2. Use the above enterprise customer to assign licenses to some user
3. verify that the email sent to the user has the sender alias set above as the `from` address.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backward-compatible

## Post-review

Squash commits into discrete sets of changes
