### PR TITLE
feat: add prior renewals on subscription plan detail response

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -10,7 +10,31 @@ from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
     SubscriptionPlan,
+    SubscriptionPlanRenewal,
 )
+
+
+class SubscriptionPlanRenewalSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the `SubscriptionPlanRenewal` model.
+    """
+    prior_subscription_plan_start_date = serializers.SerializerMethodField()
+    renewed_subscription_plan_start_date = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SubscriptionPlanRenewal
+        fields = [
+            'prior_subscription_plan_id',
+            'prior_subscription_plan_start_date',
+            'renewed_subscription_plan_id',
+            'renewed_subscription_plan_start_date',
+        ]
+
+    def get_prior_subscription_plan_start_date(self, obj):
+        return obj.prior_subscription_plan.start_date
+
+    def get_renewed_subscription_plan_start_date(self, obj):
+        return obj.renewed_subscription_plan.start_date
 
 
 class SubscriptionPlanSerializer(serializers.ModelSerializer):
@@ -19,6 +43,7 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
     """
     licenses = serializers.SerializerMethodField()
     revocations = serializers.SerializerMethodField()
+    prior_renewals = SubscriptionPlanRenewalSerializer(many=True)
 
     class Meta:
         model = SubscriptionPlan
@@ -35,6 +60,7 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
             'revocations',
             'days_until_expiration',
             'days_until_expiration_including_renewals',
+            'prior_renewals'
         ]
 
     def get_licenses(self, obj):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -312,6 +312,7 @@ def _assert_subscription_response_correct(response, subscription, expected_days_
     # If `expected_days_until_renewal_expiration` is None, there is no renewal
     assert response['days_until_expiration_including_renewals'] == (
         expected_days_until_renewal_expiration or days_until_expiration)
+    assert response['prior_renewals'] == subscription.prior_renewals
 
 
 def _assert_license_response_correct(response, subscription_license):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -253,7 +253,15 @@ class LearnerLicensesViewSet(PermissionRequiredForListingMixin, ListModelMixin, 
           revocations: null
           start_date: "2020-12-01"
           title: "Pied Piper - Plan A"
-          uuid: "fe9cc40e-24a7-47a0-b800-9a11288b3ec2"
+          uuid: "fe9cc40e-24a7-47a0-b800-9a11288b3ec2",
+          prior_renewals: [
+            {
+                "prior_subscription_plan_id": "14c80170-737b-42c5-bbce-007f6ec0a557",
+                "prior_subscription_plan_start_date": "2020-10-31",
+                "renewed_subscription_plan_id": "fe9cc40e-24a7-47a0-b800-9a11288b3ec2",
+                "renewed_subscription_plan_start_date": "2020-12-01"
+            }
+          ]
         }
         user_email: "edx@example.com"
         uuid: "4e03efb7-b4ea-4a52-9cfc-11519920a40a"

--- a/license_manager/apps/subscriptions/tests/test_models.py
+++ b/license_manager/apps/subscriptions/tests/test_models.py
@@ -16,6 +16,7 @@ from license_manager.apps.subscriptions.tests.factories import (
     CustomerAgreementFactory,
     LicenseFactory,
     SubscriptionPlanFactory,
+    SubscriptionPlanRenewalFactory,
 )
 from license_manager.apps.subscriptions.utils import (
     localized_datetime_from_date,
@@ -45,6 +46,19 @@ class SubscriptionsModelTests(TestCase):
             self.subscription_plan.enterprise_catalog_uuid,
             content_ids,
         )
+
+    def test_prior_renewals(self):
+        renewed_subscription_plan_1 = SubscriptionPlanFactory.create()
+        renewed_subscription_plan_2 = SubscriptionPlanFactory.create()
+        renewal_1 = SubscriptionPlanRenewalFactory.create(
+            prior_subscription_plan=self.subscription_plan,
+            renewed_subscription_plan=renewed_subscription_plan_1
+        )
+        renewal_2 = SubscriptionPlanRenewalFactory.create(
+            prior_subscription_plan=renewed_subscription_plan_1,
+            renewed_subscription_plan=renewed_subscription_plan_2
+        )
+        self.assertEqual(renewed_subscription_plan_2.prior_renewals, [renewal_1, renewal_2])
 
 
 class LicenseModelTests(TestCase):


### PR DESCRIPTION
## Description

Adding prior renewals in the subscription plan detail response so that current state of the plan as it relates to renewals can be determined.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-3957

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
