### PR TITLE
feat: serialize info about revoked licenses

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -300,6 +300,10 @@ def _assert_subscription_response_correct(response, subscription, expected_days_
     assert response['licenses'] == {
         'total': subscription.num_licenses,
         'allocated': subscription.num_allocated_licenses,
+        'assigned': subscription.assigned_licenses.count(),
+        'activated': subscription.activated_licenses.count(),
+        'revoked': subscription.revoked_licenses.count(),
+        'unassigned': subscription.unassigned_licenses.count(),
     }
     days_until_expiration = (subscription.expiration_date - datetime.date.today()).days
     assert response['days_until_expiration'] == days_until_expiration
@@ -1843,6 +1847,10 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         assert response.json()['licenses'] == {
             'total': len(allocated_licenses) + 1,
             'allocated': len(allocated_licenses),
+            'revoked': 0,
+            'activated': 1,
+            'assigned': len(assigned_licenses),
+            'unassigned': 1,
         }
 
         # Revoke the activated license and verify the counts change appropriately
@@ -1860,6 +1868,12 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             'total': len(allocated_licenses) + 1,
             # There should be 1 fewer allocated license now that we revoked the activated license
             'allocated': len(allocated_licenses) - 1,
+            # ...and we create a new, unassigned license on revocation, so there should
+            # now be 2 unassigned licenses in this plan
+            'unassigned': 2,
+            'revoked': 1,
+            'activated': 0,
+            'assigned': len(assigned_licenses),
         }
 
 

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -247,7 +247,7 @@ class LearnerLicensesViewSet(PermissionRequiredForListingMixin, ListModelMixin, 
           expiration_date: "2021-06-30"
           is_active: true
           is_revocation_cap_enabled: false
-          licenses: {total: 1, allocated: 1}
+          licenses: {total: 1, allocated: 1, revoked: 4}
           revocations: null
           start_date: "2020-12-01"
           title: "Pied Piper - Plan A"


### PR DESCRIPTION
Return information about the number of revoked licenses in the subscription serialization (separate from counts of revocations that apply against the revocation cap).  We need this so we can tell if there are any revoked licenses associated with a plan in the admin portal.  We can't rely only on the `revocations` sub-dictionary, because it's only present when the cap is enabled (and we want to leave it that way because there's some admin-portal logic that looks for the presence/absence of this sub-dictionary).

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4804

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
