### PR TITLE
fix: copy addtl fields during renewal and ensure activation license is current

### DIFF
--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -6,6 +6,7 @@ from edx_rbac.utils import get_decoded_jwt
 from rest_framework.exceptions import ParseError
 
 from license_manager.apps.subscriptions.models import CustomerAgreement, License
+from license_manager.apps.subscriptions.utils import localized_utcnow
 
 
 def get_customer_agreement_from_request_enterprise_uuid(request):
@@ -76,10 +77,13 @@ def get_context_from_subscription_plan_by_activation_key(request):
 
     Returns: The ``enterprise_customer_uuid`` associated with the user's license.
     """
+    today = localized_utcnow().date()
     user_license = get_object_or_404(
         License,
         activation_key=get_activation_key_from_request(request),
         user_email=get_email_from_request(request),
         subscription_plan__is_active=True,
+        subscription_plan__start_date__lte=today,
+        subscription_plan__expiration_date__gte=today,
     )
     return user_license.subscription_plan.customer_agreement.enterprise_customer_uuid

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -37,7 +37,6 @@ from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
     License,
-    SubscriptionPlan,
     SubscriptionsFeatureRole,
     SubscriptionsRoleAssignment,
 )

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2946,7 +2946,12 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
             }
         )
 
-        prior_assigned_license = self._create_license(subscription_plan=subscription_plan_original)
+        prior_assigned_license = self._create_license(
+            subscription_plan=subscription_plan_original,
+            # explicitly set activation_date to assert that this license
+            # is *not* the one that gets activated during the POST request.
+            activation_date=datetime.date.today() - datetime.timedelta(days=1),
+        )
         current_assigned_license = self._create_license(subscription_plan=subscription_plan_renewed)
 
         with freeze_time(self.now):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -37,6 +37,7 @@ from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
     License,
+    SubscriptionPlan,
     SubscriptionsFeatureRole,
     SubscriptionsRoleAssignment,
 )
@@ -2921,6 +2922,47 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         assert constants.REVOKED == revoked_license.status
         assert self.lms_user_id == revoked_license.lms_user_id
         assert self.now == revoked_license.activation_date
+
+    @mock.patch('license_manager.apps.api.v1.views.send_onboarding_email_task.delay')
+    def test_activating_renewed_assigned_license(self, mock_onboarding_email_task):
+        # create an expired plan and a current plan
+        subscription_plan_original = SubscriptionPlanFactory.create(
+            customer_agreement=self.customer_agreement,
+            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
+            is_active=True,
+            start_date=datetime.date.today() - datetime.timedelta(days=366),
+            expiration_date=datetime.date.today() - datetime.timedelta(days=1),
+        )
+        subscription_plan_renewed = SubscriptionPlanFactory.create(
+            customer_agreement=self.customer_agreement,
+            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
+            is_active=True,
+        )
+
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': subscription_plan_original.plan_type.id,
+            }
+        )
+
+        prior_assigned_license = self._create_license(subscription_plan=subscription_plan_original)
+        current_assigned_license = self._create_license(subscription_plan=subscription_plan_renewed)
+
+        with freeze_time(self.now):
+            response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+        current_assigned_license.refresh_from_db()
+        prior_assigned_license.refresh_from_db()
+        assert prior_assigned_license.activation_date != self.now
+        assert current_assigned_license.activation_date == self.now
+        mock_onboarding_email_task.assert_called_with(
+            self.enterprise_customer_uuid,
+            self.user.email,
+            subscription_plan_original.plan_type.id,
+        )
 
 
 @ddt.ddt

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1209,13 +1209,17 @@ class LicenseActivationView(LicenseBaseView):
         """
         activation_key_uuid = utils.get_activation_key_from_request(request)
         try:
-            user_license = License.objects.get(
-                activation_key=activation_key_uuid,
-                user_email=self.user_email,
-                subscription_plan__is_active=True,
-            )
+            today = localized_utcnow().date()
+            kwargs = {
+                'activation_key': activation_key_uuid,
+                'user_email': self.user_email,
+                'subscription_plan__is_active': True,
+                'subscription_plan__start_date__lte': today,
+                'subscription_plan__expiration_date__gte': today,
+            }
+            user_license = License.objects.get(**kwargs)
         except License.DoesNotExist:
-            msg = 'No license exists for the email {} with activation key {}'.format(
+            msg = 'No current license exists for the email {} with activation key {}'.format(
                 self.user_email,
                 activation_key_uuid,
             )

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -100,7 +100,10 @@ def renew_subscription(subscription_plan_renewal):
             is_active=original_plan.is_active,
             netsuite_product_id=original_plan.netsuite_product_id,
             salesforce_opportunity_id=subscription_plan_renewal.salesforce_opportunity_id,
-            plan_type_id=subscription_plan_renewal.prior_subscription_plan.plan_type_id
+            plan_type_id=subscription_plan_renewal.prior_subscription_plan.plan_type_id,
+            is_revocation_cap_enabled=subscription_plan_renewal.prior_subscription_plan.is_revocation_cap_enabled,
+            revoke_max_percentage=subscription_plan_renewal.prior_subscription_plan.revoke_max_percentage,
+            for_internal_use_only=subscription_plan_renewal.prior_subscription_plan.for_internal_use_only,
         )
 
     # When creating SubscriptionPlans in Django admin, we create enough
@@ -150,6 +153,7 @@ def _renew_all_licenses(original_licenses, future_plan):
         future_license.status = original_license.status
         future_license.user_email = original_license.user_email
         future_license.lms_user_id = original_license.lms_user_id
+        future_license.activation_key = original_license.activation_key
         future_license.assigned_date = localized_utcnow()
         if original_license.status == ACTIVATED:
             future_license.activation_date = localized_datetime_from_date(future_plan.start_date)


### PR DESCRIPTION
## Description

tl;dr; Copy missing fields from original SubscriptionPlan to renewed SubscriptionPlan and ensure activation POST only checks for licenses that are in a _current_ SubscriptionPlan now that renewed/transferred licenses will have the same activation key as the original licenses.

Details in the linked ticket: https://openedx.atlassian.net/browse/ENT-4748

## Testing considerations

1. Create a new Subscription Plan or choose an existing plan, and create a SubscriptionPlanRenewal record for it.
2. Mark one of the licenses in this plan as assigned.
3. Process the renewal by using the relevant Django action on the selected plan from above.
![image](https://user-images.githubusercontent.com/2828721/128191702-dc25fc92-8319-4fdd-8a40-a3808b35ddd7.png)
4. Note that the additional fields noted in the above ticket are also copied from the original plan to the newly created, renewed plan.
5. Note that the activation key from the assigned license on the original plan is also transferred to the associated assigned license on the renewal plan.
6. Attempt to activate the license using the activation key associated with both of these licenses and ensure it appropriately activated the license for the current plan only.
