### PR TITLE
Add a '-j 0' argument to pylint so that it will use the total number of available CPUs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-**WARNING**: Please run `make lint` locally, as this repository is currently blocked from running pylint
-automatically via Github Actions.
-
 ## Description
 
 Description of changes made

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ style: ## run Python style checker
 	pycodestyle license_manager *.py
 
 lint: ## run Python code linting
-	pylint --rcfile=pylintrc license_manager *.py
+	pylint -j 0 --rcfile=pylintrc license_manager/ *.py
 
 quality: style isort_check lint ## check code style and import sorting, then lint
 

--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -188,7 +188,6 @@ def send_revocation_cap_notification_email_task(subscription_uuid):
         subscription_uuid (str): UUID (string representation) of the subscription that has reached its recovation cap.
     """
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
-    subscription_plan_type = subscription_plan.plan_type.id
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
     enterprise_name = enterprise_customer.get('name')

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -585,6 +585,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         num_potential_unassigned_licenses = num_unassigned_licenses + revoked_licenses_for_assignment.count()
         return len(user_emails) <= num_potential_unassigned_licenses, num_potential_unassigned_licenses
 
+    # pylint: disable=unused-argument
     def _reassign_revoked_licenses(self, subscription_plan, revoked_licenses_for_assignment):
         """
         Flip all revoked licenses that were associated with emails that we are assigning to unassigned,

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -2,7 +2,6 @@
 Python APIs exposed by the Subscriptions app to other in-process apps.
 """
 import logging
-from datetime import datetime
 
 from django.db import transaction
 
@@ -12,7 +11,7 @@ from ..api.tasks import (
 )
 from .constants import ACTIVATED, ASSIGNED, UNASSIGNED, LicenseTypesToRenew
 from .exceptions import LicenseRevocationError
-from .models import License, SubscriptionPlan, SubscriptionPlanRenewal
+from .models import License, SubscriptionPlan
 from .utils import localized_datetime_from_date, localized_utcnow
 
 
@@ -112,7 +111,7 @@ def renew_subscription(subscription_plan_renewal):
 
     # Are there any licenses in the renewed plan that aren't UNASSIGNED?
     # because there shouldn't be
-    if any([_license.status != UNASSIGNED for _license in licenses_for_renewal]):
+    if any(_license.status != UNASSIGNED for _license in licenses_for_renewal):
         raise RenewalProcessingError(
             "Renewal can't be processed; there are existing licenses "
             "in the renewed plan that are activated/assigned/revoked."

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -189,21 +189,6 @@ class PlanEmailTemplates(models.Model):
         null=False,
     )
 
-    def __str__(self):
-        return self.label
-
-    def render_html_template(self, kwargs):
-        """
-        Render just the HTML template and return it as a string.
-        """
-        return self.render_template(mark_safe(self.html_template), kwargs)
-
-    def render_plaintext_template(self, kwargs):
-        """
-        Render just the plaintext template and return it as a string.
-        """
-        return self.render_template(self.plaintext_template, kwargs)
-
 
 class SubscriptionPlan(TimeStampedModel):
     """
@@ -720,6 +705,7 @@ class License(TimeStampedModel):
         """
         Helper to get any existing licenses this license was renewed from.
         """
+        # pylint: disable=no-member
         try:
             return self._renewed_from
         except License._renewed_from.RelatedObjectDoesNotExist:

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -9,6 +9,7 @@ from license_manager.apps.subscriptions.constants import (
 )
 
 
+# pylint: disable=no-value-for-parameter
 def localized_utcnow():
     """Helper function to return localized utcnow()."""
     return UTC.localize(datetime.utcnow())  # pylint: disable=no-value-for-parameter

--- a/validate.sh
+++ b/validate.sh
@@ -15,8 +15,8 @@ make validate_translations
 # TODO: enable pylint once we figure out mysterious AssignAttr attribute error.
 # When that's fixed, we can replace all of the below with `make validate`
 
-# make validate
-make test
-make style
-make isort_check
-make pii_check
+make validate
+# make test
+# make style
+# make isort_check
+# make pii_check


### PR DESCRIPTION
This seems to alleviate the astroid AttributeError issue, at least on my machine.
See: http://pylint.pycqa.org/en/v2.8.3/user_guide/run.html#parallel-execution

I have no idea _why_ this works - like, pylint/astroid didn't have _enough_ CPUs, so it caused an AttributeError??  Anyway, seems to work here in Github actions, too.