### PR TITLE
chore: rename bulk_revoke -> bulk-revoke

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -453,7 +453,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
     POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/remind/
     POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/remind-all/
     POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/revoke/
-    POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/bulk_revoke/ #TODO: This should probably be renamed to bulk-revolk
+    POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/bulk-revoke/
     POST /api/v1/subscriptions/{subscription_plan_uuid}/licenses/revoke-all/
     """
     lookup_field = 'uuid'
@@ -817,7 +817,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=['post'], url_path='bulk-revoke')
     def bulk_revoke(self, request, subscription_uuid=None):
         """
         Revokes one or more licenses in a subscription plan,
@@ -825,7 +825,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         This will result in any existing enrollments for the revoked users
         being moved to the audit enrollment mode.
 
-        POST /api/v1/subscriptions/{subscription_uuid}/licenses/bulk_revoke/
+        POST /api/v1/subscriptions/{subscription_uuid}/licenses/bulk-revoke/
 
         Request payload:
           {


### PR DESCRIPTION
## Description

Rename /bulk_revoke -> /bulk-revoke to follow convention. Endpoint is currently unused.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4737

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
