### PR TITLE
refactor: uses single API call to fetch email data from edx-enterprise

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -34,11 +34,10 @@ def activation_email_task(custom_template_text, email_recipient_list, subscripti
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
-    enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
-    enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
-    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
-        subscription_plan.enterprise_customer_uuid
-    )
+    enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
+    enterprise_slug = enterprise_customer.get('slug', None)
+    enterprise_name = enterprise_customer.get('name', None)
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
 
     try:
         send_activation_emails(
@@ -84,11 +83,10 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
-    enterprise_slug = enterprise_api_client.get_enterprise_slug(subscription_plan.enterprise_customer_uuid)
-    enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
-    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
-        subscription_plan.enterprise_customer_uuid
-    )
+    enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
+    enterprise_slug = enterprise_customer.get('slug', None)
+    enterprise_name = enterprise_customer.get('name', None)
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
 
     try:
         send_activation_emails(
@@ -162,10 +160,9 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     """
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     enterprise_api_client = EnterpriseApiClient()
-    enterprise_name = enterprise_api_client.get_enterprise_name(subscription_plan.enterprise_customer_uuid)
-    enterprise_sender_alias = enterprise_api_client.get_enterprise_sender_alias(
-        subscription_plan.enterprise_customer_uuid
-    )
+    enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
+    enterprise_name = enterprise_customer.get('name', None)
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
 
     try:
         send_revocation_cap_notification_email(

--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -35,9 +35,9 @@ def activation_email_task(custom_template_text, email_recipient_list, subscripti
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
-    enterprise_slug = enterprise_customer.get('slug', None)
-    enterprise_name = enterprise_customer.get('name', None)
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
+    enterprise_slug = enterprise_customer.get('slug')
+    enterprise_name = enterprise_customer.get('name')
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
 
     try:
         send_activation_emails(
@@ -84,9 +84,9 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
-    enterprise_slug = enterprise_customer.get('slug', None)
-    enterprise_name = enterprise_customer.get('name', None)
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
+    enterprise_slug = enterprise_customer.get('slug')
+    enterprise_name = enterprise_customer.get('name')
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
 
     try:
         send_activation_emails(
@@ -161,8 +161,8 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
-    enterprise_name = enterprise_customer.get('name', None)
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', None) or 'edX Support Team'
+    enterprise_name = enterprise_customer.get('name')
+    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
 
     try:
         send_revocation_cap_notification_email(

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -32,9 +32,11 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         Assert activation_task is called with the correct arguments
         """
-        mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
-        mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
-        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+        mock_enterprise_client().get_enterprise_customer_data.return_value = {
+            'slug': self.enterprise_slug,
+            'name': self.enterprise_name,
+            'sender_alias': self.enterprise_sender_alias,
+        }
 
         tasks.activation_email_task(
             self.custom_template_text,
@@ -44,7 +46,7 @@ class LicenseManagerCeleryTaskTests(TestCase):
 
         send_email_args, _ = mock_send_emails.call_args
         self._verify_mock_send_email_arguments(send_email_args)
-        mock_enterprise_client().get_enterprise_slug.assert_called_with(
+        mock_enterprise_client().get_enterprise_customer_data.assert_called_with(
             self.subscription_plan.enterprise_customer_uuid
         )
 
@@ -55,9 +57,11 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         Tests that when sending the activate email fails, an error gets logged
         """
-        mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
-        mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
-        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+        mock_enterprise_client().get_enterprise_customer_data.return_value = {
+            'slug': self.enterprise_slug,
+            'name': self.enterprise_name,
+            'sender_alias': self.enterprise_sender_alias,
+        }
 
         with mock_send_emails:
             tasks.activation_email_task(
@@ -74,9 +78,11 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         Assert send_reminder_email_task is called with the correct arguments
         """
-        mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
-        mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
-        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+        mock_enterprise_client().get_enterprise_customer_data.return_value = {
+            'slug': self.enterprise_slug,
+            'name': self.enterprise_name,
+            'sender_alias': self.enterprise_sender_alias,
+        }
         tasks.send_reminder_email_task(
             self.custom_template_text,
             self.email_recipient_list,
@@ -85,7 +91,7 @@ class LicenseManagerCeleryTaskTests(TestCase):
 
         send_email_args, _ = mock_send_emails.call_args
         self._verify_mock_send_email_arguments(send_email_args)
-        mock_enterprise_client().get_enterprise_slug.assert_called_with(
+        mock_enterprise_client().get_enterprise_customer_data.assert_called_with(
             self.subscription_plan.enterprise_customer_uuid
         )
         # Verify the 'last_remind_date' of all licenses have been updated
@@ -97,9 +103,11 @@ class LicenseManagerCeleryTaskTests(TestCase):
         """
         Tests that when sending the remind email fails, last_remind_date is not updated
         """
-        mock_enterprise_client().get_enterprise_slug.return_value = self.enterprise_slug
-        mock_enterprise_client().get_enterprise_name.return_value = self.enterprise_name
-        mock_enterprise_client().get_enterprise_sender_alias.return_value = self.enterprise_sender_alias
+        mock_enterprise_client().get_enterprise_customer_data.return_value = {
+            'slug': self.enterprise_slug,
+            'name': self.enterprise_name,
+            'sender_alias': self.enterprise_sender_alias,
+        }
         with mock_send_emails:
             tasks.send_reminder_email_task(
                 self.custom_template_text,

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -21,48 +21,17 @@ class EnterpriseApiClient(BaseOAuthClient):
     bulk_licensed_enrollments_expiration_endpoint = api_base_url \
         + 'licensed-enterprise-course-enrollment/bulk_licensed_enrollments_expiration/'
 
-    def get_enterprise_slug(self, enterprise_customer_uuid):
+    def get_enterprise_customer_data(self, enterprise_customer_uuid):
         """
-        Gets the enterprise slug for the enterprise associated with a customer.
+        Gets the data for an EnterpriseCustomer with a given UUID.
 
         Arguments:
             enterprise_customer_uuid (UUID): UUID of the enterprise customer associated with an enterprise
-
         Returns:
-            string: The enterprise_slug for the enterprise
+            response (dict): JSON response data
         """
-        endpoint = self.enterprise_customer_endpoint + str(enterprise_customer_uuid) + '/'
-        response = self.client.get(endpoint).json()
-        return response.get('slug', None)
-
-    def get_enterprise_name(self, enterprise_customer_uuid):
-        """
-        Gets the enterprise name for the enterprise associated with a customer.
-
-        Arguments:
-            enterprise_customer_uuid (UUID): UUID of the enterprise customer associated with an enterprise
-
-        Returns:
-            string: The enterprise_name for the enterprise
-        """
-        endpoint = self.enterprise_customer_endpoint + str(enterprise_customer_uuid) + '/'
-        response = self.client.get(endpoint).json()
-        return response.get('name', None)
-
-    def get_enterprise_sender_alias(self, enterprise_customer_uuid):
-        """
-        Gets the sender alias for the enterprise associated with a customer.
-
-        Arguments:
-            enterprise_customer_uuid (UUID): UUID of the enterprise customer associated with an enterprise
-
-        Returns:
-            string: The sender alias for the enterprise, if sender alias for the enterprise is None or not present
-                then the default alias `edX Support Team` is returned.
-        """
-        endpoint = urljoin(self.enterprise_customer_endpoint, str(enterprise_customer_uuid)) + '/'
-        response = self.client.get(endpoint).json()
-        return response.get('sender_alias', None) or 'edX Support Team'
+        endpoint = '{}{}/'.format(self.enterprise_customer_endpoint, str(enterprise_customer_uuid))
+        return self.client.get(endpoint).json()
 
     @backoff.on_predicate(
         # Use an exponential backoff algorithm

--- a/license_manager/apps/subscriptions/migrations/0015_create_customer_agreements.py
+++ b/license_manager/apps/subscriptions/migrations/0015_create_customer_agreements.py
@@ -13,7 +13,7 @@ def create_relationships(apps, schema_editor):
     subscriptions_with_customers = SubscriptionPlan.objects.exclude(enterprise_customer_uuid=None)
     for plan in subscriptions_with_customers:
         customer_uuid = plan.enterprise_customer_uuid
-        enterprise_slug = EnterpriseApiClient().get_enterprise_slug(customer_uuid)
+        enterprise_slug = EnterpriseApiClient().get_enterprise_customer_data(customer_uuid).get('slug', None)
         customer_agreement, _ = CustomerAgreement.objects.get_or_create(
             enterprise_customer_uuid=customer_uuid,
             defaults={

--- a/license_manager/apps/subscriptions/migrations/0015_create_customer_agreements.py
+++ b/license_manager/apps/subscriptions/migrations/0015_create_customer_agreements.py
@@ -13,7 +13,7 @@ def create_relationships(apps, schema_editor):
     subscriptions_with_customers = SubscriptionPlan.objects.exclude(enterprise_customer_uuid=None)
     for plan in subscriptions_with_customers:
         customer_uuid = plan.enterprise_customer_uuid
-        enterprise_slug = EnterpriseApiClient().get_enterprise_customer_data(customer_uuid).get('slug', None)
+        enterprise_slug = EnterpriseApiClient().get_enterprise_customer_data(customer_uuid).get('slug')
         customer_agreement, _ = CustomerAgreement.objects.get_or_create(
             enterprise_customer_uuid=customer_uuid,
             defaults={


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

While working on ENT-4128 I realized that we currently make 3 API requests to fetch enterprise customer data from edx-enterprise for a given activation or reminder email when only 1 is needed. This PR refactors EnterpriseApiClient to only have one method which calls the EnterpriseCustomer endpoint in edx-enterprise and updates all usage accordingly.

* removes enterprise api client methods which return single field from enterprise customer API call
* adds enterprise api client method to simply return all JSON from enterprise customer API response
* updates tests to mock new enterprise api client method
* updates migration to use new enterprise api client method

## Ticket link: 
N/A

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
