### PR TITLE
fix: prefetch objects to prevent n+1 in bulk_create

### DIFF
--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -138,13 +138,6 @@ def get_license_tracking_properties(license_obj):
         "expiration_processed": license_obj.subscription_plan.expiration_processed
     }
 
-    user_who_made_change = ''
-    if license_obj.history.latest().history_user:
-        user_who_made_change = license_obj.history.latest().history_user.id
-    license_data.update({
-        'user_id': (user_who_made_change or '')
-    })
-
     if license_obj and license_obj.subscription_plan and license_obj.subscription_plan.customer_agreement:
         license_data.update(get_enterprise_tracking_properties(
             license_obj.subscription_plan.customer_agreement))

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -959,6 +959,10 @@ class License(TimeStampedModel):
         https://django-simple-history.readthedocs.io/en/2.12.0/common_issues.html#bulk-creating-and-queryset-updating
         """
         bulk_create_with_history(license_objects, cls, batch_size=batch_size)
+
+        # prefetch related objects used in get_license_tracking_properties
+        models.prefetch_related_objects(license_objects, '_renewed_from', 'subscription_plan', 'subscription_plan__customer_agreement')
+
         # Since bulk_create does not call post_save, handle tracking events manually:
         for license_obj in license_objects:
             dispatch_license_create_events(License, instance=license_obj, created=True)


### PR DESCRIPTION
## Description

Description of changes made

- Prefetch related objects so we don't make additional queries for each license
- Remove unused user_who_made_change field 

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4919

## Testing considerations

- Should not see unexpected number of queries made after calling bulk_create

## Post-review

Squash commits into discrete sets of changes
