### PR TITLE
feat: add revoke-all action

### DIFF
--- a/license_manager/apps/api/v1/tests/test_api_eventing.py
+++ b/license_manager/apps/api/v1/tests/test_api_eventing.py
@@ -147,8 +147,8 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.activation_email_task.si')
-    @mock.patch('license_manager.apps.subscriptions.api.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_bulk_revoked_event(self, *_):
         """
         Test that bulk revoking licenses  triggers the right set of events:
@@ -189,8 +189,8 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.activation_email_task.si')
-    @mock.patch('license_manager.apps.subscriptions.api.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_license_revoked_event(self, *_):
         """ Test that revoking a license from a user triggers the right set of events:
          1 revoke event and 1 creation of a fresh license

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -9,6 +9,7 @@ LICENSE_STATUS_CHOICES = (
     (UNASSIGNED, 'Unassigned'),
     (REVOKED, 'Revoked'),
 )
+REVOCABLE_LICENSE_STATUSES = [ACTIVATED, ASSIGNED]
 
 
 # Subscription/license renewals

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -295,8 +295,8 @@ class RevocationTests(TestCase):
         {'revoke_max_percentage': 0.74, 'number_licenses_to_create': 15},
     )
     @ddt.unpack
-    @mock.patch('license_manager.apps.subscriptions.api.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_revocation_limit_reached_raises_error(
         self,
         mock_cap_email_delay,
@@ -344,8 +344,8 @@ class RevocationTests(TestCase):
         constants.REVOKED,
         constants.UNASSIGNED,
     )
-    @mock.patch('license_manager.apps.subscriptions.api.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_cannot_revoke_license_if_not_assigned_or_activated(
             self, license_status, mock_cap_email_delay, mock_revoke_enrollments_delay
     ):
@@ -367,8 +367,8 @@ class RevocationTests(TestCase):
         self.assertFalse(mock_revoke_enrollments_delay.called)
 
     @ddt.data(True, False)
-    @mock.patch('license_manager.apps.subscriptions.api.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_activated_license_is_revoked(
         self, should_send_revocation_cap_email, mock_cap_email_delay, mock_revoke_enrollments_delay
     ):


### PR DESCRIPTION
## Description

Add revoke-all endpoint to revoke all licenses for a given subscription. Reorganized imports to avoid circular dependency errors.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4849

Opened https://openedx.atlassian.net/browse/ENT-4915 to be addressed outside of this pr.

## Post-review

Squash commits into discrete sets of changes
