### PR TITLE
feat: add process_renewal command

### DIFF
--- a/docs/decisions/0006-freezing-unused-licenses.rst
+++ b/docs/decisions/0006-freezing-unused-licenses.rst
@@ -1,4 +1,4 @@
-5. Freezing unused licenses on a subscription plan
+6. Freezing unused licenses on a subscription plan
 ======================
 
 Status

--- a/docs/decisions/0008-automated-renewal-processing.rst
+++ b/docs/decisions/0008-automated-renewal-processing.rst
@@ -1,0 +1,30 @@
+8. Automated Subscription Plan Renewals
+======================
+
+Status
+======
+
+* Accepted September 2021
+
+Context
+=======
+
+Currently, subscription renewals must be processed manually by an administrator through the Django Admin using the "Process selected renewal records" action.
+We'd like to automate this process so that renewals with an upcoming effective date are automatically processed. 
+The decision below describes the automated process. Refer to ADR 0004 for more details on the renewal process itself.
+
+Decision
+========
+
+A renewal with an upcoming (within the next 12 hours by default) effective date will be in its renewal processing window.
+Subscription plans with a renewal within its renewal processing window will be locked, and admins will not be able to take
+actions related to the plan (i.e. invite learners, revoke licenses). 
+A cron job will run every 6 hours to execute the process_renewals command, which will fetch and process renewals.
+Failure to process a renewal will trigger an OpsGenie P1 Alert, but the job will continue to process other renewals normally.
+The subscription renewal process itself is atomic, and changes will not be commited in the event of a failure.
+
+Consequences
+============
+
+* We assume that a renewal record will not be created until business approval is granted. 
+  The prescence of a renewal record indicates that it can be automatically processed.

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -94,3 +94,6 @@ BULK_ENROLL_TOO_MANY_ENROLLMENTS = 'Too many provided enrollments, please try a 
 
 # Deprecated Constants #
 DEACTIVATED = 'deactivated'  # Deprecated for REVOKED
+
+# Segment events
+PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED = 'edx.server.license-manager.process_subscription_renewal.auto_renewed'

--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -1,7 +1,6 @@
 """
 Forms to be used in the subscriptions django app.
 """
-from datetime import datetime
 
 from django import forms
 from django.utils.translation import gettext as _

--- a/license_manager/apps/subscriptions/management/commands/process_renewals.py
+++ b/license_manager/apps/subscriptions/management/commands/process_renewals.py
@@ -1,0 +1,97 @@
+import logging
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from license_manager.apps.core.models import User
+from license_manager.apps.subscriptions.api import (
+    RenewalProcessingError,
+    renew_subscription,
+)
+from license_manager.apps.subscriptions.constants import (
+    PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED,
+)
+from license_manager.apps.subscriptions.event_utils import track_event
+from license_manager.apps.subscriptions.models import SubscriptionPlanRenewal
+from license_manager.apps.subscriptions.utils import localized_utcnow
+
+
+logger = logging.getLogger(__name__)
+LCM_WORKER_USERNAME = "license_manager_worker"
+
+
+class Command(BaseCommand):
+    help = (
+        'Process subscription plan renewals with an upcoming (within the next 12 hours by default) effective date.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--processing-window-length-hours',
+            action='store',
+            dest='processing_window_length_hours',
+            help='The length of the renewal processing window in hours, the default is 12 hours (e.g. renewals with an effective date within the next 12 hours will be processed)',
+            default=(settings.SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS)
+        )
+
+        parser.add_argument(
+            '--dry-run',
+            action='store',
+            dest='dry_run',
+            help='Used to see which subscriptions would be renewed by running this command without making changes',
+            default=False
+        )
+
+    worker = None
+
+    def track_subscription_renewal(self, renewal):
+        if self.worker:
+            try:
+                track_event(self.worker.id, PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED, {
+                    'user_id': self.worker.id,
+                    'prior_subscription_plan_id': str(renewal.prior_subscription_plan.uuid),
+                    'renewed_subscription_plan_id': str(renewal.renewed_subscription_plan.uuid)
+                })
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.info(exc)
+
+    def handle(self, *args, **options):
+        now = localized_utcnow()
+        renewal_processing_window_cutoff = now + timedelta(hours=int(options['processing_window_length_hours']))
+
+        renewals_to_be_processed = SubscriptionPlanRenewal.objects.filter(
+            effective_date__gte=now, effective_date__lte=renewal_processing_window_cutoff, processed=False
+        ).select_related(
+            'prior_subscription_plan',
+            'prior_subscription_plan__customer_agreement',
+            'renewed_subscription_plan'
+        )
+
+        subscriptions_to_be_renewed_uuids = [str(renewal.prior_subscription_plan.uuid) for renewal in renewals_to_be_processed]
+
+        if not options['dry_run']:
+            logger.info('Processing {} renewals for subscriptions with uuids: {}'.format(
+                len(subscriptions_to_be_renewed_uuids), subscriptions_to_be_renewed_uuids)
+            )
+
+            try:
+                # get worker for sending tracking events to segment
+                self.worker = User.objects.get(username=LCM_WORKER_USERNAME)
+            except User.DoesNotExist:
+                pass
+
+            renewed_subscription_uuids = []
+            for renewal in renewals_to_be_processed:
+                subscription_uuid = str(renewal.prior_subscription_plan.uuid)
+                try:
+                    renew_subscription(renewal)
+                    renewed_subscription_uuids.append(subscription_uuid)
+                    self.track_subscription_renewal(renewal)
+                except RenewalProcessingError:
+                    logger.error('Could not automatically process renewal with id: {}'.format(renewal.id), exc_info=True)
+
+            logger.info('Processed {} renewals for subscriptions with uuids: {}'.format(len(renewed_subscription_uuids), renewed_subscription_uuids))
+        else:
+            message = 'Dry-run result subscriptions that would be renewed: {} '.format(subscriptions_to_be_renewed_uuids)
+            logger.info(message)

