### PR TITLE
feat: Add memoization by <subs_plan_uuid>__<course_key> to avoid extraneous Catalog server calls

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -933,6 +933,7 @@ class LicenseViewSetActionMixin:
     """
     Mixin of common functionality for LicenseViewSet action tests.
     """
+
     def setUp(self):
         super().setUp()
 
@@ -2264,6 +2265,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyViewTests(LicenseViewTestMixin, Test
             expected_enterprise_enrollment_request_options
         )
         mock_contains_content.assert_called_with([self.course_key])
+        assert mock_contains_content.call_count == 1
 
     @mock.patch('license_manager.apps.api.v1.views.SubscriptionPlan.contains_content')
     @mock.patch('license_manager.apps.api_client.enterprise.EnterpriseApiClient.bulk_enroll_enterprise_learners')

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -901,17 +901,16 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
         """
         Helper function to check that each of the provided learners has a valid subscriptions license for the provided
         courses.
-        """
-        missing_subscriptions = {}
-        licensed_enrollment_info = []
 
-        '''
-        This map will track:
+        Uses a map to track:
             <plan_key>: <plan_contains_course>
         where, plan_key = {subscription_plan.uuid}_{course_key}
         This will help us memoize the value of the subscription_plan.contains_content([course_key])
         to avoid repeated requests to the enterprise catalog endpoint for the same information
-        '''
+        """
+        missing_subscriptions = {}
+        licensed_enrollment_info = []
+
         subscription_plan_course_map = {}
 
         for email in set(self.requested_user_emails):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -926,7 +926,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                 key=lambda user_license: user_license.subscription_plan.expiration_date,
                 reverse=True,
             )
-            for course_key in self.requested_course_run_keys:
+            for course_key in set(self.requested_course_run_keys):
                 plan_found = False
                 for user_license in ordered_licenses_by_expiration:
                     subscription_plan = user_license.subscription_plan

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -934,8 +934,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                     if plan_key in subscription_plan_course_map:
                         plan_contains_content = subscription_plan_course_map.get(plan_key)
                     else:
-                        plan_contains_content = subscription_plan.contains_content([course_key])
-                        subscription_plan_course_map[plan_key] = plan_contains_content
+                        subscription_plan_course_map[plan_key] = subscription_plan.contains_content([course_key])
 
                     if plan_contains_content:
                         licensed_enrollment_info.append({

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -914,7 +914,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
         '''
         subscription_plan_course_map = {}
 
-        for email in self.requested_user_emails:
+        for email in set(self.requested_user_emails):
             filtered_licenses = License.objects.filter(
                 subscription_plan__in=customer_agreement.subscriptions.all(),
                 user_email=email,
@@ -934,7 +934,8 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                     if plan_key in subscription_plan_course_map:
                         plan_contains_content = subscription_plan_course_map.get(plan_key)
                     else:
-                        subscription_plan_course_map[plan_key] = subscription_plan.contains_content([course_key])
+                        plan_contains_content = subscription_plan.contains_content([course_key])
+                        subscription_plan_course_map[plan_key] = plan_contains_content
 
                     if plan_contains_content:
                         licensed_enrollment_info.append({
@@ -967,7 +968,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                 course_run_keys: ['course-v1:edX+DemoX+Demo_Course', 'course-v2:edX+The+Second+DemoX+Demo_Course', ... ]
             - emails (string): A single string of multiple learner emails separated with a newline character
             Example:
-                emails: 'testuser@abc.com\\nlearner@example.com\\newuser@wow.com'
+                emails: ['testuser@abc.com','learner@example.com','newuser@wow.com']
             - enterprise_customer_uuid (string): the uuid of the associated enterprise customer provided as a query
             params.
         Expected Return Values:

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -933,11 +933,9 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
                     plan_key = f'{subscription_plan.uuid}_{course_key}'
                     if plan_key in subscription_plan_course_map:
                         plan_contains_content = subscription_plan_course_map.get(plan_key)
-                        logger.info('Plan with uuid: %s already contains course with key: %s', subscription_plan.uuid, course_key)
                     else:
                         plan_contains_content = subscription_plan.contains_content([course_key])
                         subscription_plan_course_map[plan_key] = plan_contains_content
-                        logger.info('Plan with uuid: %s does not contain course with key: %s. Adding...', subscription_plan.uuid, course_key)
 
                     if plan_contains_content:
                         licensed_enrollment_info.append({


### PR DESCRIPTION
### PR contains

- uniqify user emails, and course keys before looping over them
- avoid extraneous calls to catalog by memoizing using `{subs_plan_uuid}__{course_run_key}`

### Problem: 

From the bulk_license_enroll endpoint, Currently we call the catalog endpoint this many times

`Learners x Course keys x num_user_licenses_in_plan`

This is not necessary since subs plan + course_key combination only needs to be queried once. 

This is likely also leading to the hammering of the catalog service I noticed when I scaled up course count from 4 to 5 (keeping learner count at 25), in staging. So we got 500s or CORS errors.

The number of requests with the refactor (to use a dict to memoize by <subsplanUUid__course_key>, contained in this PR will now instead scale only by course count. Since our subs plan is always going to be one in quantity :)

So new scale factor:

`num_requests_expected = num_courses x num_subs_plan (=1 always for now)`

This will significantly reduce no. of calls and I am hoping will help scale up bulk enrollment a few notches (let's see how far we can get)

### Testing notes

Locally watched Enterprise catalog server while enrolling 3 courses x N learners and verified that only ever got 3 requests to this endpoint, regardless of N.

```
nterprise.catalog.app | [2021-07-13 18:22:12 +0000] [40] [INFO] GET /api/v1/enterprise-catalogs/d471e5c0-ef50-4066-b32c-298d7eb159b7/contains_content_items/
enterprise.catalog.app | [2021-07-13 18:22:12 +0000] [38] [INFO] GET /api/v1/enterprise-catalogs/d471e5c0-ef50-4066-b32c-298d7eb159b7/contains_content_items/
enterprise.catalog.app | [2021-07-13 18:22:12 +0000] [40] [INFO] GET /api/v1/enterprise-catalogs/d471e5c0-ef50-4066-b32c-298d7eb159b7/contains_content_items/
```

instead of the prior change was 6. This difference should be much higher / pronounced once we go to higher learner counts.

JIRA: ENT-4735

**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
automatically via Github Actions.

