### PR TITLE
fix: ensure we do not exceed current API limits for enrollment

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -3,6 +3,8 @@
 Tests for the Subscription and License V1 API view sets.
 """
 import datetime
+import random
+from math import ceil, sqrt
 from unittest import mock
 from uuid import uuid4
 
@@ -2584,6 +2586,22 @@ class EnterpriseEnrollmentWithLicenseSubsidyViewTests(LicenseViewTestMixin, Test
         self.api_client.post(url, payload2)
 
         assert mock_contains_content.call_count == 2
+
+    def test_bulk_enroll_too_many_enrollments(self):
+        # Unnecessary math time!
+        enrollment_split = ceil(sqrt(settings.BULK_ENROLL_REQUEST_LIMIT)) + 1
+
+        self._assign_multi_learner_roles()
+
+        payload = {
+            'emails': random.sample(range(1, 100), enrollment_split),
+            'course_run_keys': random.sample(range(1, 100), enrollment_split),
+            'notify': True,
+        }
+        url = self._get_url_with_params()
+        response = self.api_client.post(url, payload)
+        assert response.status_code == 400
+        assert response.json() == constants.BULK_ENROLL_TOO_MANY_ENROLLMENTS
 
 
 @ddt.ddt

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -89,6 +89,8 @@ EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API = 'expose_license_activation_key_over_api
 # Default sender alias for emails
 DEFAULT_EMAIL_SENDER_ALIAS = 'edX Support Team'
 
+# Error messages
+BULK_ENROLL_TOO_MANY_ENROLLMENTS = 'Too many provided enrollments, please try a smaller request.'
 
 # Deprecated Constants #
 DEACTIVATED = 'deactivated'  # Deprecated for REVOKED

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -355,6 +355,7 @@ SUPPORT_SITE_URL = os.environ.get('SUPPORT_SITE_URL', '')
 
 # Bulk enroll specific
 BULK_ENROLL_REQUEST_TIMEOUT_SECONDS = os.environ.get('BULK_ENROLL_REQUEST_TIMEOUT_SECONDS', 180)
+BULK_ENROLL_REQUEST_LIMIT = os.environ.get('BULK_ENROLL_REQUEST_LIMIT', 500)
 
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {


### PR DESCRIPTION
## Description
We identified a rough numerical limit to the number of enrollments we could process at once.
We want to ensure we do not exceed that number.

Thus, this PR adds the following:
- A new setting variable (and default value)
- Logic in the bulk enrollment endpoint to immediately return before even hitting edx-enterprise if the enrollments exceed our limit.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4774

## Testing considerations
- manual testing done and working (requires assigning a boat load of emails to licenses)

## Post-review

Squash commits into discrete sets of changes
