### PR TITLE
fix: removing an unsed, broken call

### DIFF
--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -89,9 +89,6 @@ def track_event(lms_user_id, event_name, properties):
     if hasattr(settings, "SEGMENT_KEY") and settings.SEGMENT_KEY:
         try:  # We should never raise an exception when not able to send a tracking event
             if not lms_user_id:
-                analytics.track(anonymous_id=('license_mgr_user_id_{}'.format(properties['user_id'])),
-                                event=event_name,
-                                properties=properties)
                 # We dont have an LMS user id for this event, so we can't track it in segment the same way.
                 logger.warning(
                     "Event {} for License Manager tracked without LMS User Id: {}".format(event_name, properties)


### PR DESCRIPTION
This change is removing a piece of code which is breaking non-lms-id enterprise learner tracking in Braze. I've consulted with a few folks and the code doesn't seem to be part of a fully formed implementation and seems safe to remove for the time being. Removing this code will restore the tracking we're trying to do while I do some deeper digging.

Context TLDR:
@edx-abolger was implementing some tracking for non-lms-id enterprise learners directly into Braze before she left. Alongside the braze call, she had added a call into segment with an anonymous_id. It doesn't appear to be a fully formed/baked implementation of the anonymous_id. The tracking call broke when an [n+1 issue was found/fixed](https://github.com/edx/license-manager/commit/cb8d0a752b67c1216b020a8b0bb69645d0105765#diff-5eaa5b0d4d10dc788bb5275b0cd5b48087d160a6f0c3b9a9a6acdb0c731001bc) because it removed the `user_id` key. That key seems to have been optional even before this fix and no attempt to merge these anonymous ids has been implemented elsewhere which has led me to believe this wasn't a fully implemented code path as of yet. I'll dig in further but it seems safe to remove for the time being.

- [ENT-4904](https://openedx.atlassian.net/browse/ENT-4904)
- https://github.com/edx/license-manager/pull/271
- Splunk error:
```
2021-09-28 19:03:11,382 ERROR 21243 [license_manager.apps.subscriptions.event_utils] event_utils.py:106 - 'user_id'
Traceback (most recent call last):
  File "/edx/app/license_manager/license_manager/apps/subscriptions/event_utils.py", line 92, in track_event
    analytics.track(anonymous_id=('license_mgr_user_id_{}'.format(properties['user_id'])),
KeyError: 'user_id'
```
