### PR TITLE
fix: expose license activation key in license serializer

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -1,10 +1,7 @@
 from django.conf import settings
 from rest_framework import serializers
 
-from license_manager.apps.subscriptions.constants import (
-    ACTIVATED,
-    ASSIGNED,
-)
+from license_manager.apps.subscriptions.constants import ACTIVATED, ASSIGNED
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 from license_manager.apps.subscriptions.constants import (
     ACTIVATED,
     ASSIGNED,
-    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API,
 )
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
@@ -133,9 +132,8 @@ class LicenseSerializer(serializers.ModelSerializer):
             'last_remind_date',
             'subscription_plan',
             'revoked_date',
+            'activation_key',
         ]
-        if settings.FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API]:
-            fields.append('activation_key')
 
 
 class StaffLicenseSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -204,8 +204,8 @@ class RevokeAllLicensesTaskTests(TestCase):
         Verify that revoke_license and execute_post_revocation_tasks is called for each revocable license
         """
         tasks.revoke_all_licenses_task(self.subscription_plan.uuid)
-        assert mock_revoke_license.call_args_list == [
-            mock.call(self.assigned_license), mock.call(self.activated_license)]
+        expected_calls = [mock.call(self.activated_license), mock.call(self.assigned_license)]
+        mock_revoke_license.assert_has_calls(expected_calls, any_order=True)
         assert mock_execute_post_revocation_tasks.call_count == 2
 
     @mock.patch('license_manager.apps.subscriptions.api.execute_post_revocation_tasks')
@@ -219,8 +219,7 @@ class RevokeAllLicensesTaskTests(TestCase):
         with self.assertLogs(level='INFO') as log, pytest.raises(LicenseRevocationError):
             tasks.revoke_all_licenses_task(self.subscription_plan.uuid)
 
-        assert mock_revoke_license.call_args_list == [
-            mock.call(self.assigned_license)]
+        assert mock_revoke_license.call_args_list == [mock.call(self.assigned_license)]
 
         assert 'Could not revoke license with uuid {} during revoke_all_licenses_task'.format(
             self.assigned_license.uuid) in log.output[0]

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -315,12 +315,14 @@ def _assert_license_response_correct(response, subscription_license):
         'last_remind_date',
         'subscription_plan',
         'activation_date',
-        'revoked_date'
+        'revoked_date',
+        'activation_key',
     }
     assert set(response.keys()) == expected_fields
     assert response['uuid'] == str(subscription_license.uuid)
     assert response['status'] == subscription_license.status
     assert response['user_email'] == subscription_license.user_email
+    assert response['activation_key'] == str(subscription_license.activation_key)
     assert response['activation_date'] == _iso_8601_format(subscription_license.activation_date)
     assert response['last_remind_date'] == _iso_8601_format(subscription_license.last_remind_date)
 

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -96,7 +96,6 @@ PENDING_ACCOUNT_CREATION_BATCH_SIZE = 100
 VALIDATE_NUM_CATALOG_QUERIES_BATCH_SIZE = 100
 
 # Feature Toggles
-EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API = 'expose_license_activation_key_over_api'
 
 # Default sender alias for emails
 DEFAULT_EMAIL_SENDER_ALIAS = 'edX Support Team'

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -4,7 +4,6 @@ from os.path import abspath, dirname, join
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 
 from license_manager.apps.subscriptions.constants import (
-    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API,
     SUBSCRIPTIONS_ADMIN_ROLE,
     SUBSCRIPTIONS_LEARNER_ROLE,
     SYSTEM_ENTERPRISE_ADMIN_ROLE,
@@ -373,9 +372,7 @@ MOBILE_STORE_URLS = os.environ.get('MOBILE_STORE_URLS', '')
 RETIREMENT_SERVICE_WORKER_USERNAME = "replace with valid username"
 
 # Feature Toggles
-FEATURES = {
-    EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API: False,
-}
+FEATURES = {}
 
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -84,7 +84,6 @@ SOCIAL_MEDIA_FOOTER_URLS = {
 }
 
 # Feature Toggles
-FEATURES[EXPOSE_LICENSE_ACTIVATION_KEY_OVER_API] = True
 
 # Install django-extensions for improved dev experiences
 # https://github.com/django-extensions/django-extensions#using-it

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,9 +16,9 @@ backoff==1.10.0
     #   analytics-python
 billiard==3.6.4.0
     # via celery
-boto3==1.18.55
+boto3==1.18.60
     # via django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   boto3
     #   s3transfer
@@ -27,11 +27,11 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
 cffi==1.14.6
     # via cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 coreapi==2.3.3
     # via drf-yasg
@@ -39,7 +39,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   pyjwt
     #   social-auth-core
@@ -138,7 +138,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-idna==3.2
+idna==3.3
     # via requests
 inflection==0.5.1
     # via drf-yasg
@@ -164,7 +164,7 @@ monotonic==1.6
     # via analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -178,11 +178,11 @@ psutil==5.8.0
     # via edx-django-utils
 pycparser==2.20
     # via cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   drf-jwt
     #   edx-auth-backends
@@ -257,7 +257,7 @@ stevedore==3.4.0
     #   edx-opaque-keys
 unicodecsv==0.14.1
     # via djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -20,10 +20,6 @@
 # using LTS django version
 
 
-# latest version is causing e2e failures in edx-platform.
-# See  comment.
-
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,11 +31,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -45,7 +45,7 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -53,7 +53,7 @@ cffi==1.14.6
     # via
     #   -r requirements/validation.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -83,11 +83,11 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -227,7 +227,7 @@ future==0.18.2
     #   pyjwkest
 gunicorn==20.1.0
     # via -r requirements/dev.in
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -293,7 +293,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/validation.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -321,7 +321,7 @@ pep517==0.11.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.txt
 pluggy==1.0.0
     # via
@@ -340,13 +340,13 @@ py==1.10.0
     # via
     #   -r requirements/validation.txt
     #   pytest
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/validation.txt
 pycparser==2.20
     # via
     #   -r requirements/validation.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/validation.txt
     #   pyjwkest
@@ -358,7 +358,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/validation.txt
     #   drf-jwt
@@ -532,7 +532,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/validation.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
     #   coreapi

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -37,11 +37,11 @@ billiard==3.6.4.0
     #   celery
 bleach==4.1.0
     # via readme-renderer
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -51,7 +51,7 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/test.txt
     #   requests
@@ -59,7 +59,7 @@ cffi==1.14.6
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/test.txt
     #   requests
@@ -87,11 +87,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -225,7 +225,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
@@ -286,7 +286,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -322,7 +322,7 @@ pycparser==2.20
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -335,7 +335,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -526,7 +526,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==7.1.2
     #   pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,11 +22,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -36,7 +36,7 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
@@ -44,7 +44,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -57,7 +57,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -172,7 +172,7 @@ greenlet==1.1.2
     # via gevent
 gunicorn==20.1.0
     # via -r requirements/production.in
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -213,7 +213,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -238,7 +238,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -246,7 +246,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -358,7 +358,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,11 +26,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -40,7 +40,7 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
@@ -48,7 +48,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -71,7 +71,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -182,7 +182,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -232,7 +232,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -253,13 +253,13 @@ psutil==5.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.in
 pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -269,7 +269,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -403,7 +403,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -42,7 +42,7 @@ celery==4.4.7
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
@@ -50,7 +50,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -75,11 +75,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -201,7 +201,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -251,7 +251,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -281,7 +281,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -289,7 +289,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -438,7 +438,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,13 +6,13 @@
 #
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 codecov==2.1.12
     # via -r requirements/travis.in
-coverage==6.0
+coverage==6.0.2
     # via codecov
 distlib==0.3.3
     # via virtualenv
@@ -20,7 +20,7 @@ filelock==3.3.0
     # via
     #   tox
     #   virtualenv
-idna==3.2
+idna==3.3
     # via requests
 packaging==21.0
     # via tox

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -38,12 +38,12 @@ billiard==3.6.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.18.55
+boto3==1.18.60
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.21.55
+botocore==1.21.60
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -55,7 +55,7 @@ celery==4.4.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-celeryutils
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -65,7 +65,7 @@ cffi==1.14.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -99,11 +99,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -271,7 +271,7 @@ future==0.18.2
     #   django-ses
     #   edx-celeryutils
     #   pyjwkest
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -343,7 +343,7 @@ mysqlclient==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -384,14 +384,14 @@ py==1.10.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.txt
 pycparser==2.20
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -403,7 +403,7 @@ pyjwkest==1.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -605,7 +605,7 @@ unicodecsv==0.14.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description

Exposes `activation_key` in the API in all environments (dev/stage/prod).

I also had to run `make upgrade` to upgrade `pip-tools` since the version it was currently on was failing CI.

Related PRs: 
1. https://github.com/edx/edx-internal/pull/5560
2. https://github.com/edx/frontend-app-learner-portal-enterprise/pull/340

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4942

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
