### PR TITLE
Edx abolger/hackathon tooling

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -40,6 +40,14 @@ class Command(BaseCommand):
             help='Friendly name of an existing enterprise customer.',
             type=str,
         )
+        parser.add_argument(
+            '--num-licenses',
+            action='store',
+            dest='num_licenses',
+            default=10,
+            help='Specify the number of licenses you want on this subscription. Defaults to 10.',
+            type=int,
+        )
 
     def get_enterprise_customer(self, enterprise_customer_name):
         """ Returns an enterprise customer """
@@ -115,5 +123,6 @@ class Command(BaseCommand):
         )
         logger.info(self.enterprise_customer)
         customer_agreement = self.get_or_create_customer_agreement(self.enterprise_customer)
-        new_plan = self.create_subscription_plan(customer_agreement, num_licenses=1)
+        new_plan = self.create_subscription_plan(customer_agreement, num_licenses=options['num_licenses'])
         logger.info(new_plan)
+        logger.info('Licenses created: {}'.format(License.objects.filter(subscription_plan=new_plan)))

--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -1,0 +1,70 @@
+"""
+Management command for assigning enterprise roles to existing enterprise users.
+"""
+
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+from license_manager.apps.api_client.enterprise import EnterpriseApiClient
+
+
+from license_manager.apps.subscriptions.models import License, SubscriptionPlan, CustomerAgreement
+from license_manager.apps.subscriptions.utils import chunks
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command for populating License Manager with an enterprise customer agreement, subscriptions, and licenses.
+
+    Example usage:
+        $ ./manage.py seed_enterprise_devstack_data --enterprise-customer "CUSTOMER-UUID-HERE"
+    """
+
+    enterprise_customer = None
+    enterprise_catalog = None
+    help = 'Seeds an enterprise customer agreement, subscription and licenses for an existing enterprise customer.'
+
+    def add_arguments(self, parser):
+        """ Adds argument(s) to the the command """
+        parser.add_argument(
+            '--enterprise-customer-name',
+            action='store',
+            dest='enterprise_customer_name',
+            required=True,
+            help='Friendly name of an existing enterprise customer.',
+            type=str,
+        )
+
+    def get_enterprise_customer(self, enterprise_customer_name):
+        """ Returns an enterprise customer """
+        logger.info('\nFetching an enterprise customer {} name ...'.format(enterprise_customer_name))
+        try:
+            enterprise_api_client = EnterpriseApiClient()
+
+            # Query endpoint by name instead of UUID:
+            endpoint = '{}?name={}'.format(enterprise_api_client.enterprise_customer_endpoint, str(enterprise_customer_name))
+            response = enterprise_api_client.client.get(endpoint).json()
+            if response.get('count'):
+                return response.get('results')[0]
+
+            return None
+
+        except IndexError:
+            logger.error('No enterprise customer found.')
+            return None
+
+    def handle(self, *args, **options):
+        """
+        Entry point for managment command execution.
+        """
+        enterprise_customer_name = options['enterprise_customer_name']
+
+        # Fetch enterprise customer
+        self.enterprise_customer = self.get_enterprise_customer(
+            enterprise_customer_name,
+        )
+        logger.info(self.enterprise_customer)

--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -84,6 +84,12 @@ class Command(BaseCommand):
             }
         )
         if customer_agreement:
+            # Data sync for running command multiple times:
+            # update the uuid with the latest that matches the slug:
+            customer_agreement.enterprise_customer_uuid = enterprise_customer.get('uuid')
+            customer_agreement.default_enterprise_catalog_uuid = enterprise_customer.get('enterprise_customer_catalogs')[0]
+            customer_agreement.save()
+
             logger.info('\nCustomerAgreement created on {} found: {}'.
                         format(customer_agreement.created, customer_agreement.uuid))
 

--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -1,5 +1,5 @@
 """
-Management command for seeding devstack with licenses and subscriptions for development. 
+Management command for seeding devstack with licenses and subscriptions for development.
 """
 
 
@@ -8,10 +8,15 @@ from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from license_manager.apps.subscriptions.utils import localized_utcnow
-from license_manager.apps.api_client.enterprise import EnterpriseApiClient
 
-from license_manager.apps.subscriptions.models import License, SubscriptionPlan, CustomerAgreement, PlanType
+from license_manager.apps.api_client.enterprise import EnterpriseApiClient
+from license_manager.apps.subscriptions.models import (
+    CustomerAgreement,
+    License,
+    PlanType,
+    SubscriptionPlan,
+)
+from license_manager.apps.subscriptions.utils import localized_utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -52,7 +57,7 @@ class Command(BaseCommand):
         try:
             enterprise_api_client = EnterpriseApiClient()
 
-            # Query endpoint by name instead of UUID:
+            # Query endpoint by slug for easy dev CLI experience
             endpoint = '{}?slug={}'.format(enterprise_api_client.enterprise_customer_endpoint,
                                            str(enterprise_customer_slug))
             response = enterprise_api_client.client.get(endpoint).json()
@@ -86,7 +91,6 @@ class Command(BaseCommand):
         customer_agreement.enterprise_customer_uuid = enterprise_customer.get('uuid')
         customer_agreement.default_enterprise_catalog_uuid = enterprise_customer.get('enterprise_customer_catalogs')[0]
         customer_agreement.save()
-
         return customer_agreement
 
     def create_subscription_plan(self, customer_agreement, num_licenses=1):

--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -57,6 +57,35 @@ class Command(BaseCommand):
             logger.error('No enterprise customer found.')
             return None
 
+    def get_or_create_customer_agreement(self, enterprise_customer):
+        """
+        Gets or creates a CustomerAgreement for a customer.
+        """
+        logger.info('\nFetching/Creating enterprise CustomerAgreement ...')
+
+        customer_agreement, _ = CustomerAgreement.objects.get_or_create(
+            enterprise_customer_slug=enterprise_customer.get('slug'),
+            defaults={
+                'enterprise_customer_uuid': enterprise_customer.get('uuid'),
+                'enterprise_customer_slug': enterprise_customer.get('slug'),
+                'default_enterprise_catalog_uuid': enterprise_customer.get('enterprise_customer_catalogs')[0]
+
+            }
+        )
+        if customer_agreement:
+            logger.info('\nCustomerAgreement created on {} found: {}'.format(customer_agreement.created, customer_agreement.uuid))
+
+        return customer_agreement
+
+    def create_subscription_plan(self, enterprise_uuid):
+        """ 
+        Creates a SubscriptionPlan for a customer.
+        """
+        pass
+
+    def create_licenses(self, subscription_plan_id, num_licenses=100):
+        pass
+
     def handle(self, *args, **options):
         """
         Entry point for managment command execution.
@@ -67,4 +96,6 @@ class Command(BaseCommand):
         self.enterprise_customer = self.get_enterprise_customer(
             enterprise_customer_name,
         )
-        logger.info(self.enterprise_customer)
+        if (self.enterprise_customer):
+            logger.info(self.enterprise_customer)
+            self.get_or_create_customer_agreement(self.enterprise_customer)


### PR DESCRIPTION
## Description

Adds a management command to seed devstack data for development.  Example usage: 

docker exec license_manager.app bash -c "./manage.py seed_enterprise_devstack_data --enterprise-customer-slug the-whinery-spirits-company --num-licenses=2"

## Testing considerations

Command has been run with all options specified, used only for devstack data.

## Post-review

Squash commits into discrete sets of changes
