### PR TITLE
feat: allow the editing of CustomerAgreement.enterprise_customer_slug from Admin site

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -147,10 +147,10 @@ class SubscriptionPlanAdmin(admin.ModelAdmin):
 class CustomerAgreementAdmin(admin.ModelAdmin):
     read_only_fields = (
         'enterprise_customer_uuid',
-        'enterprise_customer_slug',
     )
     writable_fields = (
         'default_enterprise_catalog_uuid',
+        'enterprise_customer_slug',
     )
     fields = read_only_fields + writable_fields
     list_display = (


### PR DESCRIPTION
## Description

Does what the title says.  Allows us to match changes made to the slug in `edx-enterprise`.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
