### PR TITLE
fix: support filtering by license status again

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -373,9 +373,6 @@ class LicenseViewSet(LearnerLicenseViewSet):
 
     pagination_class = LicensePagination
 
-    filter_backends = [filters.SearchFilter]
-    search_fields = ['user_email']
-
     @property
     def active_only(self):
         return int(self.request.query_params.get('active_only', 0))


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

A previous change unintentionally prevents the `/subscriptions/<EnterpriseUuid>/licenses` API endpoint from being filtered by license status (e.g., only return activated or assigned licenses).

The 2 lines that are removed in this PR are to get the filtering back in a workable place for Admin Portal "Subscription Management" page to function properly. The search by "user_email" is already functional from the inherited `LearnerLicenseViewSet`.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