--- a/license_manager/apps/subscriptions/management/commands/tests/test_expire_subscriptions.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_expire_subscriptions.py
@@ -30,7 +30,7 @@ class ExpireSubscriptionsCommandTests(TestCase):
 
     def tearDown(self):
         """
-        Deletes all licenses and subscription after each test method is run.
+        Deletes all licenses and subscriptions after each test method is run.
         """
         super().tearDown()
         License.objects.all().delete()

--- a/license_manager/apps/subscriptions/management/commands/tests/test_process_renewals.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_process_renewals.py
@@ -1,0 +1,139 @@
+from datetime import timedelta
+from unittest import mock
+
+import freezegun
+import pytest
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+
+from license_manager.apps.subscriptions.api import RenewalProcessingError
+from license_manager.apps.subscriptions.constants import (
+    PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED,
+)
+from license_manager.apps.subscriptions.models import (
+    License,
+    SubscriptionPlan,
+    SubscriptionPlanRenewal,
+)
+from license_manager.apps.subscriptions.tests.factories import (
+    SubscriptionPlanFactory,
+    SubscriptionPlanRenewalFactory,
+    UserFactory,
+)
+from license_manager.apps.subscriptions.utils import localized_utcnow
+
+
+@pytest.mark.django_db
+class ProcessRenewalsCommandTests(TestCase):
+    command_name = 'process_renewals'
+    now = localized_utcnow()
+
+    def tearDown(self):
+        """
+        Deletes all renewals, licenses, and subscription after each test method is run.
+        """
+        super().tearDown()
+        License.objects.all().delete()
+        SubscriptionPlan.objects.all().delete()
+        SubscriptionPlanRenewal.objects.all().delete()
+
+    def create_subscription_with_renewal(self, effective_date, processed=False):
+        prior_subscription_plan = SubscriptionPlanFactory.create(
+            start_date=self.now - timedelta(days=7),
+            expiration_date=self.now,
+        )
+
+        renewed_subscription_plan = SubscriptionPlanFactory.create(
+            start_date=self.now,
+            expiration_date=self.now + timedelta(days=7),
+        )
+
+        SubscriptionPlanRenewalFactory.create(
+            prior_subscription_plan=prior_subscription_plan,
+            renewed_subscription_plan=renewed_subscription_plan,
+            effective_date=effective_date,
+            processed=processed
+        )
+
+        return (prior_subscription_plan)
+
+    @mock.patch('license_manager.apps.subscriptions.management.commands.process_renewals.renew_subscription')
+    def test_no_upcoming_renewals(self, mock_renew_subscription):
+        """
+        Verify that only unprocessed renewals within their processing window are processed
+        """
+        with self.assertLogs(level='INFO') as log, freezegun.freeze_time(self.now):
+            # renewal far in the future
+            self.create_subscription_with_renewal(
+                self.now + timedelta(hours=settings.SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS) + timedelta(seconds=1))
+
+            # renewal in the past
+            self.create_subscription_with_renewal(self.now - timedelta(seconds=1))
+
+            # renewal that has already been processed
+            self.create_subscription_with_renewal(self.now + timedelta(seconds=1), processed=True)
+
+            call_command(self.command_name)
+            assert mock_renew_subscription.call_count == 0
+            assert 'Processing 0 renewals for subscriptions with uuids: []' in log.output[0]
+            assert 'Processed 0 renewals for subscriptions with uuids: []' in log.output[1]
+
+    @mock.patch('license_manager.apps.subscriptions.management.commands.process_renewals.renew_subscription')
+    def test_upcoming_renewals(self, mock_renew_subscription):
+        """
+        Verify that unprocessed renewals within their processing window are processed
+        """
+        subscription_plan_1 = self.create_subscription_with_renewal(
+            self.now + timedelta(hours=settings.SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS))
+
+        subscription_plan_2 = self.create_subscription_with_renewal(self.now + timedelta(seconds=1))
+
+        with self.assertLogs(level='INFO') as log, freezegun.freeze_time(self.now):
+            call_command(self.command_name)
+            assert mock_renew_subscription.call_count == 2
+            assert "Processing 2 renewals for subscriptions with uuids: ['{}', '{}']".format(
+                subscription_plan_1.uuid, subscription_plan_2.uuid) in log.output[0]
+            assert "Processed 2 renewals for subscriptions with uuids: ['{}', '{}']".format(
+                subscription_plan_1.uuid, subscription_plan_2.uuid) in log.output[1]
+
+    @mock.patch('license_manager.apps.subscriptions.management.commands.process_renewals.renew_subscription')
+    def test_renew_subscription_exception(self, mock_renew_subscription):
+        """
+        Verify that an exception when processing a renewal will not stop other renewals from being processed
+        """
+        mock_renew_subscription.side_effect = [RenewalProcessingError, None]
+
+        subscription_plan_1 = self.create_subscription_with_renewal(
+            self.now + timedelta(hours=settings.SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS))
+
+        subscription_plan_2 = self.create_subscription_with_renewal(self.now + timedelta(seconds=1))
+
+        with self.assertLogs(level='INFO') as log, freezegun.freeze_time(self.now):
+            call_command(self.command_name)
+            assert mock_renew_subscription.call_count == 2
+            assert "Processing 2 renewals for subscriptions with uuids: ['{}', '{}']".format(
+                subscription_plan_1.uuid, subscription_plan_2.uuid) in log.output[0]
+            assert "Could not automatically process renewal with id: {}".format(subscription_plan_1.renewal.id) in log.output[1]
+            assert "Processed 1 renewals for subscriptions with uuids: ['{}']".format(subscription_plan_2.uuid) in log.output[2]
+
+    @mock.patch('license_manager.apps.subscriptions.management.commands.process_renewals.renew_subscription')
+    @mock.patch('license_manager.apps.subscriptions.management.commands.process_renewals.track_event')
+    def test_track_subscription_renewal(self, mock_track_event, mock_renew_subscription):
+        """
+        Verify that a segment event is sent if the license_manager_worker user exists and a subscription is renewed
+        """
+        subscription_plan_1 = self.create_subscription_with_renewal(
+            self.now + timedelta(hours=settings.SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS))
+
+        worker = UserFactory.create(username='license_manager_worker')
+
+        with freezegun.freeze_time(self.now):
+            call_command(self.command_name)
+            assert mock_renew_subscription.call_count == 1
+            assert mock_track_event.call_count == 1
+            mock_track_event.assert_called_with(worker.id, PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED, {
+                'user_id': worker.id,
+                'prior_subscription_plan_id': str(subscription_plan_1.uuid),
+                'renewed_subscription_plan_id': str(subscription_plan_1.renewal.renewed_subscription_plan.uuid)
+            })

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -1,6 +1,6 @@
 import random
 import string
-from datetime import date, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 import factory

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -2,7 +2,7 @@
 import hashlib
 import hmac
 from base64 import b64encode
-from datetime import date, datetime
+from datetime import datetime
 
 from django.conf import settings
 from pytz import UTC


### PR DESCRIPTION
## Description

- Added command to process renewals with an upcoming effective date
- Added ADR to document behavior of auto renewals

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4702

## Testing considerations
- Create a renewal(s) for a SubscriptionPlan(s) with an effective date within 12 hours of today's date & time.
- Run `python manage.py process_renewals`
- Verify that the renewal has been processed and the licenses have been copied successfully

## Post-review

Squash commits into discrete sets of changes
