### PR TITLE
fix: unrevoke licenses, rather than assigning to a new license for pr…

### DIFF
--- a/docs/decisions/0005-unrevoking-licenses.rst
+++ b/docs/decisions/0005-unrevoking-licenses.rst
@@ -9,21 +9,29 @@ Accepted July 2021
 Context
 =======
 
-When a license is revoked, the current behavior transitions that license to the ``revoked`` state,
-then adds a new license to the available "pool" of licenses for the associated subscription plan.
-If an admin then re-invites that learner, the revoked license will transition to the ``unassigned`` state
-and re-enter the pool of available unassigned licenses, before grabbing an unassigned
-license from the plan's pool to assign to the learner.
-The net effect of this logic is to add an additional unassigned license for the plan, to
-which the plan is not entitled.
+When a learner's license is revoked, the current behavior transitions that license to the ``revoked`` state,
+then adds a new, unassigned license to the available "pool" of licenses for the associated subscription plan.
+The idea behind this is that revoked licenses shouldn't count against the total number of licenses allocated
+for the subscription plan (to a point - this is where a revocation cap would come into play).
+
+Currently, if an admin revokes a learner's license, and later re-assigns a license to that same learner,
+we transition the "original" (revoked) license to the ``unassigned`` state, before a different unassigned
+license from the plan's pool is assigned to the learner.  The original license thus re-enters
+the pool of available unassigned licenses.
+
+The net effect of this logic is that an additional unassigned license,
+to which the plan is not entitled, is added to the plan.
+
+The decision below describes how we will fix this defect.
 
 Decision
 ========
 
-We'll do the follow for license assignment actions that involve un-revoking a license.  For any
-to-be-assigned user email that's associated with a currently revoked license:
+When un-revoking a license for any to-be-assigned user email that's currently associated with a revoked license,
+we'll do the following:
 
-* We'll re-assign the currently revoked license to the email/user.
+* We'll re-assign the currently associated revoked license to the user email.
+* We'll set the ``lms_user_id`` to null and let it become populated during license activation (as it usually is).
 * We'll switch its status back to ``assigned``.
 * We'll set that license's ``assignment_date`` and ``last_remind_date`` to now
 * We'll set the ``revoked_date`` and ``activation_date`` to null.
@@ -38,7 +46,8 @@ while taking into account any deletions that occur due to unrevocation.  That is
 must check that:
 ``num_emails_to_assign <= total_unassigned_licenses_for_plan + revoked_licenses_for_reassignment``
 
-We'll modify the assign action to do model writes atomically.
+We'll modify the assign action to do the reads of license counts and all of the writes
+in one atomic transaction.
 
 Users for whom a licenses is unrevoked during an assign action will still receive
 assignment notifications, as net-new users would.
@@ -50,3 +59,28 @@ Consequences
   means we won't be able to see the original values (from the original assignment and/or activation of the license)
   without looking at the history table for the license model.  This history is not currently exposed
   to enterprise admins in the admin portal.
+
+Alternatives Considered
+=======================
+
+Why not assign a new unassigned license as we currently do and delete the revoked license?
+
+* License uuids are associated with enrollments in edx-enterprise for book-keeping.
+  Deleting a license means that some licensed enrollment records would have no associated
+  license record in license-manager, which would make our bookkeeping invalid.
+
+Another proposal, which prevents the need to delete any records, would be to simply wipe all data from
+license that is revoked rather than keeping the record and adding a new license to the pool.
+
+* We can't do this because we associate a license's uuid with licensed-enrollments.  If a second
+  learner came along with the same license uuid as the first user and enrolled in the same course,
+  that could violate some data constraints.
+
+If there is already a new license created when one is revoked, why not just assign
+the new license and have the revoked license stay as it is?
+
+* From a product perspective, doing this would make it appear in the admin portal
+  as if the learner has multiple licenses in the same plan.
+  From a data perspective, we have unique constraints on ``(subscription_plan, user_email)``
+  and ``(subscription_plan, lms_user_id)`` on the ``License`` model, so we can't give a user/email
+  two licenses in the same plan.

--- a/docs/decisions/0005-unrevoking-licenses.rst
+++ b/docs/decisions/0005-unrevoking-licenses.rst
@@ -1,0 +1,52 @@
+5. Unrevoking licenses
+======================
+
+Status
+======
+
+Accepted July 2021
+
+Context
+=======
+
+When a license is revoked, the current behavior transitions that license to the ``revoked`` state,
+then adds a new license to the available "pool" of licenses for the associated subscription plan.
+If an admin then re-invites that learner, the revoked license will transition to the ``unassigned`` state
+and re-enter the pool of available unassigned licenses, before grabbing an unassigned
+license from the plan's pool to assign to the learner.
+The net effect of this logic is to add an additional unassigned license for the plan, to
+which the plan is not entitled.
+
+Decision
+========
+
+We'll do the follow for license assignment actions that involve un-revoking a license.  For any
+to-be-assigned user email that's associated with a currently revoked license:
+
+* We'll re-assign the currently revoked license to the email/user.
+* We'll switch its status back to ``assigned``.
+* We'll set that license's ``assignment_date`` and ``last_remind_date`` to now
+* We'll set the ``revoked_date`` and ``activation_date`` to null.
+* The ``activation_key`` will remain the same.
+
+Furthermore, we'll now delete an existing ``unassigned`` license from the plan's pool, to account
+for the fact that we previously added an additional license to the pool during the revoke action.
+
+This means that during the assign action, before doing any license assignment, we must
+ensure that there are enough licenses in the plan's pool to assign to net-new users
+while taking into account any deletions that occur due to unrevocation.  That is, we
+must check that:
+``num_emails_to_assign <= total_unassigned_licenses_for_plan + revoked_licenses_for_reassignment``
+
+We'll modify the assign action to do model writes atomically.
+
+Users for whom a licenses is unrevoked during an assign action will still receive
+assignment notifications, as net-new users would.
+
+Consequences
+============
+
+* We're changing data about unrevoked licenses (all of the dates mentioned above), which
+  means we won't be able to see the original values (from the original assignment and/or activation of the license)
+  without looking at the history table for the license model.  This history is not currently exposed
+  to enterprise admins in the admin portal.

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1282,12 +1282,12 @@ class LicenseViewSetActionTests(LicenseViewSetActionMixin, TestCase):
 
         self.assertEqual(revoked_license.user_email, self.test_email)
         self.assertEqual(revoked_license.status, constants.ASSIGNED)
