### PR TITLE
chore: add ignore_enrollments_modified_after arg to bulk_licensed_enrollments_expiration

### DIFF
--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -214,7 +214,10 @@ class RevokeAllLicensesTaskTests(TestCase):
         """
         Verify that revoke_license handles any errors
         """
-        mock_revoke_license.side_effect = [LicenseRevocationError(self.assigned_license.uuid, 'something terrible went wrong'), None]
+        mock_revoke_license.side_effect = [
+            LicenseRevocationError(self.assigned_license.uuid, 'something terrible went wrong'),
+            None
+        ]
 
         with self.assertLogs(level='INFO') as log, pytest.raises(LicenseRevocationError):
             tasks.revoke_all_licenses_task(self.subscription_plan.uuid)

--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -108,7 +108,7 @@ class EnterpriseApiClient(BaseOAuthClient):
             logger.error(msg)
             raise exc
 
-    def bulk_licensed_enrollments_expiration(self, expired_license_uuids):
+    def bulk_licensed_enrollments_expiration(self, expired_license_uuids, ignore_enrollments_modified_after=None):
         """
         Calls the Enterprise API Client to terminate expired course enrollments for the provided license uuids
 
@@ -117,6 +117,7 @@ class EnterpriseApiClient(BaseOAuthClient):
         """
         data = {
             'expired_license_uuids': expired_license_uuids,
+            'ignore_enrollments_modified_after': ignore_enrollments_modified_after
         }
         response = self.client.post(self.bulk_licensed_enrollments_expiration_endpoint, json=data)
 

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -86,7 +86,7 @@ MIN_NUM_LICENSES = 0
 MAX_NUM_LICENSES = 5000
 
 # Number of license uuids enrollments are expired for in each batch
-LICENSE_EXPIRATION_BATCH_SIZE = 200
+LICENSE_EXPIRATION_BATCH_SIZE = 100
 
 # Bulk operation constants
 LICENSE_BULK_OPERATION_BATCH_SIZE = 100


### PR DESCRIPTION
## Description

Changes to be made after https://github.com/edx/edx-enterprise/pull/1381. 
Add subscription expiration date as ignore_enrollments_modified_after arg to bulk_licensed_enrollments_expiration call.
Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4944

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
