### PR TITLE
feat: add django action to sync enterprise slugs with selected agreements

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -269,6 +269,10 @@ class MultipleOrSingleEmailSerializer(serializers.Serializer):  # pylint: disabl
         ]
 
 
-class CustomTextWithMultipleOrSingleEmailSerializer(MultipleOrSingleEmailSerializer, CustomTextSerializer):
+class CustomTextWithMultipleOrSingleEmailSerializer(MultipleOrSingleEmailSerializer, CustomTextSerializer):  # pylint: disable=abstract-method
+    """
+    Serializer for specifying custom text to use in a license management email for
+    either multiple user_emails or a single email.
+    """
     class Meta:
         fields = MultipleOrSingleEmailSerializer.Meta.fields + CustomTextSerializer.Meta.fields

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -3270,7 +3270,9 @@ class StaffLicenseLookupViewTests(LicenseViewTestMixin, TestCase):
                 'last_remind_date': None,
                 'revoked_date': None,
                 'status': constants.ACTIVATED,
-                'subscription_plan_expiration_date': _iso_8601_format(self.active_subscription_for_customer.expiration_date),  # pylint: disable=line-too-long
+                'subscription_plan_expiration_date': _iso_8601_format(
+                    self.active_subscription_for_customer.expiration_date
+                ),
                 'subscription_plan_title': self.active_subscription_for_customer.title,
             },
         ], response.json())

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -677,10 +677,12 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
     @action(detail=False, methods=['post'])
     def remind(self, request, subscription_uuid=None):
         """
-        Given a single email or a list of emails in the POST data, sends reminder email(s) that they have a license pending activation.
+        Given a single email or a list of emails in the POST data, sends
+        reminder email(s) that they have a license pending activation.
 
-        This endpoint reminds users by sending an email to the given email address(es), if there is a license which has not
-        yet been activated that is associated with the email address(es).
+        This endpoint reminds users by sending an email to the given email
+        address(es), if there is a license which has not yet been activated
+        that is associated with the email address(es).
         """
         # Validate the user_email and text sent in the data
         self._validate_data(request.data)

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -92,7 +92,9 @@ def track_event(lms_user_id, event_name, properties):
                                 event=event_name,
                                 properties=properties)
                 # We dont have an LMS user id for this event, so we can't track it in segment the same way.
-                logger.warning("Event {} for License Manager tracked without LMS User Id: {}". format(event_name, properties))
+                logger.warning(
+                    "Event {} for License Manager tracked without LMS User Id: {}".format(event_name, properties)
+                )
                 if properties['assigned_email']:
                     _track_event_via_braze_alias(properties['assigned_email'], event_name, properties)
 
@@ -102,7 +104,9 @@ def track_event(lms_user_id, event_name, properties):
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(exc)
     else:
-        logger.warning("Event {} for user_id {} not tracked because SEGMENT_KEY not set". format(event_name, lms_user_id))
+        logger.warning(
+            "Event {} for user_id {} not tracked because SEGMENT_KEY not set".format(event_name, lms_user_id)
+        )
 
 
 def get_license_tracking_properties(license_obj):

--- a/license_manager/apps/subscriptions/exceptions.py
+++ b/license_manager/apps/subscriptions/exceptions.py
@@ -3,7 +3,7 @@ Exceptions raised by functions exposed by the Subscriptions app.
 """
 
 
-class CustomerAgreementException(Exception):
+class CustomerAgreementError(Exception):
     """
     A general exception dealing with CustomerAgreements.
     """
@@ -64,3 +64,24 @@ class LicenseNotFoundError(Exception):
             self.subscription_plan.uuid,
             self.license_statuses,
         )
+
+
+class RenewalProcessingError(Exception):
+    """
+    An Exception indicating that a SubscriptionPlanRenewal
+    cannot be processed.
+    """
+
+
+class UnprocessableSubscriptionPlanExpirationError(Exception):
+    """
+    An exception indicating that a subscription plan's
+    expiration cannot be processed.
+    """
+
+
+class UnprocessableSubscriptionPlanFreezeError(Exception):
+    """
+    An exception indicating that a subscription plan cannot be
+    frozen to delete unused licenses.
+    """

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -39,7 +39,7 @@ from license_manager.apps.subscriptions.event_utils import (
     track_event,
 )
 from license_manager.apps.subscriptions.exceptions import (
-    CustomerAgreementException,
+    CustomerAgreementError,
     LicenseUnrevokeError,
 )
 from license_manager.apps.subscriptions.utils import (
@@ -155,7 +155,7 @@ class CustomerAgreement(TimeStampedModel):
                     'CustomerAgreement was not saved - '
                     'could not fetch customer slug field from the enterprise API because {}'.format(exc)
                 )
-                raise CustomerAgreementException(error_message) from exc
+                raise CustomerAgreementError(error_message) from exc
 
         super().save(*args, **kwargs)
 

--- a/license_manager/apps/subscriptions/tests/test_models.py
+++ b/license_manager/apps/subscriptions/tests/test_models.py
@@ -7,9 +7,7 @@ from django.test import TestCase
 from requests.exceptions import HTTPError
 
 from license_manager.apps.subscriptions.constants import REVOKED, UNASSIGNED
-from license_manager.apps.subscriptions.exceptions import (
-    CustomerAgreementException,
-)
+from license_manager.apps.subscriptions.exceptions import CustomerAgreementError
 from license_manager.apps.subscriptions.models import License
 from license_manager.apps.subscriptions.tests.factories import (
     CustomerAgreementFactory,
@@ -320,7 +318,7 @@ class CustomerAgreementTests(TestCase):
         client = mock_client.return_value
         client.get_enterprise_customer_data.side_effect = HTTPError('some error')
 
-        with self.assertRaisesRegex(CustomerAgreementException, 'some error'):
+        with self.assertRaisesRegex(CustomerAgreementError, 'some error'):
             agreement.save()
 
         self.assertTrue(mock_client.called)


### PR DESCRIPTION
## Description

Adds a Django Action for `CustomerAgreements` to allow a self-service way for ECS to sync any updates to a customer's slug to the agreement record.

Currently, when a new agreement is saved, we fetch the customer's slug to populate the agreement's slug field. However, if the slug changes on the LMS side of things, there's no existing way to get it updated on the agreement record.

While this is still not a truly hands off solution to this syncing, it does provide a stop-gap to manually gets the slugs in sync when this scenario arises.

Link to the associated ticket: TBD

![image](https://user-images.githubusercontent.com/2828721/132897400-5594fc52-9118-4e47-af08-c05541cb4b4e.png)

## Testing considerations

- Create a new CustomerAgreement for a customer UUID that exists in the LMS. Observe the agreement record has the correct slug associated with the customer.
- Update the slug for that customer in the LMS.
- Run the new Django action for your selected `CustomerAgreement`.
- Verify the slug field on the agreement did in fact get updated with the modified slug.

## Post-review

Squash commits into discrete sets of changes
