### PR TITLE
fix: refactor bulk tracking logic

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -654,11 +654,8 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
             unassigned_licenses,
             ['user_email', 'status', 'activation_key', 'assigned_date', 'last_remind_date'],
         )
-        for newly_assigned in unassigned_licenses:
-            event_properties = event_utils.get_license_tracking_properties(newly_assigned)
-            event_utils.track_event(None,  # track_event will handle users with unregistered emails
-                                    constants.SegmentEvents.LICENSE_ASSIGNED,
-                                    event_properties)
+
+        event_utils.track_license_changes(list(unassigned_licenses), constants.SegmentEvents.LICENSE_ASSIGNED)
 
     def _link_and_notify_assigned_emails(self, request_data, subscription_plan, user_emails):
         """

--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -195,12 +195,9 @@ def _renew_all_licenses(original_licenses, future_plan, is_auto_renewed):
         ['renewed_to'],
     )
 
-    for future_license in future_licenses:
-        event_properties = event_utils.get_license_tracking_properties(future_license)
-        event_properties['is_auto_renewed'] = is_auto_renewed
-        event_utils.track_event(future_license.lms_user_id,
-                                SegmentEvents.LICENSE_RENEWED,
-                                event_properties)
+    event_utils.track_license_changes(future_licenses, SegmentEvents.LICENSE_RENEWED, {
+        'is_auto_renewed': is_auto_renewed
+    })
 
 
 def _original_licenses_to_copy(original_plan, license_types_to_copy):

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -248,7 +248,7 @@ class RenewalProcessingTests(TestCase):
     @mock.patch('license_manager.apps.subscriptions.event_utils.track_event')
     def test_renewal_processed_segment_events(self, mock_track_event):
         prior_plan = SubscriptionPlanFactory()
-        original_activated_licenses = [LicenseFactory.create(
+        [LicenseFactory.create(
             subscription_plan=prior_plan,
             status=constants.ACTIVATED,
             user_email='activated_user_{}@example.com'
@@ -260,13 +260,15 @@ class RenewalProcessingTests(TestCase):
             license_types_to_copy=constants.LicenseTypesToRenew.ASSIGNED_AND_ACTIVATED
         )
         api.renew_subscription(renewal)
-        assert mock_track_event.call_count == len(original_activated_licenses)
-        self.assertFalse(mock_track_event.call_args_list[0].args[2]['is_auto_renewed'])
+        assert mock_track_event.call_count == 2
+        assert (mock_track_event.call_args_list[0].args[1] == constants.SegmentEvents.LICENSE_CREATED)
+        assert (mock_track_event.call_args_list[1].args[1] == constants.SegmentEvents.LICENSE_RENEWED)
+        self.assertFalse(mock_track_event.call_args_list[1].args[2]['is_auto_renewed'])
 
     @mock.patch('license_manager.apps.subscriptions.event_utils.track_event')
     def test_renewal_processed_segment_events_is_auto_renewed(self, mock_track_event):
         prior_plan = SubscriptionPlanFactory()
-        original_activated_licenses = [LicenseFactory.create(
+        [LicenseFactory.create(
             subscription_plan=prior_plan,
             status=constants.ACTIVATED,
             user_email='activated_user_{}@example.com'
@@ -278,8 +280,10 @@ class RenewalProcessingTests(TestCase):
             license_types_to_copy=constants.LicenseTypesToRenew.ASSIGNED_AND_ACTIVATED
         )
         api.renew_subscription(renewal, is_auto_renewed=True)
-        assert mock_track_event.call_count == len(original_activated_licenses)
-        self.assertTrue(mock_track_event.call_args_list[0].args[2]['is_auto_renewed'])
+        assert mock_track_event.call_count == 2
+        assert (mock_track_event.call_args_list[0].args[1] == constants.SegmentEvents.LICENSE_CREATED)
+        assert (mock_track_event.call_args_list[1].args[1] == constants.SegmentEvents.LICENSE_RENEWED)
+        self.assertTrue(mock_track_event.call_args_list[1].args[2]['is_auto_renewed'])
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description

Follow up to ticket: https://openedx.atlassian.net/browse/ENT-4943

- Created and use new util function `track_license_changes` tracks bulk changes after prefetching data
- Dispatch expiration events in expire_subscriptions command, add subscription_plan__expiration_processed=True to filter since we should only be expiring plans that aren't already processed
- Remove dispatch_license_create_events calls in bulk_update since they do nothing and return immediately

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4943

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
