### PR TITLE
feat: add attributes to aliased profiles in braze

### DIFF
--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -53,6 +53,16 @@ def _track_event_via_braze_alias(email, event_name, properties):
 
     track_url = "{}/users/track".format(settings.BRAZE_URL)
     track_payload = {
+        "attributes" : [
+            {
+                "user_alias" : {
+                    "alias_name" : email,
+                    "alias_label" : "Enterprise"
+                },
+                "email" : email,
+                "is_enterprise_learner": true,
+                "_update_existing_only" : false
+            }],
         "events": [
             {
                 "user_alias": {
@@ -61,7 +71,8 @@ def _track_event_via_braze_alias(email, event_name, properties):
                 },
                 "name": event_name,
                 "time": _iso_8601_format_string(localized_utcnow()),
-                "properties": properties
+                "properties": properties,
+                "_update_existing_only" : false
             }]
     }
     track_response = requests.request("POST", track_url, headers=headers, data=json.dumps(track_payload))

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -53,15 +53,15 @@ def _track_event_via_braze_alias(email, event_name, properties):
 
     track_url = "{}/users/track".format(settings.BRAZE_URL)
     track_payload = {
-        "attributes" : [
+        "attributes": [
             {
-                "user_alias" : {
-                    "alias_name" : email,
-                    "alias_label" : "Enterprise"
+                "user_alias": {
+                    "alias_name": email,
+                    "alias_label": "Enterprise"
                 },
-                "email" : email,
+                "email": email,
                 "is_enterprise_learner": true,
-                "_update_existing_only" : false
+                "_update_existing_only": false
             }],
         "events": [
             {
@@ -72,7 +72,7 @@ def _track_event_via_braze_alias(email, event_name, properties):
                 "name": event_name,
                 "time": _iso_8601_format_string(localized_utcnow()),
                 "properties": properties,
-                "_update_existing_only" : false
+                "_update_existing_only": false
             }]
     }
     track_response = requests.request("POST", track_url, headers=headers, data=json.dumps(track_payload))


### PR DESCRIPTION
Our Braze tracking of Enterprise Learners before they have an LMS ID is done with Braze "aliases". Those "aliases" need an `email` attribute in order for us to be able to nudge them. This attribute normally makes its way into Braze after a user has registered.

Tested on Braze Staging via Postman.

- [ENT-5015](https://openedx.atlassian.net/browse/ENT-5015)
- [Braze Attribute Specs](https://www.braze.com/docs/api/objects_filters/user_attributes_object/)
- [Braze User Track Endpoint](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/)