### PR TITLE
feat: add support for active_only query param

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -667,13 +667,14 @@ def test_subscription_plan_detail_staff_user_200(api_client, staff_user, boolean
         expected_days_until_renewal_expiration=SUBSCRIPTION_RENEWAL_DAYS_OFFSET,
     )
 
+
 @pytest.mark.django_db
 def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
     (subscription,
-    assigned_license,
-    unassigned_license,
-    activated_license,
-    revoked_license) = _subscription_and_licenses()
+     assigned_license,
+     unassigned_license,
+     activated_license,
+     revoked_license) = _subscription_and_licenses()
 
     _assign_role_via_jwt_or_db(
         api_client,
@@ -692,44 +693,11 @@ def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
     _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
     _assert_license_response_correct(results_by_uuid[str(revoked_license.uuid)], revoked_license)
 
-@pytest.mark.django_db
-def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
-    (subscription,
-    assigned_license,
-    unassigned_license,
-    activated_license,
-    revoked_license) = _subscription_and_licenses()
-
-    _assign_role_via_jwt_or_db(
-        api_client,
-        staff_user,
-        subscription.enterprise_customer_uuid,
-        boolean_toggle,
-    )
-
-@pytest.mark.django_db
-def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
-    subscription, assigned_license, unassigned_license, activated_license, revoked_license = _subscription_and_licenses()
-    _assign_role_via_jwt_or_db(
-        api_client,
-        staff_user,
-        subscription.enterprise_customer_uuid,
-        boolean_toggle,
-    )
-
-    response = _licenses_list_request(api_client, subscription.uuid)
-
-    assert status.HTTP_200_OK == response.status_code
-    results_by_uuid = {item['uuid']: item for item in response.data['results']}
-    assert len(results_by_uuid) == 4
-    _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
-    _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
-    _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
-    _assert_license_response_correct(results_by_uuid[str(revoked_license.uuid)], revoked_license)
 
 @pytest.mark.django_db
 def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
-    subscription, assigned_license, unassigned_license, activated_license, revoked_license = _subscription_and_licenses()
+    subscription, assigned_license, unassigned_license, activated_license, revoked_license \
+        = _subscription_and_licenses()
     _assign_role_via_jwt_or_db(
         api_client,
         staff_user,
@@ -747,6 +715,7 @@ def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
     _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
     assert not hasattr(results_by_uuid, str(unassigned_license.uuid))
     assert not hasattr(results_by_uuid, str(revoked_license.uuid))
+
 
 @pytest.mark.django_db
 def test_license_list_staff_user_200_custom_page_size(api_client, staff_user):
@@ -887,6 +856,7 @@ def _assign_role_via_jwt_or_db(
             user=user,
             role=SubscriptionsFeatureRole.objects.get(name=subscriptions_role),
         )
+
 
 def _subscription_and_licenses():
     """

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -868,11 +868,11 @@ def _subscription_and_licenses():
     # Associate some licenses with the subscription
     unassigned_license = LicenseFactory.create(user_email='unassigned@edx.org')
     assigned_license = LicenseFactory.create(status=constants.ASSIGNED, user_email='assigned@fake.com')
-    pending_license = LicenseFactory.create(status=constants.ACTIVATED, user_email='activated@edx.org')
+    active_license = LicenseFactory.create(status=constants.ACTIVATED, user_email='activated@edx.org')
     revoked_license = LicenseFactory.create(status=constants.REVOKED)
-    subscription.licenses.set([unassigned_license, assigned_license, pending_license, revoked_license])
+    subscription.licenses.set([unassigned_license, assigned_license, active_license, revoked_license])
 
-    return subscription, assigned_license, unassigned_license, pending_license, revoked_license
+    return subscription, assigned_license, unassigned_license, active_license, revoked_license
 
 
 def _create_subscription_plans(enterprise_customer_uuid):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -667,10 +667,14 @@ def test_subscription_plan_detail_staff_user_200(api_client, staff_user, boolean
         expected_days_until_renewal_expiration=SUBSCRIPTION_RENEWAL_DAYS_OFFSET,
     )
 
-
 @pytest.mark.django_db
 def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
-    subscription, assigned_license, unassigned_license = _subscription_and_licenses()
+    (subscription,
+    assigned_license,
+    unassigned_license,
+    activated_license,
+    revoked_license) = _subscription_and_licenses()
+
     _assign_role_via_jwt_or_db(
         api_client,
         staff_user,
@@ -685,6 +689,23 @@ def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
     assert len(results_by_uuid) == 4
     _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
     _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
+    _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
+    _assert_license_response_correct(results_by_uuid[str(revoked_license.uuid)], revoked_license)
+
+@pytest.mark.django_db
+def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
+    (subscription,
+    assigned_license,
+    unassigned_license,
+    activated_license,
+    revoked_license) = _subscription_and_licenses()
+
+    _assign_role_via_jwt_or_db(
+        api_client,
+        staff_user,
+        subscription.enterprise_customer_uuid,
+        boolean_toggle,
+    )
 
 @pytest.mark.django_db
 def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
@@ -863,10 +884,10 @@ def _assign_role_via_jwt_or_db(
             role=SubscriptionsFeatureRole.objects.get(name=subscriptions_role),
         )
 
-
 def _subscription_and_licenses():
     """
-    Helper method to return a SubscriptionPlan, an unassigned license, active license, revoked licenseand an assigned license.
+    Helper method to return a SubscriptionPlan, an unassigned license, active license, revoked license and an assigned
+    license.
     """
     subscription = SubscriptionPlanFactory.create()
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -207,15 +207,15 @@ def _subscriptions_detail_request(api_client, user, subscription_uuid):
     return api_client.get(url)
 
 
-def _licenses_list_request(api_client, subscription_uuid, page_size=None, is_active=None):
+def _licenses_list_request(api_client, subscription_uuid, page_size=None, active_only=None):
     """
     Helper method that requests a list of licenses for a given subscription_uuid.
     """
     url = reverse('api:v1:licenses-list', kwargs={'subscription_uuid': subscription_uuid})
     if page_size:
         url += f'?page_size={page_size}'
-    if is_active:
-        url += f'?is_active={is_active}'
+    if active_only:
+        url += f'?active_only={active_only}'
     return api_client.get(url)
 
 
@@ -737,8 +737,12 @@ def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
         boolean_toggle,
     )
 
-    response = _licenses_list_request(api_client, subscription.uuid, is_active='1')
+    response = _licenses_list_request(api_client, subscription.uuid, active_only='1')
+
+    assert status.HTTP_200_OK == response.status_code
     results_by_uuid = {item['uuid']: item for item in response.data['results']}
+
+    assert len(results_by_uuid) == 2
     _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
     _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
     assert not hasattr(results_by_uuid, str(unassigned_license.uuid))

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -207,13 +207,15 @@ def _subscriptions_detail_request(api_client, user, subscription_uuid):
     return api_client.get(url)
 
 
-def _licenses_list_request(api_client, subscription_uuid, page_size=None):
+def _licenses_list_request(api_client, subscription_uuid, page_size=None, is_active=None):
     """
     Helper method that requests a list of licenses for a given subscription_uuid.
     """
     url = reverse('api:v1:licenses-list', kwargs={'subscription_uuid': subscription_uuid})
     if page_size:
         url += f'?page_size={page_size}'
+    if is_active:
+        url += f'?is_active={is_active}'
     return api_client.get(url)
 
 
@@ -680,14 +682,50 @@ def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
 
     assert status.HTTP_200_OK == response.status_code
     results_by_uuid = {item['uuid']: item for item in response.data['results']}
-    assert len(results_by_uuid) == 2
+    assert len(results_by_uuid) == 4
     _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
     _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
 
+@pytest.mark.django_db
+def test_license_list_staff_user_200(api_client, staff_user, boolean_toggle):
+    subscription, assigned_license, unassigned_license, activated_license, revoked_license = _subscription_and_licenses()
+    _assign_role_via_jwt_or_db(
+        api_client,
+        staff_user,
+        subscription.enterprise_customer_uuid,
+        boolean_toggle,
+    )
+
+    response = _licenses_list_request(api_client, subscription.uuid)
+
+    assert status.HTTP_200_OK == response.status_code
+    results_by_uuid = {item['uuid']: item for item in response.data['results']}
+    assert len(results_by_uuid) == 4
+    _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
+    _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
+    _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
+    _assert_license_response_correct(results_by_uuid[str(revoked_license.uuid)], revoked_license)
+
+@pytest.mark.django_db
+def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
+    subscription, assigned_license, unassigned_license, activated_license, revoked_license = _subscription_and_licenses()
+    _assign_role_via_jwt_or_db(
+        api_client,
+        staff_user,
+        subscription.enterprise_customer_uuid,
+        boolean_toggle,
+    )
+
+    response = _licenses_list_request(api_client, subscription.uuid, is_active='1')
+    results_by_uuid = {item['uuid']: item for item in response.data['results']}
+    _assert_license_response_correct(results_by_uuid[str(assigned_license.uuid)], assigned_license)
+    _assert_license_response_correct(results_by_uuid[str(activated_license.uuid)], activated_license)
+    assert not hasattr(results_by_uuid, str(unassigned_license.uuid))
+    assert not hasattr(results_by_uuid, str(revoked_license.uuid))
 
 @pytest.mark.django_db
 def test_license_list_staff_user_200_custom_page_size(api_client, staff_user):
-    subscription, _, _ = _subscription_and_licenses()
+    subscription, _, _, _, _ = _subscription_and_licenses()
     _assign_role_via_jwt_or_db(
         api_client,
         staff_user,
@@ -701,7 +739,7 @@ def test_license_list_staff_user_200_custom_page_size(api_client, staff_user):
     results_by_uuid = {item['uuid']: item for item in response.data['results']}
     # We test for content in the test above, we're just worried about the number of pages here
     assert len(results_by_uuid) == 1
-    assert 2 == response.data['count']
+    assert response.data['count'] == 4
     assert response.data['next'] is not None
 
 
@@ -828,16 +866,18 @@ def _assign_role_via_jwt_or_db(
 
 def _subscription_and_licenses():
     """
-    Helper method to return a SubscriptionPlan, an unassigned license, and an assigned license.
+    Helper method to return a SubscriptionPlan, an unassigned license, active license, revoked licenseand an assigned license.
     """
     subscription = SubscriptionPlanFactory.create()
 
     # Associate some licenses with the subscription
-    unassigned_license = LicenseFactory.create()
-    assigned_license = LicenseFactory.create(status=constants.ASSIGNED, user_email='fake@fake.com')
-    subscription.licenses.set([unassigned_license, assigned_license])
+    unassigned_license = LicenseFactory.create(user_email='unassigned@edx.org')
+    assigned_license = LicenseFactory.create(status=constants.ASSIGNED, user_email='assigned@fake.com')
+    pending_license = LicenseFactory.create(status=constants.ACTIVATED, user_email='activated@edx.org')
+    revoked_license = LicenseFactory.create(status=constants.REVOKED)
+    subscription.licenses.set([unassigned_license, assigned_license, pending_license, revoked_license])
 
-    return subscription, assigned_license, unassigned_license
+    return subscription, assigned_license, unassigned_license, pending_license, revoked_license
 
 
 def _create_subscription_plans(enterprise_customer_uuid):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -355,12 +355,12 @@ class LicensePagination(PageNumberPaginationWithCount):
     A PageNumber paginator that allows the client to specify the page size, up to some maximum.
     """
     page_size_query_param = 'page_size'
-    max_page_size = 10000
+    max_page_size = 500
 
 
 class LicenseViewSet(LearnerLicenseViewSet):
     """ Viewset for Admin read operations on Licenses.
-    /subscriptions/<EnterpriseUUid/licenses
+    /subscriptions/<EnterpriseUuid>/licenses
     """
     lookup_field = 'uuid'
     lookup_url_kwarg = 'license_uuid'

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -381,7 +381,8 @@ class LicenseViewSet(LearnerLicenseViewSet):
         For non-list actions, this is what's returned by `get_queryset()`.
         For list actions, some non-strict subset of this is what's returned by `get_queryset()`.
         """
-        queryset = License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('status', 'user_email')
+        queryset = License.objects.filter(subscription_plan=self._get_subscription_plan()) \
+            .order_by('status', 'user_email')
         if self.active_only:
             queryset = queryset.filter(status__in=[constants.ACTIVATED, constants.ASSIGNED])
 

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -354,11 +354,13 @@ class LicensePagination(PageNumberPaginationWithCount):
     A PageNumber paginator that allows the client to specify the page size, up to some maximum.
     """
     page_size_query_param = 'page_size'
-    max_page_size = 500
+    max_page_size = 10000
 
 
 class LicenseViewSet(LearnerLicenseViewSet):
-    """ Viewset for Admin read operations on Licenses."""
+    """ Viewset for Admin read operations on Licenses.
+    /subscriptions/<EnterpriseUUid/licenses
+    """
     lookup_field = 'uuid'
     lookup_url_kwarg = 'license_uuid'
 
@@ -368,13 +370,21 @@ class LicenseViewSet(LearnerLicenseViewSet):
     pagination_class = LicensePagination
 
     @property
+    def active_only(self):
+        return int(self.request.query_params.get('active_only', 0))
+
+    @property
     def base_queryset(self):
         """
         Required by the `PermissionRequiredForListingMixin`.
         For non-list actions, this is what's returned by `get_queryset()`.
         For list actions, some non-strict subset of this is what's returned by `get_queryset()`.
         """
-        return License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('status', 'user_email')
+        queryset = License.objects.filter(subscription_plan=self._get_subscription_plan()).order_by('status', 'user_email')
+        if self.active_only:
+            queryset = queryset.filter(status__in=[constants.ACTIVATED, constants.ASSIGNED])
+
+        return queryset
 
     def _get_custom_text(self, data):
         """

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -270,10 +270,11 @@ class LearnerLicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnly
 class LearnerLicensesViewSet(PermissionRequiredForListingMixin, ListModelMixin, viewsets.GenericViewSet):
     """
     This Viewset allows read operations of all Licenses for a given user-customer pair.
+    /learner-licenses
     """
     authentication_classes = [JwtAuthentication]
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
-    filter_class = LicenseStatusFilter
+    filterset_class = LicenseStatusFilter
     ordering_fields = [
         'user_email',
         'status',

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -359,7 +359,8 @@ class LicensePagination(PageNumberPaginationWithCount):
 
 
 class LicenseViewSet(LearnerLicenseViewSet):
-    """ Viewset for Admin read operations on Licenses.
+    """
+    Viewset for Admin read operations on Licenses.
     /subscriptions/<EnterpriseUuid>/licenses
     """
     lookup_field = 'uuid'

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -63,7 +63,7 @@ MIDDLEWARE = (
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
 
     # Enables monitoring utility for writing custom metrics.
-    'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
 
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -82,7 +82,7 @@ MIDDLEWARE = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
 
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
 
     # Ensures proper DRF permissions in support of JWTs
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',


### PR DESCRIPTION
Returns only assigned and activated licenses for a given subscription
Ups the upper page limit so we can choose frontend pagination

Tested locally against admin portal requests.

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
