### PR TITLE
fix: move tasks out of revoke_license

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -224,9 +224,15 @@ def revoke_all_licenses_task(subscription_uuid):
             status__in=REVOCABLE_LICENSE_STATUSES,
         )
 
+        revocation_results = []
+
         for sl in subscription_licenses:
             try:
-                subscriptions_api.revoke_license(sl)
-            except Exception:  # pylint: disable=broad-except
-                logger.error('Could not revoke license with uuid {} during revoke_all_licenses_task'.format(sl.uuid), exc_info=True)
+                revocation_results.append(subscriptions_api.revoke_license(sl))
+            except Exception:
+                logger.error('Could not revoke license with uuid {} during revoke_all_licenses_task'.format(sl.uuid),
+                             exc_info=True)
                 raise
+
+    for result in revocation_results:
+        subscriptions_api.execute_post_revocation_tasks(**result)


### PR DESCRIPTION
## Description

Description of changes made

- Move the execution of tasks out of revoke_license into a helper
- Call helper in bulk_revoke and revoke_all after licenses have been successfully revoked

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4915

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
