### PR TITLE
fix: Fixing django32 failures.

### DIFF
--- a/license_manager/apps/subscriptions/apps.py
+++ b/license_manager/apps/subscriptions/apps.py
@@ -3,3 +3,5 @@ from django.apps import AppConfig
 
 class SubscriptionsConfig(AppConfig):
     name = 'subscriptions'
+    default = False
+

--- a/license_manager/apps/subscriptions/apps.py
+++ b/license_manager/apps/subscriptions/apps.py
@@ -4,4 +4,3 @@ from django.apps import AppConfig
 class SubscriptionsConfig(AppConfig):
     name = 'subscriptions'
     default = False
-


### PR DESCRIPTION
Fixing django32 failures.

```
  File "/edx/app/license_manager/.tox/py38-django32/lib/python3.8/site-packages/pytest_django/plugin.py", line 235, in _setup_django
    django.setup()
  File "/edx/app/license_manager/.tox/py38-django32/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/edx/app/license_manager/.tox/py38-django32/lib/python3.8/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/edx/app/license_manager/.tox/py38-django32/lib/python3.8/site-packages/django/apps/config.py", line 246, in create
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Cannot import 'subscriptions'. Check that 'license_manager.apps.subscriptions.apps.SubscriptionsConfig.name' is correct.
make: *** [test] Error 1
```
https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.default

prevent Django from selecting a configuration class automatically.
it already has defined path in Installed apps.

Django [PR](https://github.com/django/django/commit/3f2821af6bc48fa8e7970c1ce27bc54c3172545e#diff-0f8bc657bc27c9f80385c4814c2c2ebc033bda3e03285a7212965309a481cc70R104) 