### PR TITLE
feat: adds endpoint to return csv license data for given subscription plan

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -601,7 +601,7 @@ class LicenseViewSet(LearnerLicenseViewSet):
         Only includes licenses with a status of ACTIVATED, ASSIGNED, or REVOKED.
         """
         subscription = self._get_subscription_plan()
-        enterprise_slug = EnterpriseApiClient().get_enterprise_slug(subscription.enterprise_customer_uuid)
+        enterprise_slug = subscription.customer_agreement.enterprise_customer_slug
         licenses = subscription.licenses.filter(
             status__in=[constants.ACTIVATED, constants.ASSIGNED, constants.REVOKED],
         ).values('status', 'user_email', 'activation_date', 'last_remind_date', 'activation_key')

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -21,6 +21,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_csv.renderers import CSVRenderer
 from simplejson.errors import JSONDecodeError
 
 from license_manager.apps.api import serializers, utils
@@ -41,7 +42,11 @@ from license_manager.apps.subscriptions.models import (
     SubscriptionPlan,
     SubscriptionsRoleAssignment,
 )
-from license_manager.apps.subscriptions.utils import chunks, localized_utcnow
+from license_manager.apps.subscriptions.utils import (
+    chunks,
+    get_license_activation_link,
+    localized_utcnow,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -587,6 +592,25 @@ class LicenseViewSet(LearnerLicenseViewSet):
         queryset_values = queryset.values('status').annotate(count=Count('status')).order_by('-count')
         license_overview = list(queryset_values)
         return Response(license_overview, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['get'])
+    def csv(self, request, subscription_uuid):
+        """
+        Returns license data for a given subscription in CSV format.
+
+        Only includes licenses with a status of ACTIVATED, ASSIGNED, or REVOKED.
+        """
+        subscription = self._get_subscription_plan()
+        enterprise_slug = EnterpriseApiClient().get_enterprise_slug(subscription.enterprise_customer_uuid)
+        licenses = subscription.licenses.filter(
+            status__in=[constants.ACTIVATED, constants.ASSIGNED, constants.REVOKED],
+        ).values('status', 'user_email', 'activation_date', 'last_remind_date', 'activation_key')
+        for lic in licenses:
+            # We want to expose the full activation link rather than just the activation key
+            lic['activation_link'] = get_license_activation_link(enterprise_slug, str(lic['activation_key']))
+            lic.pop('activation_key', None)
+        csv_data = CSVRenderer().render(list(licenses))
+        return Response(csv_data, status=status.HTTP_200_OK, content_type='text/csv')
 
 
 class LicenseBaseView(APIView):

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -11,7 +11,10 @@ from license_manager.apps.subscriptions.constants import (
     REVOCATION_CAP_NOTIFICATION_EMAIL_SUBJECT,
     REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE,
 )
-from license_manager.apps.subscriptions.utils import chunks
+from license_manager.apps.subscriptions.utils import (
+    chunks,
+    get_license_activation_link,
+)
 
 
 def send_revocation_cap_notification_email(subscription_plan, enterprise_name, enterprise_sender_alias):
@@ -90,7 +93,7 @@ def _send_email_with_activation(email_activation_key_map, context, enterprise_sl
     for email_address in email_recipient_list:
         # Construct user specific context for each message
         context.update({
-            'LICENSE_ACTIVATION_LINK': _generate_license_activation_link(
+            'LICENSE_ACTIVATION_LINK': get_license_activation_link(
                 enterprise_slug,
                 email_activation_key_map.get(email_address)
             ),
@@ -106,26 +109,6 @@ def _send_email_with_activation(email_activation_key_map, context, enterprise_sl
         # Renew the email connection for each chunk of emails sent
         with mail.get_connection() as connection:
             connection.send_messages(email_chunk)
-
-
-def _generate_license_activation_link(enterprise_slug, activation_key):
-    """
-    Returns the activation link displayed in the activation email sent to a learner
-    """
-    return '/'.join((
-        _learner_portal_link(enterprise_slug),
-        'licenses',
-        activation_key,
-        'activate'
-    ))
-
-
-def _learner_portal_link(enterprise_slug):
-    """
-    Returns the link to the learner portal, given an enterprise slug.
-    Does not contain a trailing slash.
-    """
-    return settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_slug
 
 
 def _get_rendered_template_content(template_name, extension, context):

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -31,7 +31,7 @@ def get_learner_portal_url(enterprise_slug):
     Returns the link to the learner portal, given an enterprise slug.
     Does not contain a trailing slash.
     """
