### PR TITLE
feat: add support-tool to CORS for devstack

### DIFF
--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -58,6 +58,7 @@ CELERY_TASK_ALWAYS_EAGER = (
 CORS_ORIGIN_WHITELIST = [
     'http://localhost:1991',  # frontend-admin-portal
     'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:18450',  # frontend-app-support-tools
 ]
 # END CORS
 


### PR DESCRIPTION
## Description

Allow `edx/frontend-app-support-tools` in CORS Origin Whitelist

Link to the associated ticket: https://openedx.atlassian.net/browse/PROD-2257

## Note
Ideally it should be added to stage and production environments as well 