### PR TITLE
Bulk license revocation

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1598,12 +1598,8 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         response = self.api_client.post(request_url, request_payload)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        expected_response_payload = {
-            'error_message': 'No SubscriptionPlan identified by {} exists'.format(non_existent_uuid),
-            'status': 'failure',
-            'processed_revocations': [],
-        }
-        self.assertEqual(expected_response_payload, response.json())
+        expected_response_message = 'No SubscriptionPlan identified by {} exists'.format(non_existent_uuid)
+        self.assertEqual(expected_response_message, response.json())
         self.assertFalse(mock_revoke_license.called)
 
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')
@@ -1633,12 +1629,8 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         response = self.api_client.post(request_url, request_payload)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        expected_response_payload = {
-            'error_message': 'Plan does not have enough revocations remaining.',
-            'status': 'failure',
-            'processed_revocations': [],
-        }
-        self.assertEqual(expected_response_payload, response.json())
+        expected_response_message = 'Plan does not have enough revocations remaining.'
+        self.assertEqual(expected_response_message, response.json())
         self.assertFalse(mock_revoke_license.called)
 
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')
@@ -1668,12 +1660,7 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             "No license for email bob@example.com exists in plan "
             "{} with a status in ['activated', 'assigned']".format(self.subscription_plan.uuid)
         )
-        expected_response_payload = {
-            'error_message': expected_error_msg,
-            'status': 'failure',
-            'processed_revocations': ['alice@example.com'],
-        }
-        self.assertEqual(expected_response_payload, response.json())
+        self.assertEqual(expected_error_msg, response.json())
         mock_revoke_license.assert_called_once_with(alice_license)
 
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')
@@ -1704,12 +1691,7 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             alice_license.uuid,
             'floor is lava',
         )
-        expected_response_payload = {
-            'error_message': expected_error_msg,
-            'status': 'failure',
-            'processed_revocations': [],
-        }
-        self.assertEqual(expected_response_payload, response.json())
+        self.assertEqual(expected_error_msg, response.json())
         mock_revoke_license.assert_called_once_with(alice_license)
 
     @ddt.data(

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1449,6 +1449,10 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             'api:v1:licenses-revoke',
             kwargs={'subscription_uuid': cls.subscription_plan.uuid},
         )