-    return settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_slug
+    return '{}/{}'.format(settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL, enterprise_slug)
 
 
 def get_license_activation_link(enterprise_slug, activation_key):

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -1,6 +1,7 @@
 """ Utility functions for the subscriptions app. """
 from datetime import date, datetime
 
+from django.conf import settings
 from pytz import UTC
 
 
@@ -23,3 +24,23 @@ def chunks(list, chunk_size):
     """
     for i in range(0, len(list), chunk_size):
         yield list[i:i + chunk_size]
+
+
+def get_learner_portal_url(enterprise_slug):
+    """
+    Returns the link to the learner portal, given an enterprise slug.
+    Does not contain a trailing slash.
+    """
+    return settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_slug
+
+
+def get_license_activation_link(enterprise_slug, activation_key):
+    """
+    Returns the activation link displayed in the activation email sent to a learner
+    """
+    return '/'.join((
+        get_learner_portal_url(enterprise_slug),
+        'licenses',
+        activation_key,
+        'activate'
+    ))

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,6 +15,7 @@ rules
 django-simple-history
 django-waffle
 djangorestframework
+djangorestframework-csv
 drf-nested-routers
 edx-auth-backends
 edx-celeryutils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -86,10 +86,13 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/base.in
 djangorestframework==3.12.2
     # via
     #   -r requirements/base.in
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -205,6 +208,7 @@ simplejson==3.17.2
 six==1.15.0
     # via
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rbac
@@ -228,6 +232,8 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
+unicodecsv==0.14.1
+    # via djangorestframework-csv
 uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.4

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,7 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
- 
+
 
 edx-rest-api-client==1.9.2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -151,10 +151,13 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/validation.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -447,6 +450,7 @@ six==1.15.0
     #   -r requirements/validation.txt
     #   django-dynamic-fixture
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-i18n-tools
@@ -499,6 +503,10 @@ toml==0.10.2
     #   pep517
     #   pylint
     #   pytest
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/validation.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -145,10 +145,13 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/test.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -426,6 +429,7 @@ six==1.15.0
     #   bleach
     #   django-dynamic-fixture
     #   django-simple-history
+    #   djangorestframework-csv
     #   doc8
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -491,6 +495,10 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/test.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -105,10 +105,13 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/base.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -287,6 +290,7 @@ six==1.15.0
     # via
     #   -r requirements/base.txt
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rbac
@@ -319,6 +323,10 @@ stevedore==3.3.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -120,10 +120,13 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/base.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -325,6 +328,7 @@ six==1.15.0
     # via
     #   -r requirements/base.txt
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-lint
@@ -364,6 +368,10 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pylint
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -131,10 +131,13 @@ django-waffle==2.1.0
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via -r requirements/base.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -357,6 +360,7 @@ six==1.15.0
     #   -r requirements/base.txt
     #   django-dynamic-fixture
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-lint
@@ -398,6 +402,10 @@ toml==0.10.2
     # via
     #   pylint
     #   pytest
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/base.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -173,11 +173,16 @@ django==2.2.19
     #   edx-rbac
     #   jsonfield2
     #   rest-condition
+djangorestframework-csv==2.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 djangorestframework==3.12.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
+    #   djangorestframework-csv
     #   drf-jwt
     #   drf-nested-routers
     #   edx-drf-extensions
@@ -501,6 +506,7 @@ six==1.15.0
     #   -r requirements/test.txt
     #   django-dynamic-fixture
     #   django-simple-history
+    #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-i18n-tools
@@ -557,6 +563,11 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
+unicodecsv==0.14.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   djangorestframework-csv
 uritemplate==3.0.1
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

* adds endpoint to return csv license data for given subscription plan

## Ticket

[ENT-3986](https://openedx.atlassian.net/browse/ENT-3986)

## Testing instructions

* Checkout branch, run `make requirements` in the app-shell to install `djangorestframework-csv`
* Using Postman, make a GET request to `http://localhost:18170/api/v1/subscriptions/<uuid>/licenses/csv/`
* Observe the CSV data returned in the response and verify it matches the expected data from devstack

## Post-review

Squash commits into discrete sets of changes
