### PR TITLE
feat: licenses/remind endpoint supports multiple emails

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -238,3 +238,36 @@ class CustomTextWithMultipleEmailsSerializer(MultipleEmailsSerializer, CustomTex
     """
     class Meta:
         fields = MultipleEmailsSerializer.Meta.fields + CustomTextSerializer.Meta.fields
+
+
+class MultipleOrSingleEmailSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for specifying multiple or single email
+
+    Requires that valid emails are submitted.
+    """
+    user_email = serializers.EmailField(
+        allow_blank=True,
+        required=False,
+        write_only=True,
+    )
+
+    user_emails = serializers.ListField(
+        child=serializers.EmailField(
+            allow_blank=True,
+            write_only=True,
+        ),
+        allow_empty=True,
+        required=False,
+    )
+
+    class Meta:
+        fields = [
+            'user_email',
+            'user_emails',
+        ]
+
+
+class CustomTextWithMultipleOrSingleEmailSerializer(MultipleOrSingleEmailSerializer, CustomTextSerializer):
+    class Meta:
+        fields = MultipleOrSingleEmailSerializer.Meta.fields + CustomTextSerializer.Meta.fields


### PR DESCRIPTION
### [Closes ENT-3956](https://openedx.atlassian.net/browse/ENT-3956)

Allows support to remind multiple emails using the `/subscriptions/{subscriontion_uuid}/licenses/remind/` end point.

- Previously only supported passing 1 email in body, `user_email`.
- Now also supports a list of emails, `user_emails`
- If passed both `user_emails` and `user_email` it will only remind the list `user_emails`.
- Support for `user_email` to be deprecated in the future.