### PR TITLE
fix: Return subscription plan as part of licenses.

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -69,6 +69,8 @@ class LicenseSerializer(serializers.ModelSerializer):
     """
     Serializer for the `License` model.
     """
+    subscription_plan = SubscriptionPlanSerializer(read_only=True)
+
     class Meta:
         model = License
         fields = [
@@ -77,6 +79,7 @@ class LicenseSerializer(serializers.ModelSerializer):
             'user_email',
             'activation_date',
             'last_remind_date',
+            'subscription_plan',
         ]
         if settings.FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API]:
             fields.append('activation_key')


### PR DESCRIPTION
**This needs to be merged BEFORE the accompanying frontend PR**

## Description

In the learner portal, we are separately retrieving licenses and subscription plans. This causes a major issue because we do not necessarily retrieve a subscription plan that the license is associated with. This has resulted in users seeing courses for a subscription they do not have access to.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4486

## Testing considerations
Manual test scenarios run:
- Offer only org:
  - User with code - should see courses associated with offer catalog
  - User with no code - search page shouldn't even load
- Sub only org:
  - User with license - should see courses associated with their license catalog
  - User with no license - search page shouldn't load
- Sub & Offer Org:
  - User with license only - should see courses associated with their license catalog
  - User with code only - should see courses associated with the offer catalog
  - User with both license and codes - should see courses associated with both offers and their license.
  - User with neither license nor code - should see nothing.
 - The "All" filter in all cases (except where the search page just doesn't load) should still just show all courses the enterprise has access to (and only the courses the enterprise has access to)

## Post-review

Squash commits into discrete sets of changes
