### PR TITLE
Add python API functions to support renewals and license transfer.

### DIFF
--- a/docs/decisions/0004-renewal-processing.rst
+++ b/docs/decisions/0004-renewal-processing.rst
@@ -91,7 +91,7 @@ Which licenses in the original plan should be "copied" to new licenses in the fu
 * We'll copy the status value from the original license to the future license.  The future licenses
   will end up only being ``ASSIGNED`` or ``ACTIVATED``.
 * We'll set a new ``License.renewed_to`` field to reference the ``uuid`` field of the future license.
-  This field allow us to know the pre-renewal status of a license after the renewal
+  This field allows us to know the pre-renewal status of a license after the renewal
   is processed (e.g. was it "assigned" or "activated" before the renewal happened?).
   It will also let us directly reference an original license from a future license, or the converse.
 

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -1,12 +1,18 @@
 """
 Python APIs exposed by the Subscriptions app to other in-process apps.
 """
+from datetime import datetime
+
+from django.db import transaction
+
 from ..api.tasks import (
     revoke_course_enrollments_for_user_task,
     send_revocation_cap_notification_email_task,
 )
-from .constants import ACTIVATED, ASSIGNED
+from .constants import ACTIVATED, ASSIGNED, UNASSIGNED, LicenseTypesToRenew
 from .exceptions import LicenseRevocationError
+from .models import License, SubscriptionPlan, SubscriptionPlanRenewal
+from .utils import localized_datetime_from_date, localized_utcnow
 
 
 def revoke_license(user_license):
@@ -56,3 +62,160 @@ def revoke_license(user_license):
     user_license.revoke()
     # Create new license to add to the unassigned license pool
     user_license.subscription_plan.increase_num_licenses(1)
