### PR TITLE
fix: ensure we are correctly defaulting sender alias if not set

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -14,7 +14,10 @@ from license_manager.apps.subscriptions.emails import (
     send_revocation_cap_notification_email,
 )
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
-from license_manager.apps.subscriptions.utils import chunks
+from license_manager.apps.subscriptions.utils import (
+    chunks,
+    get_enterprise_sender_alias,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +46,7 @@ def activation_email_task(custom_template_text, email_recipient_list, subscripti
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
     enterprise_slug = enterprise_customer.get('slug')
     enterprise_name = enterprise_customer.get('name')
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
+    enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
 
     try:
         send_activation_emails(
@@ -93,7 +96,7 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
     enterprise_slug = enterprise_customer.get('slug')
     enterprise_name = enterprise_customer.get('name')
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
+    enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
 
     try:
         send_activation_emails(
@@ -180,7 +183,7 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
     enterprise_name = enterprise_customer.get('name')
-    enterprise_sender_alias = enterprise_customer.get('sender_alias', 'edX Support Team')
+    enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
 
     try:
         send_revocation_cap_notification_email(

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -60,3 +60,6 @@ VALIDATE_NUM_CATALOG_QUERIES_BATCH_SIZE = 100
 
 # Feature Toggles
 EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API = 'expose_license_activation_key_over_api'
+
+# Default sender alias for emails
+DEFAULT_EMAIL_SENDER_ALIAS = 'edX Support Team'

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -16,6 +16,7 @@ from license_manager.apps.subscriptions.constants import (
 )
 from license_manager.apps.subscriptions.utils import (
     chunks,
+    get_enterprise_sender_alias,
     get_learner_portal_url,
     get_license_activation_link,
 )
@@ -48,10 +49,11 @@ def send_onboarding_email(enterprise_customer_uuid, user_email):
         that is linked to the SubscriptionPlan associated with the activated license
         user_email (str): email of the learner whose license has just been activated
     """
-    enterprise_customer_data = EnterpriseApiClient().get_enterprise_customer_data(enterprise_customer_uuid)
-    enterprise_name = enterprise_customer_data.get('name')
-    enterprise_slug = enterprise_customer_data.get('slug')
-    sender_alias = enterprise_customer_data.get('sender_alias', 'edX Support Team')
+    enterprise_customer = EnterpriseApiClient().get_enterprise_customer_data(enterprise_customer_uuid)
+    enterprise_name = enterprise_customer.get('name')
+    enterprise_slug = enterprise_customer.get('slug')
+    enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
+
     context = {
         'subject': ONBOARDING_EMAIL_SUBJECT,
         'template_name': ONBOARDING_EMAIL_TEMPLATE,
@@ -63,7 +65,7 @@ def send_onboarding_email(enterprise_customer_uuid, user_email):
         'RECIPIENT_EMAIL': user_email,
         'SOCIAL_MEDIA_FOOTER_URLS': settings.SOCIAL_MEDIA_FOOTER_URLS,
     }
-    email = _message_from_context_and_template(context, sender_alias)
+    email = _message_from_context_and_template(context, enterprise_sender_alias)
     email.send()
 
 

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -4,7 +4,9 @@ from datetime import date, datetime
 from django.conf import settings
 from pytz import UTC
 
-from license_manager.apps.subscriptions.constants import DEFAULT_EMAIL_SENDER_ALIAS
+from license_manager.apps.subscriptions.constants import (
+    DEFAULT_EMAIL_SENDER_ALIAS,
+)
 
 
 def localized_utcnow():

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -4,6 +4,8 @@ from datetime import date, datetime
 from django.conf import settings
 from pytz import UTC
 
+from license_manager.apps.subscriptions.constants import DEFAULT_EMAIL_SENDER_ALIAS
+
 
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
@@ -44,3 +46,11 @@ def get_license_activation_link(enterprise_slug, activation_key):
         str(activation_key),
         'activate'
     ))
+
+
+def get_enterprise_sender_alias(enterprise_customer):
+    """
+    Returns the configured sender alias for an enterprise, if configured; otherwise
+    returns the default sender alias.
+    """
+    return enterprise_customer.get('sender_alias') or DEFAULT_EMAIL_SENDER_ALIAS


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Fixes issue with sending emails using a non-configured sender alias for an Enterprise Customer. Currently, if this field on the `EnterpriseCustomer` model is not set, we are sending emails to learners with "None" as the sender alias, which is probably not good for spam filters.

This PR refactors the logic to pull the sender alias from the customer data or correctly default to "edX Support Team" (not `None`).

![image](https://user-images.githubusercontent.com/2828721/115083997-3daefc00-9ed6-11eb-96da-bf527e3175e6.png)

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