+        cls.bulk_revoke_license_url = reverse(
+            'api:v1:licenses-bulk-revoke',
+            kwargs={'subscription_uuid': cls.subscription_plan.uuid},
+        )
         cls.assign_url = reverse(
             'api:v1:licenses-assign',
             kwargs={'subscription_uuid': cls.subscription_plan.uuid},
@@ -1485,7 +1489,10 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         mock_revoke_license.assert_called_once_with(original_license)
-        self.assertEqual(response.json(), 'Revocation fail')
+        expected_msg = 'Attempted license revocation FAILED for License [{}]. Reason: Revocation fail'.format(
+            original_license.uuid,
+        )
+        self.assertEqual(response.json(), expected_msg)
 
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')
     def test_revoke_no_license(self, mock_revoke_license):
@@ -1495,6 +1502,12 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         response = self.api_client.post(self.revoke_license_url, {'user_email': self.test_email})
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+        expected_msg = 'No license for email {} exists in plan {} with a status in {}'.format(
+            self.test_email,
+            self.subscription_plan.uuid,
+            [constants.ACTIVATED, constants.ASSIGNED],
+        )
+        self.assertEqual(response.json(), expected_msg)
         self.assertFalse(mock_revoke_license.called)
 
     @ddt.data(True, False)
@@ -1512,6 +1525,192 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         self.assertFalse(mock_revoke_license.called)
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_happy_path(self, mock_revoke_license):
+        """
+        Test that we can revoke multiple licenses from the bulk_revoke action.
+        """
+        self._setup_request_jwt(user=self.user)
+        alice_license = LicenseFactory.create(user_email='alice@example.com', status=constants.ACTIVATED)
+        bob_license = LicenseFactory.create(user_email='bob@example.com', status=constants.ACTIVATED)
+        self.subscription_plan.licenses.set([alice_license, bob_license])
+
+        request_payload = {
+            'user_emails': [
+                'alice@example.com',
+                'bob@example.com',
+            ],
+        }
+        response = self.api_client.post(self.bulk_revoke_license_url, request_payload)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_revoke_license.assert_has_calls([
+            mock.call(alice_license),
+            mock.call(bob_license),
+        ])
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_no_valid_subscription_plan(self, mock_revoke_license):
+        """
+        Test that calls to bulk_revoke fail with a 403 if no valid subscription plan uuid
+        is provided, for requests made by a regular user.  A 403 is expected because our
+        test user has an admin role assigned for a specific, existing enterprise, but (obviously)
+        there is no role assignment for an enterprise/subscription plan that does not exist.
+        """
+        self._setup_request_jwt(user=self.user)
+
+        request_payload = {
+            'user_emails': [
+                'alice@example.com',
+                'bob@example.com',
+            ],
+        }
+        non_existent_uuid = uuid4()
+        request_url = reverse(
+            'api:v1:licenses-bulk-revoke',
+            kwargs={'subscription_uuid': non_existent_uuid},
+        )
+        response = self.api_client.post(request_url, request_payload)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.assertFalse(mock_revoke_license.called)
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_no_valid_subscription_plan_superuser(self, mock_revoke_license):
+        """
+        Test that calls to bulk_revoke fail with a 404 if no valid subscription plan uuid
+        is provided, for requests made by a superuser.
+        """
+        self._setup_request_jwt(user=self.super_user)
+
+        request_payload = {
+            'user_emails': [
+                'alice@example.com',
+                'bob@example.com',
+            ],
+        }
+        non_existent_uuid = uuid4()
+        request_url = reverse(
+            'api:v1:licenses-bulk-revoke',
+            kwargs={'subscription_uuid': non_existent_uuid},
+        )
+        response = self.api_client.post(request_url, request_payload)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        expected_response_payload = {
+            'error_message': 'No SubscriptionPlan identified by {} exists'.format(non_existent_uuid),
+            'status': 'failure',
+            'processed_revocations': [],
+        }
+        self.assertEqual(expected_response_payload, response.json())
+        self.assertFalse(mock_revoke_license.called)
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_not_enough_revocations_remaining(self, mock_revoke_license):
+        """
+        Test that calls to bulk_revoke fail with a 400 if the plan does not have enough
+        revocations remaining.
+        """
+        plan = SubscriptionPlanFactory.create(
+            is_revocation_cap_enabled=True,
+            revoke_max_percentage=0,
+        )
+        _ = LicenseFactory.create(
+            subscription_plan=plan,
+            user_email='alice@example.com',
+            status=constants.ACTIVATED,
+        )
+
+        self._setup_request_jwt(self.user, plan.enterprise_customer_uuid)
+        request_payload = {
+            'user_emails': ['alice@example.com'],
+        }
+        request_url = reverse(
+            'api:v1:licenses-bulk-revoke',
+            kwargs={'subscription_uuid': plan.uuid},
+        )
+        response = self.api_client.post(request_url, request_payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        expected_response_payload = {
+            'error_message': 'Plan does not have enough revocations remaining.',
+            'status': 'failure',
+            'processed_revocations': [],
+        }
+        self.assertEqual(expected_response_payload, response.json())
+        self.assertFalse(mock_revoke_license.called)
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_license_not_found(self, mock_revoke_license):
+        """
+        Test that calls to bulk_revoke fail with a 404 if the plan does not have enough
+        revocations remaining.
+        """
+        self._setup_request_jwt(self.user)
+
+        alice_license = LicenseFactory.create(
+            subscription_plan=self.subscription_plan,
+            user_email='alice@example.com',
+            status=constants.ACTIVATED,
+        )
+
+        request_payload = {
+            'user_emails': [
+                'alice@example.com',
+                'bob@example.com',  # There's no license for bob
+            ],
+        }
+        response = self.api_client.post(self.bulk_revoke_license_url, request_payload)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        expected_error_msg = (
+            "No license for email bob@example.com exists in plan "
+            "{} with a status in ['activated', 'assigned']".format(self.subscription_plan.uuid)
+        )
+        expected_response_payload = {
+            'error_message': expected_error_msg,
+            'status': 'failure',
+            'processed_revocations': ['alice@example.com'],
+        }
+        self.assertEqual(expected_response_payload, response.json())
+        mock_revoke_license.assert_called_once_with(alice_license)
+
+    @mock.patch('license_manager.apps.api.v1.views.revoke_license')
+    def test_bulk_revoke_license_revocation_error(self, mock_revoke_license):
+        """
+        Test that calls to bulk_revoke fail with a 400 if some error occurred during
+        the actual revocation process.
+        """
+        self._setup_request_jwt(self.user)
+
+        alice_license = LicenseFactory.create(
+            subscription_plan=self.subscription_plan,
+            user_email='alice@example.com',
+            status=constants.ACTIVATED,
+        )
+
+        mock_revoke_license.side_effect = LicenseRevocationError(alice_license.uuid, 'floor is lava')
+
+        request_payload = {
+            'user_emails': [
+                'alice@example.com',
+            ],
+        }
+        response = self.api_client.post(self.bulk_revoke_license_url, request_payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        expected_error_msg = "Attempted license revocation FAILED for License [{}]. Reason: {}".format(
+            alice_license.uuid,
+            'floor is lava',
+        )
+        expected_response_payload = {
+            'error_message': expected_error_msg,
+            'status': 'failure',
+            'processed_revocations': [],
+        }
+        self.assertEqual(expected_response_payload, response.json())
+        mock_revoke_license.assert_called_once_with(alice_license)
 
     @ddt.data(
         {'is_revocation_cap_enabled': True},

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -1,6 +1,7 @@
 """
 Python APIs exposed by the Subscriptions app to other in-process apps.
 """
+import logging
 from datetime import datetime
 
 from django.db import transaction
@@ -13,6 +14,9 @@ from .constants import ACTIVATED, ASSIGNED, UNASSIGNED, LicenseTypesToRenew
 from .exceptions import LicenseRevocationError
 from .models import License, SubscriptionPlan, SubscriptionPlanRenewal
 from .utils import localized_datetime_from_date, localized_utcnow
+
+
+logger = logging.getLogger(__name__)
 
 
 def revoke_license(user_license):
@@ -60,6 +64,7 @@ def revoke_license(user_license):
 
     # Revoke the license
     user_license.revoke()
+    logger.info('License {} has been revoked'.format(user_license.uuid))
     # Create new license to add to the unassigned license pool
     user_license.subscription_plan.increase_num_licenses(1)
 

--- a/license_manager/apps/subscriptions/exceptions.py
+++ b/license_manager/apps/subscriptions/exceptions.py
@@ -20,3 +20,21 @@ class LicenseRevocationError(Exception):
             self.license_uuid,
             self.failure_reason,
         )
+
+
+class LicenseNotFoundError(Exception):
+    """
+    Raised when no license exists for a given (email, subscription_plan, statuses) combination.
+    """
+    def __init__(self, user_email, subscription_plan, license_statuses):
+        super().__init__()
+        self.user_email = user_email
+        self.subscription_plan = subscription_plan
+        self.license_statuses = license_statuses
+
+    def __str__(self):
+        return "No license for email {} exists in plan {} with a status in {}".format(
+            self.user_email,
+            self.subscription_plan.uuid,
+            self.license_statuses,
+        )

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1,4 +1,4 @@
-from math import ceil
+from math import ceil, inf
 from operator import itemgetter
 from uuid import uuid4
 
@@ -243,8 +243,7 @@ class SubscriptionPlan(TimeStampedModel):
     @property
     def has_revocations_remaining(self):
         """
-        Gets whether there are any revocations remaining for this SubscriptionPlan. If the revocation cap is enabled,
-        returns whether there is at least one revocation remaining.
+        Returns true if there are any revocations remaining for this SubscriptionPlan, false otherwise.
         """
         if not self.is_revocation_cap_enabled:
             return True
@@ -253,12 +252,14 @@ class SubscriptionPlan(TimeStampedModel):
     @property
     def num_revocations_remaining(self):
         """
-        Gets the number of revocations that can still be made against this SubscriptionPlan. The
-        revocation cap must be enabled for a count that decrements per revocation. Note: This value
-        is rounded up.
+        When the revocation cap is enabled for this plan,
+        returns the number of revocations that can still be made against this plan.
 
-        When the revocation cap is not enabled for this SubscriptionPlan, ``None``is returned.
+        When the revocation cap is not enabled for this plan, positive infinity is returned.
         """
+        if not self.is_revocation_cap_enabled:
+            return inf
+
         num_revocations_allowed = ceil(self.num_licenses * (self.revoke_max_percentage / 100))
         return num_revocations_allowed - self.num_revocations_applied
     num_revocations_remaining.fget.short_description = "Number of Revocations Remaining"


### PR DESCRIPTION
## Description

Implements a `bulk_revoke` action endpoint.  This endpoint revokes one or more licenses in a subscription plan,
given a list of email addresses with which the licenses are associated.

Example request:
```
POST /api/v1/subscriptions/{subscription_uuid}/licenses/bulk_revoke/
```
Example Request payload:
```
          {
            "user_emails": [
              "alice@example.com",
              "carol@example.com"
            ]
          }
```

https://openedx.atlassian.net/browse/ENT-3955

## Testing instructions
* Set up a subscription plan with some assigned or activated licenses - use the admin-portal to make it easy on yourself.
* [Optional] You can use the license-manager Django Admin site to mark licenses as activated: http://localhost:18170/admin/subscriptions/license/?status__exact=assigned
* Use Postman or curl to make a request to the URL provided above, making sure to include in your payload email addresses for licenses you want to revoke.

## Before Request
![image](https://user-images.githubusercontent.com/2307986/125106878-27b47000-e0ae-11eb-8604-e01eb96ba57d.png)

## Making the Request
![image](https://user-images.githubusercontent.com/2307986/125106989-431f7b00-e0ae-11eb-8afd-fd7fc6ad9a98.png)

## After the request
![image](https://user-images.githubusercontent.com/2307986/125107036-54688780-e0ae-11eb-9421-74bcc160cd94.png)