+
+
+class RenewalProcessingError(Exception):
+    """
+    An Exception indicating that a SubscriptionPlanRenewal
+    cannot be processed.
+    """
+
+
+def renew_subscription(subscription_plan_renewal):
+    """
+    Renew the subscription plan.
+    """
+    original_plan = subscription_plan_renewal.prior_subscription_plan
+    original_licenses = _original_licenses_to_copy(
+        original_plan,
+        subscription_plan_renewal.license_types_to_copy,
+    )
+
+    if subscription_plan_renewal.number_of_licenses < len(original_licenses):
+        raise RenewalProcessingError("Cannot renew for fewer than the number of original activated licenses.")
+
+    future_plan = subscription_plan_renewal.renewed_subscription_plan
+    if not future_plan:
+        # create the renewed plan
+        future_plan = SubscriptionPlan(
+            title=subscription_plan_renewal.get_renewed_plan_title(),
+            start_date=subscription_plan_renewal.effective_date,
+            expiration_date=subscription_plan_renewal.renewed_expiration_date,
+            enterprise_catalog_uuid=original_plan.enterprise_catalog_uuid,
+            customer_agreement=original_plan.customer_agreement,
+            is_active=original_plan.is_active,
+            netsuite_product_id=original_plan.netsuite_product_id,
+            salesforce_opportunity_id=subscription_plan_renewal.salesforce_opportunity_id,
+        )
+
+    # When creating SubscriptionPlans in Django admin, we create enough
+    # Licenses associated with it to satisfy the "num_licenses" form field.
+    # If a user enters a non-zero number in this field while setting up a new
+    # SubscriptionPlanRenewal (i.e. so that there's an existant plan to renew
+    # into), we'll have to modify existing Licenses in the renewed plan.
+    licenses_for_renewal = list(future_plan.licenses.all())
+
+    # Are there any licenses in the renewed plan that aren't UNASSIGNED?
+    # because there shouldn't be
+    if any([_license.status != UNASSIGNED for _license in licenses_for_renewal]):
+        raise RenewalProcessingError(
+            "Renewal can't be processed; there are existing licenses "
+            "in the renewed plan that are activated/assigned/revoked."
+        )
+
+    if len(licenses_for_renewal) > subscription_plan_renewal.number_of_licenses:
+        raise RenewalProcessingError("More licenses exist than were requested to be renewed.")
+
+    with transaction.atomic():
+        future_plan.save()
+        future_plan.increase_num_licenses(
+            subscription_plan_renewal.number_of_licenses - future_plan.num_licenses
+        )
+
+        _renew_all_licenses(
+            original_licenses,
+            future_plan,
+        )
+
+        subscription_plan_renewal.renewed_subscription_plan = future_plan
+        subscription_plan_renewal.processed = True
+        subscription_plan_renewal.processed_datetime = localized_utcnow()
+        subscription_plan_renewal.save()
+
+
+def _renew_all_licenses(original_licenses, future_plan):
+    """
+    We assume at this point that the future plan has at least as many licenses
+    as the number of licenses in the original plan.  Does a bulk update of
+    the renewed licenses.
+    """
+    future_licenses = []
+
+    for original_license, future_license in zip(original_licenses, future_plan.licenses.all()):
+        future_license.status = original_license.status
+        future_license.user_email = original_license.user_email
+        future_license.lms_user_id = original_license.lms_user_id
+        future_license.assigned_date = localized_utcnow()
+        if original_license.status == ACTIVATED:
+            future_license.activation_date = localized_datetime_from_date(future_plan.start_date)
+
+        future_licenses.append(future_license)
+
+        original_license.renewed_to = future_license
+
+    License.bulk_update(
+        future_licenses,
+        ['status', 'user_email', 'lms_user_id', 'activation_date', 'assigned_date'],
+    )
+    License.bulk_update(
+        original_licenses,
+        ['renewed_to'],
+    )
+
+
+def _original_licenses_to_copy(original_plan, license_types_to_copy):
+    """
+    Returns a list of licenses to copy from an original plan to
+    a future plan as part of the renewal process.
+    """
+    if license_types_to_copy == LicenseTypesToRenew.NOTHING:
+        return[]
+
+    if license_types_to_copy == LicenseTypesToRenew.ASSIGNED_AND_ACTIVATED:
+        license_status_kwargs = {'status__in': (ASSIGNED, ACTIVATED)}
+    elif license_types_to_copy == LicenseTypesToRenew.ACTIVATED:
+        license_status_kwargs = {'status': ACTIVATED}
+
+    return list(original_plan.licenses.filter(**license_status_kwargs))
+
+
+class UnprocessableSubscriptionPlanExpirationError(Exception):
+    """
+    An exception indicating that a subscription plan's
+    expiration cannot be processed.
+    """
+
+
+def expire_plan_post_renewal(subscription_plan):
+    """
+    Expires an old plan and marks its associated licenses
+    as transferred.
+
+    The original license can't be marked as transferred until after the original
+    plan expires.  So we'll need a management command to periodically look
+    through expired plans, see if they were renewed, and update the
+    status of the expired plan's (previously) active licenses.
+    """
+    if subscription_plan.expiration_processed:
+        raise UnprocessableSubscriptionPlanExpirationError(
+            "Cannot expire {}. The plan's expiration is already marked as processed.".format(subscription_plan)
+        )
+
+    if localized_datetime_from_date(subscription_plan.expiration_date) > localized_utcnow():
+        raise UnprocessableSubscriptionPlanExpirationError(
+            "Cannot expire {}. The plan's expiration date is in the future.".format(subscription_plan)
+        )
+
+    renewal = subscription_plan.get_renewal()
+    if not renewal:
+        raise UnprocessableSubscriptionPlanExpirationError(
+            "Cannot expire {}. The plan has no associated renewal record.".format(subscription_plan)
+        )
+
+    if not renewal.processed:
+        raise UnprocessableSubscriptionPlanExpirationError(
+            "Cannot expire {}. The plan's renewal has not been processed.".format(subscription_plan)
+        )
+
+    subscription_plan.expiration_processed = True
+    subscription_plan.save()

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -526,6 +526,14 @@ class SubscriptionPlanRenewal(TimeStampedModel):
         verbose_name = _("Subscription Plan Renewal")
         verbose_name_plural = _("Subscription Plan Renewals")
 
