### PR TITLE
docs: :sparkles: fix doc formatting for api doc ENT-4339 (plus make upgrade)

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -751,37 +751,28 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
         """
         Returns the enterprise bulk enrollment API response after validating that each user requesting to be enrolled
         has a valid subscription for each of the requested courses.
-
         Expected params:
             - notify (bool): Whether or not learners should be notified of their enrollments.
-
             - course_run_keys (list of strings): An array of course run keys in which all provided learners will be
             enrolled in
             Example:
                 course_run_keys: ['course-v1:edX+DemoX+Demo_Course', 'course-v2:edX+The+Second+DemoX+Demo_Course', ... ]
-
-            - emails (string): A single string of multiple learner emails separated with a `\n` (new line) character
+            - emails (string): A single string of multiple learner emails separated with a newline character
             Example:
-                emails: 'testuser@abc.com\nlearner@example.com\newuser@wow.com'
-
+                emails: 'testuser@abc.com\\nlearner@example.com\\newuser@wow.com'
             - enterprise_customer_uuid (string): the uuid of the associated enterprise customer provided as a query
             params.
-
         Expected Return Values:
             Success cases:
                 - All learners have licenses and are enrolled - {}, 201
-
             Partial failure cases:
                 License verification and bulk enterprise enrollment happen non-transactionally, meaning that a subset of
                 learners failing one step will not stop others from continuing the enrollment flow. As such, partial
                 failures will be reported in the following ways:
-
                 Fails license verification:
-                    response includes: {'failed_license_checks': [<users who do not have valid licenses>]}
-
+                    response includes: {'failed_license_checks': [<users who do not have valid licenses>]
                 Fails Enrollment:
                     response includes {'failed_enrollments': [<users who were not able to be enrolled>]
-
                 Fails Validation (something goes wrong with requesting enrollments):
                     response includes:
                      {'bulk_enrollment_errors': [<errors returned by the bulk enrollment endpoint>]}

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -770,9 +770,9 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                 learners failing one step will not stop others from continuing the enrollment flow. As such, partial
                 failures will be reported in the following ways:
                 Fails license verification:
-                    response includes: {'failed_license_checks': [<users who do not have valid licenses>]
+                    response includes: {'failed_license_checks': [<users who do not have valid licenses>]}
                 Fails Enrollment:
-                    response includes {'failed_enrollments': [<users who were not able to be enrolled>]
+                    response includes {'failed_enrollments': [<users who were not able to be enrolled>]}
                 Fails Validation (something goes wrong with requesting enrollments):
                     response includes:
                      {'bulk_enrollment_errors': [<errors returned by the bulk enrollment endpoint>]}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,11 @@ amqp==2.6.1
     # via kombu
 backoff==1.10.0
     # via -r requirements/base.in
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
-boto3==1.17.36
+boto3==1.17.72
     # via django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   boto3
     #   s3transfer
@@ -33,7 +33,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   pyjwt
     #   social-auth-core
@@ -47,7 +47,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in
@@ -58,21 +58,22 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/base.in
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/base.in
 django-waffle==2.1.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -88,7 +89,7 @@ django==2.2.19
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/base.in
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/base.in
     #   django-rest-swagger
@@ -97,7 +98,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via edx-drf-extensions
 drf-nested-routers==0.93.3
     # via -r requirements/base.in
@@ -105,7 +106,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/base.in
 edx-celeryutils==1.0.0
     # via -r requirements/base.in
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -131,7 +132,9 @@ idna==2.10
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3
-    # via coreschema
+    # via
+    #   -c requirements/constraints.txt
+    #   coreschema
 jmespath==0.10.0
     # via
     #   boto3
@@ -141,7 +144,9 @@ jsonfield2==4.0.0.post0
 kombu==4.6.11
     # via celery
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c requirements/constraints.txt
+    #   jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.in
 newrelic==6.2.0.156
@@ -152,7 +157,7 @@ oauthlib==3.1.0
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
 psutil==5.8.0
     # via edx-django-utils
@@ -164,11 +169,12 @@ pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.11.3
+pymongo==3.11.4
     # via edx-opaque-keys
 python-dateutil==2.8.1
     # via
@@ -197,17 +203,16 @@ requests==2.25.1
     #   social-auth-core
 rest-condition==1.0.3
     # via edx-drf-extensions
-rules==2.2
+rules==3.0
     # via -r requirements/base.in
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via boto3
 semantic-version==2.8.5
     # via edx-drf-extensions
 simplejson==3.17.2
     # via django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -222,7 +227,6 @@ social-auth-app-django==4.0.0
     # via edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,3 +25,4 @@ celery<5.0
 # 4.0.3 requires PyJWT > 2.0 but drf-jwt requires < 2.0
 social-auth-core<4.0.3
 
+faker==8.1.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,4 +25,5 @@ celery<5.0
 # 4.0.3 requires PyJWT > 2.0 but drf-jwt requires < 2.0
 social-auth-core<4.0.3
 
+# 8.1.3 has a fix for the issue "AttributeError: 'PosixPath' object has no attribute 'startswith'"
 faker==8.1.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,3 +27,11 @@ social-auth-core<4.0.3
 
 # 8.1.3 has a fix for the issue "AttributeError: 'PosixPath' object has no attribute 'startswith'"
 faker==8.1.3
+
+# Sphinx 4 and Jinja 3 are not playing nicely
+Sphinx<4.0
+jinja2<3.0
+MarkupSafe<2.0
+
+# Not sure why but this seems to be needed too
+click<8.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -196,7 +196,7 @@ edx-rest-api-client==1.9.2
     #   -r requirements/validation.txt
 factory-boy==3.2.0
     # via -r requirements/validation.txt
-faker==6.6.2
+faker==8.1.3
     # via
     #   -r requirements/validation.txt
     #   factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,26 +8,26 @@ amqp==2.6.1
     # via
     #   -r requirements/validation.txt
     #   kombu
-astroid==2.5.1
+astroid==2.5.6
     # via
     #   -r requirements/validation.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/validation.txt
     #   pytest
 backoff==1.10.0
     # via -r requirements/validation.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -56,13 +56,14 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
     #   click-log
     #   code-annotations
     #   edx-lint
     #   pip-tools
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -79,7 +80,7 @@ coverage==5.5
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -93,7 +94,7 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==5.0.1
+diff-cover==5.1.1
     # via -r requirements/dev.in
 django-cors-headers==3.7.0
     # via -r requirements/validation.txt
@@ -102,11 +103,11 @@ django-crum==0.7.9
     #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==3.2
+django-debug-toolbar==3.2.1
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.1
     # via -r requirements/validation.txt
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via
     #   -r requirements/dev.in
     #   -r requirements/validation.txt
@@ -119,16 +120,16 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/validation.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/validation.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/validation.txt
 django-waffle==2.1.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/validation.txt
@@ -136,6 +137,7 @@ django==2.2.19
     #   django-cors-headers
     #   django-crum
     #   django-debug-toolbar
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -153,7 +155,7 @@ django==2.2.19
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/validation.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
@@ -162,7 +164,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -172,7 +174,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/validation.txt
 edx-celeryutils==1.0.0
     # via -r requirements/validation.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -198,6 +200,7 @@ factory-boy==3.2.0
     # via -r requirements/validation.txt
 faker==8.1.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   factory-boy
 freezegun==1.1.0
@@ -208,7 +211,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-gunicorn==20.0.4
+gunicorn==20.1.0
     # via -r requirements/dev.in
 idna==2.10
     # via
@@ -234,6 +237,7 @@ jinja2-pluralize==0.3.0
     # via diff-cover
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   code-annotations
     #   coreschema
@@ -258,6 +262,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   jinja2
 mccabe==0.6.1
@@ -293,7 +298,7 @@ path==15.1.2
     #   path.py
 pathlib2==2.3.5
     # via -r requirements/validation.txt
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/validation.txt
     #   stevedore
@@ -301,14 +306,14 @@ pep517==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
     # via
     #   -r requirements/validation.txt
     #   diff-cover
     #   pytest
-polib==1.1.0
+polib==1.1.1
     # via
     #   -r requirements/validation.txt
     #   edx-i18n-tools
@@ -332,7 +337,7 @@ pycryptodomex==3.10.1
     #   pyjwkest
 pydocstyle==6.0.0
     # via -r requirements/validation.txt
-pygments==2.8.1
+pygments==2.9.0
     # via diff-cover
 pyjwkest==1.4.2
     # via
@@ -340,6 +345,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/validation.txt
     #   drf-jwt
     #   edx-auth-backends
@@ -349,7 +355,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/validation.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -358,14 +364,14 @@ pylint-plugin-utils==0.6
     #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.2
+pylint==2.8.2
     # via
     #   -r requirements/validation.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/validation.txt
     #   edx-opaque-keys
@@ -375,9 +381,9 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/validation.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/validation.txt
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -389,7 +395,7 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -431,9 +437,9 @@ rest-condition==1.0.3
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-rules==2.2
+rules==3.0
     # via -r requirements/validation.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -445,11 +451,10 @@ simplejson==3.17.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/validation.txt
     #   django-dynamic-fixture
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -475,7 +480,6 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   edx-auth-backends

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -198,7 +198,7 @@ edx-sphinx-theme==2.0.0
     # via -r requirements/doc.in
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.6.2
+faker==8.1.3
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,30 +10,30 @@ amqp==2.6.1
     # via
     #   -r requirements/test.txt
     #   kombu
-astroid==2.5.1
+astroid==2.5.6
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.9.0
+babel==2.9.1
     # via sphinx
 backoff==1.10.0
     # via -r requirements/test.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
 bleach==3.3.0
     # via readme-renderer
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -62,11 +62,12 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -83,7 +84,7 @@ coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -104,7 +105,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.txt
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via -r requirements/test.txt
 django-filter==2.4.0
     # via -r requirements/test.txt
@@ -115,22 +116,23 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/test.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/test.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/test.txt
 django-waffle==2.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -147,7 +149,7 @@ django==2.2.19
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/test.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -160,11 +162,12 @@ doc8==0.8.1
     # via -r requirements/doc.in
 docutils==0.16
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   doc8
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -174,7 +177,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/test.txt
 edx-celeryutils==1.0.0
     # via -r requirements/test.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -194,12 +197,13 @@ edx-rest-api-client==1.9.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-edx-sphinx-theme==2.0.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/doc.in
 factory-boy==3.2.0
     # via -r requirements/test.txt
 faker==8.1.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   factory-boy
 freezegun==1.1.0
@@ -230,6 +234,7 @@ itypes==1.2.0
     #   coreapi
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
@@ -253,6 +258,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   jinja2
 mccabe==0.6.1
@@ -280,7 +286,7 @@ packaging==20.9
     #   bleach
     #   pytest
     #   sphinx
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -304,7 +310,7 @@ pycryptodomex==3.10.1
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   doc8
     #   readme-renderer
@@ -315,6 +321,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-auth-backends
@@ -324,7 +331,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -333,14 +340,14 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.2
+pylint==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -350,9 +357,9 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -364,7 +371,7 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -409,9 +416,9 @@ rest-condition==1.0.3
     #   edx-drf-extensions
 restructuredtext-lint==1.3.2
     # via doc8
-rules==2.2
+rules==3.0
     # via -r requirements/test.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -423,12 +430,11 @@ simplejson==3.17.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/test.txt
     #   bleach
     #   django-dynamic-fixture
-    #   django-simple-history
     #   djangorestframework-csv
     #   doc8
     #   edx-auth-backends
@@ -453,13 +459,13 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==3.5.3
+sphinx==3.5.4
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
     #   edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,10 +5,12 @@
 #    make upgrade
 #
 click==7.1.2
-    # via pip-tools
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools
 pep517==0.10.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,15 +10,15 @@ amqp==2.6.1
     #   kombu
 backoff==1.10.0
     # via -r requirements/base.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -49,7 +49,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -66,7 +66,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==2.4.0
     # via -r requirements/base.txt
@@ -77,21 +77,22 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/base.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-waffle==2.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -107,7 +108,7 @@ django==2.2.19
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/base.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -116,7 +117,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -126,7 +127,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/base.txt
 edx-celeryutils==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -152,9 +153,9 @@ future==0.18.2
     #   pyjwkest
 gevent==21.1.2
     # via -r requirements/production.in
-greenlet==1.0.0
+greenlet==1.1.0
     # via gevent
-gunicorn==20.0.4
+gunicorn==20.1.0
     # via -r requirements/production.in
 idna==2.10
     # via
@@ -166,6 +167,7 @@ itypes==1.2.0
     #   coreapi
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   coreschema
 jmespath==0.10.0
@@ -183,6 +185,7 @@ kombu==4.6.11
     #   celery
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mysqlclient==2.0.3
@@ -200,7 +203,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -222,12 +225,13 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -272,9 +276,9 @@ rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-rules==2.2
+rules==3.0
     # via -r requirements/base.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -286,10 +290,9 @@ simplejson==3.17.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -309,7 +312,6 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -347,7 +349,7 @@ zipp==1.2.0
     #   -r requirements/base.txt
 zope.event==4.5.0
     # via gevent
-zope.interface==5.3.0
+zope.interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,21 +8,21 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-astroid==2.5.1
+astroid==2.5.6
     # via
     #   pylint
     #   pylint-celery
 backoff==1.10.0
     # via -r requirements/base.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -48,10 +48,11 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via edx-lint
 coreapi==2.3.3
     # via
@@ -62,7 +63,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -79,7 +80,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==2.4.0
     # via -r requirements/base.txt
@@ -90,22 +91,23 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/base.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-waffle==2.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -122,7 +124,7 @@ django==2.2.19
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/base.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -131,7 +133,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -141,7 +143,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/base.txt
 edx-celeryutils==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -181,6 +183,7 @@ itypes==1.2.0
     #   coreapi
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
@@ -201,6 +204,7 @@ lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.6.1
@@ -220,7 +224,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -246,6 +250,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-auth-backends
@@ -253,19 +258,19 @@ pyjwt[crypto]==1.7.1
     #   social-auth-core
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.2
+pylint==2.8.2
     # via
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -274,7 +279,7 @@ python-dateutil==2.8.1
     #   -r requirements/base.txt
     #   botocore
     #   edx-drf-extensions
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -310,9 +315,9 @@ rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-rules==2.2
+rules==3.0
     # via -r requirements/base.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -324,10 +329,9 @@ simplejson==3.17.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -349,7 +353,6 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,23 +8,23 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-astroid==2.5.1
+astroid==2.5.6
     # via
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via pytest
 backoff==1.10.0
     # via -r requirements/base.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -50,10 +50,11 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -r requirements/test.in
     #   edx-lint
@@ -70,7 +71,7 @@ coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -91,7 +92,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.in
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==2.4.0
     # via -r requirements/base.txt
@@ -102,9 +103,9 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/base.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-waffle==2.1.0
     # via
@@ -117,6 +118,7 @@ django-waffle==2.1.0
     #   code-annotations
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -133,7 +135,7 @@ django-waffle==2.1.0
     #   rest-condition
 djangorestframework-csv==2.1.0
     # via -r requirements/base.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -142,7 +144,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -152,7 +154,7 @@ edx-auth-backends==3.3.3
     # via -r requirements/base.txt
 edx-celeryutils==1.0.0
     # via -r requirements/base.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -175,7 +177,9 @@ edx-rest-api-client==1.9.2
 factory-boy==3.2.0
     # via -r requirements/test.in
 faker==8.1.3
-    # via factory-boy
+    # via
+    #   -c requirements/constraints.txt
+    #   factory-boy
 freezegun==1.1.0
     # via -r requirements/test.in
 future==0.18.2
@@ -198,6 +202,7 @@ itypes==1.2.0
     #   coreapi
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
@@ -218,6 +223,7 @@ lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.6.1
@@ -239,7 +245,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 packaging==20.9
     # via pytest
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -265,6 +271,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-auth-backends
@@ -272,19 +279,19 @@ pyjwt[crypto]==1.7.1
     #   social-auth-core
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.2
+pylint==2.8.2
     # via
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -292,9 +299,9 @@ pyparsing==2.4.7
     # via packaging
 pytest-cov==2.11.1
     # via -r requirements/test.in
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.in
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   pytest-cov
     #   pytest-django
@@ -305,7 +312,7 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -341,9 +348,9 @@ rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-rules==2.2
+rules==3.0
     # via -r requirements/base.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -355,11 +362,10 @@ simplejson==3.17.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/base.txt
     #   django-dynamic-fixture
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -379,7 +385,6 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -174,7 +174,7 @@ edx-rest-api-client==1.9.2
     #   -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==6.6.2
+faker==8.1.3
     # via factory-boy
 freezegun==1.1.0
     # via -r requirements/test.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -32,15 +32,15 @@ pyparsing==2.4.7
     # via packaging
 requests==2.25.1
     # via codecov
-six==1.15.0
+six==1.16.0
     # via
     #   tox
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.23.0
+tox==3.23.1
     # via -r requirements/travis.in
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via tox

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -236,7 +236,7 @@ edx-rest-api-client==1.9.2
     #   -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==6.6.2
+faker==8.1.3
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -9,13 +9,13 @@ amqp==2.6.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   kombu
-astroid==2.5.1
+astroid==2.5.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -23,17 +23,17 @@ backoff==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.17.36
+boto3==1.17.72
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.20.36
+botocore==1.20.72
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -67,12 +67,13 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -92,7 +93,7 @@ coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -118,7 +119,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-dynamic-fixture==3.1.1
     # via -r requirements/test.txt
-django-extensions==3.1.1
+django-extensions==3.1.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -136,11 +137,11 @@ django-rest-swagger==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-ses==1.0.3
+django-ses==2.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -150,7 +151,7 @@ django-waffle==2.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django==2.2.19
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -158,6 +159,7 @@ django==2.2.19
     #   code-annotations
     #   django-cors-headers
     #   django-crum
+    #   django-extensions
     #   django-filter
     #   django-model-utils
     #   django-ses
@@ -177,7 +179,7 @@ djangorestframework-csv==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -187,7 +189,7 @@ djangorestframework==3.12.2
     #   drf-nested-routers
     #   edx-drf-extensions
     #   rest-condition
-drf-jwt==1.18.0
+drf-jwt==1.19.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -204,7 +206,7 @@ edx-celeryutils==1.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==3.15.0
+edx-django-utils==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -238,6 +240,7 @@ factory-boy==3.2.0
     # via -r requirements/test.txt
 faker==8.1.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   factory-boy
 freezegun==1.1.0
@@ -270,6 +273,7 @@ itypes==1.2.0
     #   coreapi
 jinja2==2.11.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
@@ -297,6 +301,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jinja2
@@ -335,7 +340,7 @@ path==15.1.2
     # via path.py
 pathlib2==2.3.5
     # via -r requirements/validation.in
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -344,7 +349,7 @@ pluggy==0.13.1
     # via
     #   -r requirements/test.txt
     #   pytest
-polib==1.1.0
+polib==1.1.1
     # via edx-i18n-tools
 psutil==5.8.0
     # via
@@ -376,6 +381,7 @@ pyjwkest==1.4.2
     #   edx-drf-extensions
 pyjwt[crypto]==1.7.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   drf-jwt
@@ -387,7 +393,7 @@ pylint-celery==0.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -398,7 +404,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.2
+pylint==2.8.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -406,7 +412,7 @@ pylint==2.7.2
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.3
+pymongo==3.11.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -417,9 +423,9 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -432,7 +438,7 @@ python-dateutil==2.8.1
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -481,11 +487,11 @@ rest-condition==1.0.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-rules==2.2
+rules==3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-s3transfer==0.3.6
+s3transfer==0.4.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -500,12 +506,11 @@ simplejson==3.17.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-dynamic-fixture
-    #   django-simple-history
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -533,7 +538,6 @@ social-auth-app-django==4.0.0
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
new lines need to be esacped, and actual new lines cause extra formatting in the swagger docs, this change makes the doc content appear correctly in a single section


with change looks like this

<img width="977" alt="Screen Shot 2021-05-09 at 7 11 33 PM" src="https://user-images.githubusercontent.com/528166/117589880-63f14180-b0fa-11eb-8771-d81414954e0c.png">

