### PR TITLE
refactor: makes it clearer which license viewsets are meant for plan admins.

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -196,6 +196,7 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     reply_to_email = get_enterprise_reply_to_email(enterprise_customer)
 
     try:
+        # pylint: disable=too-many-function-args
         send_revocation_cap_notification_email(
             subscription_plan,
             enterprise_name,

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -78,13 +78,13 @@ subscription_router = NestedSimpleRouter(
 )
 subscription_router.register(
     r'licenses',
-    views.LicenseViewSet,
+    views.LicenseAdminViewSet,
     basename='licenses',
 )
 
 subscription_router.register(
     r'license(?![^\/])',
-    views.LearnerLicenseViewSet,
+    views.BaseLicenseViewSet,
     basename='license',
 )
 


### PR DESCRIPTION
## Description

Renames the confusingly-named `LearnerLicenseViewset` to `BaseLicenseViewset` and `LicenseViewset` to `LicenseAdminViewSet`.
Doesn't change any routes or functionality.
Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4708