+    def get_renewed_plan_title(self):
+        if self.renewed_plan_title:
+            return self.renewed_plan_title
+        return '{prior_title} - Renewal {activation_year}'.format(
+            prior_title=self.prior_subscription_plan.title,
+            activation_year=self.effective_date.year,
+        )
+
     def __str__(self):
         """
         Return human-readable string representation.

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -1,0 +1,242 @@
+from datetime import datetime, timedelta
+from unittest import mock
+
+import ddt
+import freezegun
+from django.test import TestCase
+from pytz import UTC
+
+from license_manager.apps.subscriptions import api, constants, utils
+from license_manager.apps.subscriptions.tests.factories import (
+    LicenseFactory,
+    SubscriptionPlanFactory,
+    SubscriptionPlanRenewalFactory,
+)
+
+
+NOW = utils.localized_utcnow()
+
+
+class PostRenewalExpirationTests(TestCase):
+    """
+    Tests for the expiration of subscription plans
+    that have been renewed.
+    """
+    def test_no_action_for_previously_processed_expiration(self):
+        plan = SubscriptionPlanFactory(
+            expiration_date=utils.localized_utcnow() - timedelta(days=30),
+            expiration_processed=True,
+        )
+
+        expected_message = "The plan's expiration is already marked as processed."
+        with self.assertRaisesRegex(api.UnprocessableSubscriptionPlanExpirationError, expected_message):
+            api.expire_plan_post_renewal(plan)
+
+    def test_no_action_for_unexpired_subscription(self):
+        unexpired_plan = SubscriptionPlanFactory(
+            expiration_date=utils.localized_utcnow() + timedelta(days=30),
+            expiration_processed=False,
+        )
+
+        expected_message = "The plan's expiration date is in the future."
+        with self.assertRaisesRegex(api.UnprocessableSubscriptionPlanExpirationError, expected_message):
+            api.expire_plan_post_renewal(unexpired_plan)
+
+    def test_no_action_when_no_associated_renewal(self):
+        expired_plan = SubscriptionPlanFactory(
+            expiration_date=utils.localized_utcnow() - timedelta(days=30),
+            expiration_processed=False,
+        )
+        LicenseFactory.create_batch(
+            5,
+            subscription_plan=expired_plan,
+            status=constants.ASSIGNED,
+        )
+
+        expected_message = "The plan has no associated renewal record."
+        with self.assertRaisesRegex(api.UnprocessableSubscriptionPlanExpirationError, expected_message):
+            api.expire_plan_post_renewal(expired_plan)
+
+    def test_no_action_when_renewal_is_not_processed(self):
+        expired_plan = SubscriptionPlanFactory(
+            expiration_date=utils.localized_utcnow() - timedelta(days=30),
+            expiration_processed=False,
+        )
+        LicenseFactory.create_batch(
+            5,
+            subscription_plan=expired_plan,
+            status=constants.ASSIGNED,
+        )
+        SubscriptionPlanRenewalFactory.create(
+            number_of_licenses=5,
+            prior_subscription_plan=expired_plan,
+            processed=False,
+        )
+
+        expected_message = "The plan's renewal has not been processed."
+        with self.assertRaisesRegex(api.UnprocessableSubscriptionPlanExpirationError, expected_message):
+            api.expire_plan_post_renewal(expired_plan)
+
+    def test_expiration_processed_and_licenses_transferred(self):
+        expired_plan = SubscriptionPlanFactory(
+            expiration_date=utils.localized_utcnow() - timedelta(days=30),
+            expiration_processed=False,
+        )
+        LicenseFactory.create_batch(
+            5,
+            subscription_plan=expired_plan,
+            status=constants.ASSIGNED,
+        )
+        SubscriptionPlanRenewalFactory.create(
+            number_of_licenses=5,
+            prior_subscription_plan=expired_plan,
+            processed=True,
+        )
+
+        api.expire_plan_post_renewal(expired_plan)
+
+        self.assertTrue(expired_plan.expiration_processed)
+
+
+class RenewalProcessingTests(TestCase):
+    """
+    Tests for the processing of a SubscriptionPlanRenewal.
+    """
+    def test_cannot_renew_for_fewer_licenses(self):
+        prior_plan = SubscriptionPlanFactory()
+        LicenseFactory.create_batch(
+            5,
+            subscription_plan=prior_plan,
+            status=constants.ACTIVATED,
+        )
+        renewal = SubscriptionPlanRenewalFactory(
+            number_of_licenses=2,
+            prior_subscription_plan=prior_plan,
+        )
+
+        expected_message = 'Cannot renew for fewer than the number of original activated licenses.'
+        with self.assertRaisesRegex(api.RenewalProcessingError, expected_message):
+            api.renew_subscription(renewal)
+
+    def test_cannot_renew_with_existing_assigned_future_licenses(self):
+        future_plan = SubscriptionPlanFactory()
+        LicenseFactory.create_batch(
+            5,
+            subscription_plan=future_plan,
+            status=constants.ACTIVATED,
+        )
+        renewal = SubscriptionPlanRenewalFactory(
+            renewed_subscription_plan=future_plan,
+            number_of_licenses=20,
+        )
+
+        expected_message = 'there are existing licenses in the renewed plan that are activated'
+        with self.assertRaisesRegex(api.RenewalProcessingError, expected_message):
+            api.renew_subscription(renewal)
+
+    def test_cannot_renew_too_many_existing_unassigned_licenses(self):
+        future_plan = SubscriptionPlanFactory()
+        LicenseFactory.create_batch(
+            50,
+            subscription_plan=future_plan,
+            status=constants.UNASSIGNED,
+        )
+        renewal = SubscriptionPlanRenewalFactory(
+            renewed_subscription_plan=future_plan,
+            number_of_licenses=20,
+        )
+
+        expected_message = 'More licenses exist than were requested to be renewed'
+        with self.assertRaisesRegex(api.RenewalProcessingError, expected_message):
+            api.renew_subscription(renewal)
+
+    def _assert_all_licenses_renewed(self, future_plan):
+        """
+        Helper to assert that future license fields are updated with expected values.
+        """
+        expected_activation_datetime = utils.localized_datetime_from_date(future_plan.start_date)
+
+        future_licenses = future_plan.licenses.filter(
+            status__in=(constants.ASSIGNED, constants.ACTIVATED)
+        )
+        for future_license in future_licenses:
+            original_license = future_license.renewed_from
+
+            self.assertEqual(future_license.status, original_license.status)
+            self.assertEqual(future_license.user_email, original_license.user_email)
+            self.assertEqual(future_license.lms_user_id, original_license.lms_user_id)
+            if original_license.status == constants.ACTIVATED:
+                self.assertEqual(future_license.activation_date, expected_activation_datetime)
+            self.assertEqual(future_license.assigned_date, NOW)
+
+    def test_renewal_processed_with_no_existing_future_plan(self):
+        prior_plan = SubscriptionPlanFactory()
+        original_activated_licenses = [
+            LicenseFactory.create(
+                subscription_plan=prior_plan,
+                status=constants.ACTIVATED,
+                user_email='activated_user_{}@example.com'.format(i)
+            ) for i in range(5)
+        ]
+        original_assigned_licenses = [
+            LicenseFactory.create(
+                subscription_plan=prior_plan,
+                status=constants.ASSIGNED,
+                user_email='assigned_user_{}@example.com'.format(i)
+            ) for i in range(5)
+        ]
+        original_licenses = original_activated_licenses + original_assigned_licenses
+
+        renewal = SubscriptionPlanRenewalFactory(
+            prior_subscription_plan=prior_plan,
+            number_of_licenses=10,
+            license_types_to_copy=constants.LicenseTypesToRenew.ASSIGNED_AND_ACTIVATED
+        )
+
+        with freezegun.freeze_time(NOW):
+            api.renew_subscription(renewal)
+
+        renewal.refresh_from_db()
+        future_plan = renewal.renewed_subscription_plan
+        self.assertTrue(renewal.processed)
+        self.assertEqual(renewal.processed_datetime, NOW)
+        self.assertEqual(future_plan.num_licenses, renewal.number_of_licenses)
+        self._assert_all_licenses_renewed(future_plan)
+
+    def test_renewal_processed_with_existing_future_plan(self):
+        prior_plan = SubscriptionPlanFactory()
+        original_licenses = [
+            LicenseFactory.create(
+                subscription_plan=prior_plan,
+                status=constants.ACTIVATED,
+                user_email='activated_user_{}@example.com'.format(i)
+            ) for i in range(5)
+        ]
+
+        # create some revoked original licenses that should not be renewed
+        LicenseFactory.create_batch(
+            67,
+            subscription_plan=prior_plan,
+            status=constants.REVOKED,
+        )
+
+        future_plan = SubscriptionPlanFactory()
+        LicenseFactory.create_batch(
+            10,
+            subscription_plan=future_plan,
+            status=constants.UNASSIGNED,
+        )
+        renewal = SubscriptionPlanRenewalFactory(
+            prior_subscription_plan=prior_plan,
+            renewed_subscription_plan=future_plan,
+            number_of_licenses=10,
+        )
+
+        with freezegun.freeze_time(NOW):
+            api.renew_subscription(renewal)
+
+        future_plan.refresh_from_db()
+        self.assertTrue(renewal.processed)
+        self.assertEqual(renewal.processed_datetime, NOW)
+        self.assertEqual(future_plan.num_licenses, renewal.number_of_licenses)
+        self._assert_all_licenses_renewed(future_plan)

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -21,6 +21,13 @@ def localized_datetime(*args, **kwargs):
     return UTC.localize(datetime(*args, **kwargs))
 
 
+def localized_datetime_from_date(date_obj):
+    """
+    Converts a date object to a UTC-localized datetime with 0 hours, minutes, and seconds.
+    """
+    return UTC.localize(datetime.combine(date_obj, datetime.min.time()))
+
+
 def days_until(end_date):
     """
     Helper to return the number of days until the end date.


