### PR TITLE
refactor: make the assign() viewset action more readable, wrap the writes in a transaction

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -196,7 +196,6 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
     reply_to_email = get_enterprise_reply_to_email(enterprise_customer)
 
     try:
-        # pylint: disable=too-many-function-args
         send_revocation_cap_notification_email(
             subscription_plan,
             enterprise_name,


### PR DESCRIPTION
## Description
Little pre-factoring before tackling the true AC of the linked ticket below:
* Refactors the `assign()` action to be more readable.
* Wraps all the license assignment DB writes in a transaction
* Adds a unit test to assert that assignment is atomic.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3876

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
