### PR TITLE
Remove unused parameter being passed

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -202,7 +202,6 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
             enterprise_name,
             enterprise_sender_alias,
             reply_to_email,
-            subscription_plan_type,
         )
     except SMTPException:
         logger.error('Revocation cap notification email sending received an exception.', exc_info=True)

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -154,4 +154,8 @@ class LicenseManagerCeleryTaskTests(TestCase):
         Tests that the onboarding email task sends the email
         """
         tasks.send_onboarding_email_task(self.enterprise_uuid, self.user_email, self.subscription_plan_type)
-        mock_send_onboarding_email.assert_called_with(self.enterprise_uuid, self.user_email, self.subscription_plan_type)
+        mock_send_onboarding_email.assert_called_with(
+            self.enterprise_uuid,
+            self.user_email,
+            self.subscription_plan_type,
+        )


### PR DESCRIPTION
**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

## Description

Removal of unused parameter not caught in [this PR](https://github.com/edx/license-manager/pull/234/files), also correcting a "line too long" warning. 

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