-        self.assertEqual(revoked_license.lms_user_id, 1)
+        self.assertIsNone(revoked_license.lms_user_id)
+        self.assertIsNone(revoked_license.activation_date)
+        self.assertIsNone(revoked_license.revoked_date)
         self.assertEqual(revoked_license.activation_key, original_activation_key)
         self.assertEqual(revoked_license.last_remind_date, unrevoke_timestamp)
         self.assertEqual(revoked_license.assigned_date, unrevoke_timestamp)
-        self.assertIsNone(revoked_license.activation_date)
-        self.assertIsNone(revoked_license.revoked_date)
 
         # Assert that one of the unassigned licenses went away
         self.assertEqual(

--- a/license_manager/apps/subscriptions/exceptions.py
+++ b/license_manager/apps/subscriptions/exceptions.py
@@ -3,23 +3,43 @@ Exceptions raised by functions exposed by the Subscriptions app.
 """
 
 
-class LicenseRevocationError(Exception):
+class LicenseError(Exception):
+    """
+    General exception about some license action
+    that accepts a license UUID and some failure reason.
+    """
+    action = None
 
     def __init__(self, license_uuid, failure_reason):
         """
         Arguments:
             license_uuid (uuid4): the unique identifier for a license
-            failure_reason (str): the reason for the license revocation error
+            failure_reason (str): the reason for the license-related failure
         """
         super().__init__()
         self.license_uuid = license_uuid
         self.failure_reason = failure_reason
 
     def __str__(self):
-        return "Attempted license revocation FAILED for License [{}]. Reason: {}".format(
+        return "Action: {} failed for license: {} because: {}".format(
+            self.action,
             self.license_uuid,
             self.failure_reason,
         )
+
+
+class LicenseRevocationError(LicenseError):
+    """
+    Exception raised for failed license revocations.
+    """
+    action = 'license revocation'
+
+
+class LicenseUnrevokeError(Exception):
+    """
+    Exception raised for failed license un-revocations.
+    """
+    action = 'license un-revocation'
 
 
 class LicenseNotFoundError(Exception):

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -762,6 +762,7 @@ class License(TimeStampedModel):
 
         now = localized_utcnow()
         self.status = ASSIGNED
+        self.lms_user_id = None
         self.revoked_date = None
         self.activation_date = None
         self.assigned_date = now


### PR DESCRIPTION
…eviously revoked emails.  ENT-3876

## Description

When a license is revoked, the current behavior transitions that license to the ``revoked`` state
and adds a license to the available pool for the associated subscription plan.
If an admin then re-invites that learner, the revoked license will transition to the ``unassigned`` state
and re-enter the pool of available unassigned licenses before grabbing an unassigned
license from the plan's pool to assign to the learner.
The net effect of this logic is to add an additional unassigned license for the plan, to
which the plan should not be entitled.

Instead of doing that, we'll unrevoke the license and delete an existing unassigned license to account for the one created during revocation, so that plans don't have more licenses than they were entitled to.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3876

## Testing considerations

- Read the ADR first, so you understand what we're doing and why.
- In license-manager, create a new subscription plan with 10 licenses (using django admin).
- Use admin-portal to assign a license to a user, and then activate it in license-manager django admin.  The number of assigned licenses for this plan should drop to 9.  Call this license "the license".
- Revoke this license.  Notice that the count of unassigned licenses for the plan is now 10
- Assign a license to the same user (same email address).  The number of unassigned licenses should drop to 9 again (this is the fix - it used to stay at 10).  In license-manager django admin, check that "the license" has an activation date and revoked date that are null.  The assigned date and remind date should be the time when you unrevoked them, and the status should be "assigned" again.

## Post-review

Squash commits into discrete sets of changes

## Recordings of manual testing
Before this change (notice the "1 of 11 licenses allocated" toward the end - that's the defect we're fixing:
![unrevocation-pretest](https://user-images.githubusercontent.com/2307986/126526749-b3398448-e307-4084-a7db-683fc2b29425.gif)

After this change - notice that I skipped the back-and-forth to Django Admin to activate the license this time, because this fix is valid for both ASSIGNED and ACTIVATED licenses.  The important thing to note is that I revoked an assigned license, and after re-assigning to the same email address, the number of available licenses in the plan remained the same.
![unrevocation-fix](https://user-images.githubusercontent.com/2307986/126527595-fec304bf-ecb2-4977-9dc1-51131b0ec41c.gif)
