### PR TITLE
fix: temporarily allow edits on the slug field

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -232,9 +232,9 @@ class CustomerAgreementAdmin(admin.ModelAdmin):
 
     read_only_fields = (
         'enterprise_customer_uuid',
-        'enterprise_customer_slug',
     )
     writable_fields = (
+        'enterprise_customer_slug',
         'default_enterprise_catalog_uuid',
         'disable_expiration_notifications',
         'license_duration_before_purge',


### PR DESCRIPTION
## Description

Temporarily exposes the enterprise slug field in `CustomerAgreement` as an editable field so ECS can fix a mismatching slug.

## Post-review

Squash commits into discrete sets of changes
