### PR TITLE
feat: Add a new staff-only endpoint to help lookup license data by email

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -82,6 +82,34 @@ class LicenseSerializer(serializers.ModelSerializer):
             fields.append('activation_key')
 
 
+class StaffLicenseSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ``License`` model that is usable by views
+    that are restricted to staff/admin users.
+    """
+    subscription_plan_title = serializers.SerializerMethodField()
+    subscription_plan_expiration_date = serializers.SerializerMethodField()
+
+    class Meta:
+        model = License
+        fields = [
+            'status',
+            'assigned_date',
+            'activation_date',
+            'revoked_date',
+            'last_remind_date',
+            'subscription_plan_title',
+            'subscription_plan_expiration_date',
+            'activation_link',
+        ]
+
+    def get_subscription_plan_title(self, obj):
+        return obj.subscription_plan.title
+
+    def get_subscription_plan_expiration_date(self, obj):
+        return obj.subscription_plan.expiration_date
+
+
 class SingleEmailSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
     Serializer for specifying a single email

--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -40,10 +40,10 @@ def get_activation_key_from_request(request):
     """
     try:
         return uuid.UUID(request.query_params['activation_key'])
-    except KeyError:
-        raise ParseError('activation_key is a required parameter')
-    except ValueError:
-        raise ParseError('{} is not a valid activation key.'.format(request.query_params['activation_key']))
+    except KeyError as exc:
+        raise ParseError('activation_key is a required parameter') from exc
+    except ValueError as exc:
+        raise ParseError('{} is not a valid activation key.'.format(request.query_params['activation_key'])) from exc
 
 
 def get_key_from_jwt(decoded_jwt, key):

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -108,6 +108,11 @@ urlpatterns = [
         r'retire_user',
         views.UserRetirementView.as_view(),
         name='user-retirement',
-    )
+    ),
+    url(
+        r'staff_lookup_licenses',
+        views.StaffLicenseLookupView.as_view(),
+        name='staff-lookup-licenses',
+    ),
 ]
 urlpatterns += router.urls + subscription_router.urls

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -18,12 +18,12 @@ def days_until(end_date):
     return diff.days
 
 
-def chunks(list, chunk_size):
+def chunks(a_list, chunk_size):
     """
     Helper to break a list up into chunks. Returns a list of lists
     """
-    for i in range(0, len(list), chunk_size):
-        yield list[i:i + chunk_size]
+    for i in range(0, len(a_list), chunk_size):
+        yield a_list[i:i + chunk_size]
 
 
 def get_learner_portal_url(enterprise_slug):
@@ -41,6 +41,6 @@ def get_license_activation_link(enterprise_slug, activation_key):
     return '/'.join((
         get_learner_portal_url(enterprise_slug),
         'licenses',
-        activation_key,
+        str(activation_key),
         'activate'
     ))

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -5,4 +5,16 @@ ignore+= ,migrations, settings, wsgi.py
 const-rgx = (([A-Z_][A-Z0-9_]*)|(__.*__)|log|urlpatterns|logger|User)$
 
 [MESSAGES CONTROL]
-DISABLE+= ,invalid-name,missing-docstring,
+disable+ =
+    # Disable unicode-format-string until we can agree to turn it on.
+    native-string,
+    # Disable new refactoring suggestions for now, we have more important things to fix first
+    import-outside-toplevel,
+    inconsistent-return-statements,
+    no-else-break,
+    no-else-continue,
+    useless-object-inheritance,
+    useless-suppression,
+    cyclic-import,
+    logging-format-interpolation,
+    invalid-name,


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Does what the title says.

https://openedx.atlassian.net/browse/ENT-4304

## Testing considerations
* The requesting user needs to have `is_staff=True`.
```
curl --location --request POST 'http://localhost:18170/api/v1/staff_lookup_licenses' \
--header 'Authorization: JWT <your JWT>' \
--header 'Content-Type: application/json' \
--data-raw '{"user_email": "edx@example.com"}'
```
## Post-review

Squash commits into discrete sets of changes
