### PR TITLE
Change segment events to use LMS User Id where possible and log where not possible

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -651,7 +651,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         )
         for newly_assigned in unassigned_licenses:
             event_properties = event_utils.get_license_tracking_properties(newly_assigned)
-            event_utils.track_event(event_properties['user_id'],
+            event_utils.track_event(None,  # track_event will handle users with unregistered emails
                                     'edx.server.license-manager.license-lifecycle.assigned',
                                     event_properties)
 
@@ -1271,7 +1271,7 @@ class LicenseActivationView(LicenseBaseView):
             user_license.save()
 
             event_properties = event_utils.get_license_tracking_properties(user_license)
-            event_utils.track_event(event_properties['user_id'],
+            event_utils.track_event(self.lms_user_id,
                                     'edx.server.license-manager.license-lifecycle.activated',
                                     event_properties)
 

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -173,7 +173,7 @@ def _renew_all_licenses(original_licenses, future_plan):
     )
     for future_license in future_licenses:
         event_properties = event_utils.get_license_tracking_properties(future_license)
-        event_utils.track_event(event_properties['user_id'],
+        event_utils.track_event(future_license.lms_user_id,
                                 'edx.server.license-manager.license-lifecycle.renewed',
                                 event_properties)
 

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -34,13 +34,17 @@ class Command(BaseCommand):
         )
         # Scrub all piii on licenses whose subscription expired over 90 days ago, and mark the licenses as revoked
         for expired_license in expired_licenses_for_retirement:
+            original_lms_user_id = expired_license.lms_user_id
+            # record event data BEFORE we clear the license data:
+            event_properties = get_license_tracking_properties(expired_license)
+
             expired_license.clear_pii()
             expired_license.status = REVOKED
             expired_license.revoked_date = localized_utcnow()
             expired_license.save()
 
             event_properties = get_license_tracking_properties(expired_license)
-            track_event(event_properties['user_id'],
+            track_event(original_lms_user_id,
                         'edx.server.license-manager.license-lifecycle.revoked',
                         event_properties)
 


### PR DESCRIPTION
## Description

Change segment events to use LMS User Id where possible and log where not possible.
The plan is for a near-future ticket to address the non-lms-user create and assignment events via 
some combination of Segment anonymous users and Braze User aliases.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4753

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
