### PR TITLE
feat: ENT-4931 | Expose activation and revoke dates in LicenseSerializer

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -132,6 +132,8 @@ class LicenseSerializer(serializers.ModelSerializer):
             'activation_date',
             'last_remind_date',
             'subscription_plan',
+            'activation_date',
+            'revoked_date',
         ]
         if settings.FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API]:
             fields.append('activation_key')

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -307,6 +307,17 @@ def _assert_license_response_correct(response, subscription_license):
     """
     Helper for asserting that the response for a subscription_license matches the object's values.
     """
+    expected_fields = {
+        'uuid',
+        'status',
+        'user_email',
+        'activation_date',
+        'last_remind_date',
+        'subscription_plan',
+        'activation_date',
+        'revoked_date'
+    }
+    assert set(response.keys()) == expected_fields
     assert response['uuid'] == str(subscription_license.uuid)
     assert response['status'] == subscription_license.status
     assert response['user_email'] == subscription_license.user_email


### PR DESCRIPTION
## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
