### PR TITLE
chore: update urls and send USE-JWT-Cookie header for calls through swagger

### DIFF
--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -62,7 +62,7 @@ router.register(
     basename='learner-subscriptions',
 )
 router.register(
-    prefix=r'(?<!learner-)subscriptions',
+    prefix=r'subscriptions',
     viewset=views.SubscriptionViewSet,
     basename='subscriptions',
 )
@@ -74,7 +74,7 @@ router.register(
 
 subscription_router = NestedSimpleRouter(
     parent_router=router,
-    parent_prefix=r'(?<!learner-)subscriptions',
+    parent_prefix=r'subscriptions',
 )
 subscription_router.register(
     r'licenses',
@@ -83,7 +83,7 @@ subscription_router.register(
 )
 
 subscription_router.register(
-    r'license(?![^\/])',
+    r'license',
     views.BaseLicenseViewSet,
     basename='license',
 )

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -906,6 +906,7 @@ class LicenseBaseView(APIView):
     Base view for creating specific, one-off views
     that deal with licenses.
     """
+    authentication_classes = [JwtAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     @cached_property

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -48,7 +48,6 @@ THIRD_PARTY_APPS = (
     'edx_api_doc_tools',
     'rules.apps.AutodiscoverRulesConfig',
     'simple_history',
-    'simplejson',
     'social_django',
     'waffle',
 )
@@ -388,3 +387,7 @@ ENTERPRISE_SUBSIDY_CHECKSUM_SECRET_KEY = 'please-set-me'
 ENTERPRISE_SUBSIDY_CHECKSUM_MESSAGE_FORMAT = '{lms_user_id}:{course_key}:{license_uuid}'
 
 SUBSCRIPTION_PLAN_RENEWAL_LOCK_PERIOD_HOURS = 12
+
+SWAGGER_SETTINGS = {
+    'LOGOUT_URL': LOGOUT_URL
+}


### PR DESCRIPTION
## Description

Make it possible to use swagger to hit our endpoints/view responses in browser.

- add SessionAuthentication to views
- add CustomerGeneratorSchema to append use-jwt-cookie header to all requests through swagger
- remove regex in route prefix since the prefixes for learner-subscription and subscription are already distinct (if anyone has more context lmk but it does not seem to be doing anything but messing up swagger)

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4975

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
