### PR TITLE
fix: Be defensive about fetching related plan types

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -43,7 +43,7 @@ def activation_email_task(custom_template_text, email_recipient_list, subscripti
     """
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
-    subscription_plan_type = subscription_plan.plan_type.id
+    subscription_plan_type = subscription_plan.plan_type.id if subscription_plan.plan_type else None
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)
     enterprise_slug = enterprise_customer.get('slug')
@@ -95,7 +95,7 @@ def send_reminder_email_task(custom_template_text, email_recipient_list, subscri
             with or will be associated with.
     """
     subscription_plan = SubscriptionPlan.objects.get(uuid=subscription_uuid)
-    subscription_plan_type = subscription_plan.plan_type.id
+    subscription_plan_type = subscription_plan.plan_type.id if subscription_plan.plan_type else None
     pending_licenses = subscription_plan.licenses.filter(user_email__in=email_recipient_list).order_by('uuid')
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(subscription_plan.enterprise_customer_uuid)

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1221,10 +1221,14 @@ class LicenseActivationView(LicenseBaseView):
 
             # Following successful license activation, send learner an email
             # to help them get started using the Enterprise Learner Portal.
+            plan_type_id = None
+            if user_license.subscription_plan.plan_type:
+                plan_type_id = user_license.subscription_plan.plan_type.id
+
             send_onboarding_email_task.delay(
                 user_license.subscription_plan.enterprise_customer_uuid,
                 user_license.user_email,
-                user_license.subscription_plan.plan_type.id,
+                plan_type_id,
             )
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/license_manager/apps/subscriptions/emails.py
+++ b/license_manager/apps/subscriptions/emails.py
@@ -161,12 +161,20 @@ def _get_plan_email_template_row(context):
     template_type = context['template_type']
     if template_type == REVOCATION_CAP_NOTIFICATION_EMAIL_TEMPLATE:
         plan_email_template = PlanEmailTemplates.objects.filter(
-            template_type=template_type).get()
+            template_type=template_type,
+        ).get()
     else:
         plan_type_id = context.get('SUBSCRIPTION_PLAN_TYPE', None)
-        plan_type = PlanType.objects.get(id=plan_type_id)
+        # TODO: this can go away once every subscription plan is guaranteed to have an associated plan type
+        if not plan_type_id:
+            plan_type = PlanType.objects.get(label='Standard Paid')
+        else:
+            plan_type = PlanType.objects.get(id=plan_type_id)
+
         plan_email_template = PlanEmailTemplates.objects.get(
-            template_type=template_type, plan_type=plan_type)
+            template_type=template_type,
+            plan_type=plan_type,
+        )
 
     plaintext_template = Template(plan_email_template.plaintext_template)
     html_template = Template(plan_email_template.html_template)


### PR DESCRIPTION
And fall back to the standard template when sending emails, since apparently all of the templates are currently equivalent.  ENT-4756

## Description

SubscriptionPlan records created since the backfill of associated `PlanTypes` don't have a `plan_type`, resulting in some `None object has no attribute 'id'` exceptions when sending various emails.  This change addresses that by being defensive and grabbing the "Standard Paid" plan type by default when fetch email templates.  This works because:
*  that plan type is created by a migration, so every environment will have it
* every email template (besides the revocation cap) is identical in prod right now.  We need to address the TODO in this change before those templates become not identical.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4756

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
