### PR TITLE
fix: remove added segment event, change events to enum

### DIFF
--- a/license_manager/apps/api/v1/tests/test_api_eventing.py
+++ b/license_manager/apps/api/v1/tests/test_api_eventing.py
@@ -63,7 +63,7 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             assert mock_track_event.call_count == num_licenses
             for call in mock_track_event.call_args_list:
                 # We should have events all called with the created event:
-                assert call[0][1] == 'edx.server.license-manager.license-lifecycle.created'
+                assert call[0][1] == constants.SegmentEvents.LICENSE_CREATED
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.activation_email_task.si')
@@ -94,10 +94,10 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             assignment_call = mock_track_event.call_args_list[0]
             deletion_call = mock_track_event.call_args_list[1]
 
-            assert assignment_call[0][1] == 'edx.server.license-manager.license-lifecycle.assigned'
+            assert assignment_call[0][1] == constants.SegmentEvents.LICENSE_ASSIGNED
             assert assignment_call[0][2]['license_uuid'] == str(revoked_license.uuid)
 
-            assert deletion_call[0][1] == 'edx.server.license-manager.license-lifecycle.deleted'
+            assert deletion_call[0][1] == constants.SegmentEvents.LICENSE_DELETED
             assert deletion_call[0][2]['license_uuid'] == str(unassigned_licenses[0].uuid)
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
@@ -117,7 +117,7 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             # We should only have fired an event for 1 assignment:
             assert mock_assign_track_event.call_count == 1
             for call in mock_assign_track_event.call_args_list:
-                assert call[0][1] == 'edx.server.license-manager.license-lifecycle.assigned'
+                assert call[0][1] == constants.SegmentEvents.LICENSE_ASSIGNED
             assert response.status_code == status.HTTP_200_OK
             self._assert_licenses_assigned([self.test_email])
 
@@ -132,7 +132,7 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             self._create_available_licenses(num_licenses=5)
             assert mock_create_track_event.call_count == 5
             for call in mock_create_track_event.call_args_list:
-                assert call[0][1] == 'edx.server.license-manager.license-lifecycle.created'
+                assert call[0][1] == constants.SegmentEvents.LICENSE_CREATED
 
         with mock.patch('license_manager.apps.subscriptions.event_utils.track_event') as mock_assign_track_event:
             user_emails = ['bb8@mit.edu', self.test_email]
@@ -143,7 +143,7 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             assert response.status_code == status.HTTP_200_OK
             assert mock_assign_track_event.call_count == 2
             for call in mock_assign_track_event.call_args_list:
