### PR TITLE
feat: Add search ability on user_email field ENT-4572

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -722,6 +722,7 @@ def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
     assert not hasattr(results_by_uuid, str(unassigned_license.uuid))
     assert not hasattr(results_by_uuid, str(revoked_license.uuid))
 
+
 @pytest.mark.django_db
 def test_license_list_search_by_email(api_client, staff_user, boolean_toggle):
     subscription, _, unassigned_license, _, _ = _subscription_and_licenses()
@@ -739,6 +740,7 @@ def test_license_list_search_by_email(api_client, staff_user, boolean_toggle):
 
     assert len(results_by_uuid) == 1
     _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
+
 
 @pytest.mark.django_db
 def test_license_list_staff_user_200_custom_page_size(api_client, staff_user):
@@ -934,6 +936,7 @@ class LicenseViewSetActionTests(TestCase):
     """
     Tests for special actions on the LicenseViewSet.
     """
+
     def setUp(self):
         super().setUp()
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -211,7 +211,7 @@ def _subscriptions_detail_request(api_client, user, subscription_uuid):
     return api_client.get(url)
 
 
-def _licenses_list_request(api_client, subscription_uuid, page_size=None, active_only=None):
+def _licenses_list_request(api_client, subscription_uuid, page_size=None, active_only=None, search=None):
     """
     Helper method that requests a list of licenses for a given subscription_uuid.
     """
@@ -220,6 +220,8 @@ def _licenses_list_request(api_client, subscription_uuid, page_size=None, active
         url += f'?page_size={page_size}'
     if active_only:
         url += f'?active_only={active_only}'
+    if search:
+        url += f'?search={search}'
     return api_client.get(url)
 
 
@@ -720,6 +722,23 @@ def test_license_list_active_licenses(api_client, staff_user, boolean_toggle):
     assert not hasattr(results_by_uuid, str(unassigned_license.uuid))
     assert not hasattr(results_by_uuid, str(revoked_license.uuid))
 
+@pytest.mark.django_db
+def test_license_list_search_by_email(api_client, staff_user, boolean_toggle):
+    subscription, _, unassigned_license, _, _ = _subscription_and_licenses()
+    _assign_role_via_jwt_or_db(
+        api_client,
+        staff_user,
+        subscription.enterprise_customer_uuid,
+        boolean_toggle,
+    )
+
+    response = _licenses_list_request(api_client, subscription.uuid, search='unas')
+
+    assert status.HTTP_200_OK == response.status_code
+    results_by_uuid = {item['uuid']: item for item in response.data['results']}
+
+    assert len(results_by_uuid) == 1
+    _assert_license_response_correct(results_by_uuid[str(unassigned_license.uuid)], unassigned_license)
 
 @pytest.mark.django_db
 def test_license_list_staff_user_200_custom_page_size(api_client, staff_user):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -373,6 +373,9 @@ class LicenseViewSet(LearnerLicenseViewSet):
 
     pagination_class = LicensePagination
 
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['user_email']
+
     @property
     def active_only(self):
         return int(self.request.query_params.get('active_only', 0))


### PR DESCRIPTION
Adds ability to pass 'search=aba' as full text search on the user_email field.

If search is not provided, or passed as empty string (like ?search=) it acts as if no filter is provided

Tested manually, looking to see how best to add a test case, but manual check  by adding a search param in the frontend, to this call, works great

Will add a test soon, but can expect it to be light, since I am using a framework feature 

ENT-4572

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Added unit test
- Manually tested from ui using search=, search=partialText and search=fullEmailAddress, all of which returned the desired results for learners

## Post-review

Squash commits into discrete sets of changes
