### PR TITLE
Adds net days until subscription expiration to customer-agreement API

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -67,6 +67,7 @@ class CustomerAgreementSerializer(serializers.ModelSerializer):
             'ordered_subscription_plan_expirations',
             'subscriptions',
             'disable_expiration_notifications',
+            'net_days_until_expiration',
         ]
 
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -277,6 +277,7 @@ def _assert_customer_agreement_response_correct(response, customer_agreement):
     assert response['enterprise_customer_slug'] == customer_agreement.enterprise_customer_slug
     assert response['default_enterprise_catalog_uuid'] == str(customer_agreement.default_enterprise_catalog_uuid)
     assert response['ordered_subscription_plan_expirations'] == customer_agreement.ordered_subscription_plan_expirations
+    assert response['net_days_until_expiration'] == customer_agreement.net_days_until_expiration
     for response_subscription, agreement_subscription in zip(
         response['subscriptions'],
         customer_agreement.subscriptions.all()

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -101,6 +101,13 @@ class CustomerAgreement(TimeStampedModel):
 
         return ordered_subscription_plan_data
 
+    @property
+    def net_days_until_expiration(self):
+        net_days = 0
+        for plan in self.subscriptions.all():
+            net_days = max(net_days, plan.days_until_expiration_including_renewals)
+        return net_days
+
     class Meta:
         verbose_name = _("Customer Agreement")
         verbose_name_plural = _("Customer Agreements")


### PR DESCRIPTION
#### Closes [ENT-4630](https://openedx.atlassian.net/browse/ENT-4630)

This adds `net_days_until_expiration` to  `/api/v1/customer-agreement` so that the admin portal can better inform admins their subscriptions are expiring.