-                assert call[0][1] == 'edx.server.license-manager.license-lifecycle.assigned'
+                assert call[0][1] == constants.SegmentEvents.LICENSE_ASSIGNED
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.activation_email_task.si')
@@ -172,19 +172,19 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
             assert response.status_code == status.HTTP_204_NO_CONTENT
             assert mock_revoke_track_event.call_count == 4
             assert (mock_revoke_track_event.call_args_list[0][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.revoked')
+                    == constants.SegmentEvents.LICENSE_REVOKED)
             assert (mock_revoke_track_event.call_args_list[0][0][2]['assigned_email']
                     == 'alice@example.com')
             assert (mock_revoke_track_event.call_args_list[1][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.created')
+                    == constants.SegmentEvents.LICENSE_CREATED)
             assert mock_revoke_track_event.call_args_list[1][0][2]['assigned_email'] == ''
 
             assert (mock_revoke_track_event.call_args_list[2][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.revoked')
+                    == constants.SegmentEvents.LICENSE_REVOKED)
             assert (mock_revoke_track_event.call_args_list[2][0][2]['assigned_email']
                     == 'bob@example.com')
             assert (mock_revoke_track_event.call_args_list[3][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.created')
+                    == constants.SegmentEvents.LICENSE_CREATED)
             assert mock_revoke_track_event.call_args_list[3][0][2]['assigned_email'] == ''
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
@@ -207,10 +207,10 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
 
             assert mock_revoke_track_event.call_count == 2
             assert (mock_revoke_track_event.call_args_list[0][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.revoked')
+                    == constants.SegmentEvents.LICENSE_REVOKED)
             assert mock_revoke_track_event.call_args_list[0][0][2]['assigned_email'] == 'test@example.com'
             assert (mock_revoke_track_event.call_args_list[1][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.created')
+                    == constants.SegmentEvents.LICENSE_CREATED)
             assert mock_revoke_track_event.call_args_list[1][0][2]['assigned_email'] == ''
 
     def test_license_renewed_events(self):
@@ -251,11 +251,11 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, TestCase):
                 renewal.refresh_from_db()
 
                 for call in mock_created_track_event.call_args_list[0:4]:
-                    assert call[0][1] == 'edx.server.license-manager.license-lifecycle.created'
+                    assert call[0][1] == constants.SegmentEvents.LICENSE_CREATED
                 assert mock_created_track_event.call_count == 4
 
                 for call in mock_renewed_track_event.call_args_list[0:4]:
-                    assert call[0][1] == 'edx.server.license-manager.license-lifecycle.renewed'
+                    assert call[0][1] == constants.SegmentEvents.LICENSE_RENEWED
                 assert mock_renewed_track_event.call_count == 4
 
     def test_activate_event(self):
@@ -288,7 +288,7 @@ class LicenseLearnerActionsEventTests(LicenseViewTestMixin, TestCase):
             assert mock_activated_track_event.call_count == 1
 
             assert (mock_activated_track_event.call_args_list[0][0][1]
-                    == 'edx.server.license-manager.license-lifecycle.activated')
+                    == constants.SegmentEvents.LICENSE_ACTIVATED)
             assert mock_activated_track_event.call_args_list[0][0][2]['assigned_email'] == self.user.email
             assert mock_activated_track_event.call_args_list[0][0][2]['assigned_lms_user_id'] == self.lms_user_id
             assert (mock_activated_track_event.call_args_list[0][0][2]['activation_date']

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -652,7 +652,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         for newly_assigned in unassigned_licenses:
             event_properties = event_utils.get_license_tracking_properties(newly_assigned)
             event_utils.track_event(None,  # track_event will handle users with unregistered emails
-                                    'edx.server.license-manager.license-lifecycle.assigned',
+                                    constants.SegmentEvents.LICENSE_ASSIGNED,
                                     event_properties)
 
     def _link_and_notify_assigned_emails(self, request_data, subscription_plan, user_emails):
@@ -1288,7 +1288,7 @@ class LicenseActivationView(LicenseBaseView):
 
             event_properties = event_utils.get_license_tracking_properties(user_license)
             event_utils.track_event(self.lms_user_id,
-                                    'edx.server.license-manager.license-lifecycle.activated',
+                                    constants.SegmentEvents.LICENSE_ACTIVATED,
                                     event_properties)
 
             # Following successful license activation, send learner an email

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -42,6 +42,17 @@ class SubscriptionPlanChangeReasonChoices:
     )
 
 
+# Segment events
+class SegmentEvents:
+    LICENSE_ACTIVATED = 'edx.server.license-manager.license-lifecycle.activated'
+    LICENSE_ASSIGNED = 'edx.server.license-manager.license-lifecycle.assigned'
+    LICENSE_CREATED = 'edx.server.license-manager.license-lifecycle.created'
+    LICENSE_DELETED = 'edx.server.license-manager.license-lifecycle.deleted'
+    LICENSE_EXPIRED = 'edx.server.license-manager.license-lifecycle.expired'
+    LICENSE_RENEWED = 'edx.server.license-manager.license-lifecycle.renewed'
+    LICENSE_REVOKED = 'edx.server.license-manager.license-lifecycle.revoked'
+
+
 # Template names used for emails
 LICENSE_ACTIVATION_EMAIL_TEMPLATE = 'activation'
 LICENSE_REMINDER_EMAIL_TEMPLATE = 'reminder'
@@ -94,6 +105,3 @@ BULK_ENROLL_TOO_MANY_ENROLLMENTS = 'Too many provided enrollments, please try a 
 
 # Deprecated Constants #
 DEACTIVATED = 'deactivated'  # Deprecated for REVOKED
-
-# Segment events
-PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED = 'edx.server.license-manager.process_subscription_renewal.auto_renewed'

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -79,7 +79,7 @@ def track_event(lms_user_id, event_name, properties):
     Args:
         lms_user_id (str): LMS User ID of the user we want tracked with this event for cross-platform tracking.
                            IF None, tracking will be attempted via unregistered learner email address.
-        event_name (str): Name of the event in the format of: edx.server.license-manager.license-lifecycle.<new-status>
+        event_name (str): Name of the event in the format of: edx.server.license-manager.license-lifecycle.<new-status>, see constants.SegmentEvents
         properties (dict): All the properties of an event. See docs/segment_events.rst
 
     Returns:

--- a/license_manager/apps/subscriptions/management/commands/process_renewals.py
+++ b/license_manager/apps/subscriptions/management/commands/process_renewals.py
@@ -4,21 +4,15 @@ from datetime import timedelta
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from license_manager.apps.core.models import User
 from license_manager.apps.subscriptions.api import (
     RenewalProcessingError,
     renew_subscription,
 )
-from license_manager.apps.subscriptions.constants import (
-    PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED,
-)
-from license_manager.apps.subscriptions.event_utils import track_event
 from license_manager.apps.subscriptions.models import SubscriptionPlanRenewal
 from license_manager.apps.subscriptions.utils import localized_utcnow
 
 
 logger = logging.getLogger(__name__)
-LCM_WORKER_USERNAME = "license_manager_worker"
 
 
 class Command(BaseCommand):
@@ -45,17 +39,6 @@ class Command(BaseCommand):
 
     worker = None
 
-    def track_subscription_renewal(self, renewal):
-        if self.worker:
-            try:
-                track_event(self.worker.id, PROCESS_SUBSCRIPTION_RENEWAL_AUTO_RENEWED, {
-                    'user_id': self.worker.id,
-                    'prior_subscription_plan_id': str(renewal.prior_subscription_plan.uuid),
-                    'renewed_subscription_plan_id': str(renewal.renewed_subscription_plan.uuid)
-                })
-            except Exception as exc:  # pylint: disable=broad-except
-                logger.info(exc)
-
     def handle(self, *args, **options):
         now = localized_utcnow()
         renewal_processing_window_cutoff = now + timedelta(hours=int(options['processing_window_length_hours']))
@@ -68,30 +51,24 @@ class Command(BaseCommand):
             'renewed_subscription_plan'
         )
 
-        subscriptions_to_be_renewed_uuids = [str(renewal.prior_subscription_plan.uuid) for renewal in renewals_to_be_processed]
+        subscription_uuids = [str(renewal.prior_subscription_plan.uuid) for renewal in renewals_to_be_processed]
 
         if not options['dry_run']:
             logger.info('Processing {} renewals for subscriptions with uuids: {}'.format(
-                len(subscriptions_to_be_renewed_uuids), subscriptions_to_be_renewed_uuids)
-            )
-
-            try:
-                # get worker for sending tracking events to segment
-                self.worker = User.objects.get(username=LCM_WORKER_USERNAME)
-            except User.DoesNotExist:
-                pass
+                len(subscription_uuids), subscription_uuids))
 
             renewed_subscription_uuids = []
             for renewal in renewals_to_be_processed:
                 subscription_uuid = str(renewal.prior_subscription_plan.uuid)
                 try:
-                    renew_subscription(renewal)
+                    renew_subscription(renewal, is_auto_renewed=True)
                     renewed_subscription_uuids.append(subscription_uuid)
-                    self.track_subscription_renewal(renewal)
                 except RenewalProcessingError:
-                    logger.error('Could not automatically process renewal with id: {}'.format(renewal.id), exc_info=True)
+                    logger.error('Could not automatically process renewal with id: {}'.format(
+                        renewal.id), exc_info=True)
 
-            logger.info('Processed {} renewals for subscriptions with uuids: {}'.format(len(renewed_subscription_uuids), renewed_subscription_uuids))
+            logger.info('Processed {} renewals for subscriptions with uuids: {}'.format(
+                        len(renewed_subscription_uuids), renewed_subscription_uuids))
         else:
-            message = 'Dry-run result subscriptions that would be renewed: {} '.format(subscriptions_to_be_renewed_uuids)
-            logger.info(message)
+            logger.info('Dry-run result subscriptions that would be renewed: {} '.format(
+                        subscription_uuids))

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -7,7 +7,7 @@ from license_manager.apps.subscriptions.constants import (
     ASSIGNED,
     DAYS_TO_RETIRE,
     REVOKED,
-    UNASSIGNED,
+    SegmentEvents,
 )
 from license_manager.apps.subscriptions.event_utils import (
     get_license_tracking_properties,
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
             event_properties = get_license_tracking_properties(expired_license)
             track_event(original_lms_user_id,
-                        'edx.server.license-manager.license-lifecycle.revoked',
+                        SegmentEvents.LICENSE_REVOKED,
                         event_properties)
 
             # Clear historical pii after removing pii from the license itself

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -33,6 +33,7 @@ from license_manager.apps.subscriptions.constants import (
     SALESFORCE_ID_LENGTH,
     UNASSIGNED,
     LicenseTypesToRenew,
+    SegmentEvents,
 )
 from license_manager.apps.subscriptions.event_utils import (
     get_license_tracking_properties,
@@ -908,7 +909,7 @@ class License(TimeStampedModel):
         self.save()
         event_properties = get_license_tracking_properties(self)
         track_event(self.lms_user_id,
-                    'edx.server.license-manager.license-lifecycle.revoked',
+                    SegmentEvents.LICENSE_REVOKED,
                     event_properties)
 
     def unrevoke(self):
@@ -930,7 +931,7 @@ class License(TimeStampedModel):
         self.save()
         event_properties = get_license_tracking_properties(self)
         track_event(revoked_lms_user_id,
-                    'edx.server.license-manager.license-lifecycle.assigned',
+                    SegmentEvents.LICENSE_ASSIGNED,
                     event_properties)
 
     @staticmethod
@@ -1114,7 +1115,7 @@ def dispatch_license_delete_event(sender, **kwargs):  # pylint: disable=unused-a
     license_obj = kwargs['instance']
     event_properties = get_license_tracking_properties(license_obj)
     track_event(license_obj.lms_user_id,
-                'edx.server.license-manager.license-lifecycle.deleted',
+                SegmentEvents.LICENSE_DELETED,
                 event_properties)
 
 
@@ -1133,18 +1134,18 @@ def dispatch_license_create_events(sender, **kwargs):  # pylint: disable=unused-
     event_properties = get_license_tracking_properties(license_obj)
     # We always send a creation event.
     track_event(license_obj.lms_user_id,
-                'edx.server.license-manager.license-lifecycle.created',
+                SegmentEvents.LICENSE_CREATED,
                 event_properties)
 
     # If the license has extra statuses on creation that would normally fire events,
     # then programmatically fire events for those also
     if license_obj.status == ASSIGNED:
         track_event(license_obj.lms_user_id,
-                    'edx.server.license-manager.license-lifecycle.assigned',
+                    SegmentEvents.LICENSE_ASSIGNED,
                     event_properties)
     if license_obj.status == ACTIVATED:
         track_event(license_obj.lms_user_id,
-                    'edx.server.license-manager.license-lifecycle.activated',
+                    SegmentEvents.LICENSE_ACTIVATED,
                     event_properties)
 
 
@@ -1164,5 +1165,5 @@ def dispatch_license_expiration_event(sender, **kwargs):  # pylint: disable=unus
             if not license_obj.renewed_to:
                 license_properties = get_license_tracking_properties(license_obj)
                 track_event(license_obj.lms_user_id,
-                            'edx.server.license-manager.license-lifecycle.expired',
+                            SegmentEvents.LICENSE_EXPIRED,
                             license_properties)


### PR DESCRIPTION
## Description

Description of changes made

- Remove previous segment event that I added and use the pre-existing license lifecycle events
- Add is_auto_renewed to license renewed event properties to indicate auto renewal
- Make segment events an enum


Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4702

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible
- Command should use utc and not localized

## Post-review

Squash commits into discrete sets of changes