### PR DESCRIPTION
## Description

* Adds function to process a renewal record (creating new `SubscriptionPlan` and associated licenses).
* Adds function to mark an expired plan as expired and change the status of the licenses if the old plan has been renewed.
* Both of these functions are tied to Django Admin actions, allowing an internal admin to process renewals and expirations manually.

Will add in a later PR:
* Add a management command to expire any plans with an expiration date in the past (TODO)
* Add a management command to process any upcoming renewals (TODO)

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3853 and  https://openedx.atlassian.net/browse/ENT-3854

Note: I did not create a celery task to perform the renewal or post-renewal-expiration functions - we'll only ever do this from Django Admin or a jenkins job, and I think it's better left as a synchronous action.  Although we could still create a task to wrap these API functions and have the Django Admin action or mgmt command (run by jenkins, eventually) wait for the task to complete before returning - the only advantage of this is that it moves the work out of a web process and into a celery worker process.

## Testing considerations

* Create a `SubscriptionPlanRenewal` record in http://localhost:18170/admin/subscriptions/subscriptionplanrenewal/ for an existing subscription plan.
* Note that it must have as many or more licenses than the number of activated licenses in the existing plan.
* On the same Django Admin page, select your record and then pick the "Process selected renewal records" action 
![image](https://user-images.githubusercontent.com/2307986/121564790-d69b5880-c9e9-11eb-9f12-5424c04b08ce.png)
* Click "Go"
* Notice that a new plan now exists with new licenses corresponding to the licenses in the existing plan

Testing instructions for expiring the old plan:
* Do the steps above to create/process a renewal.
* In http://localhost:18170/admin/subscriptions/subscriptionplan/ find the original plan.
* Select that plan (with the checkbox on that page) and then pick the action "Process the post-renewal expiration of select records" from the action-picker.
* Click "Go".
* Notice that the plan now has `expiration_processed` set to true.

## Post-review

Squash commits into discrete sets of changes
