### PR TITLE
feat: add activation key for personalization

### DIFF
--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -80,7 +80,8 @@ def _track_event_via_braze_alias(email, event_name, properties):
     event_properites_to_copy_to_profile = ['enterprise_customer_uuid',
                                            'enterprise_customer_slug',
                                            'enterprise_customer_name',
-                                           'license_uuid']
+                                           'license_uuid',
+                                           'license_activation_key']
     for event_property in event_properites_to_copy_to_profile:
         if properties.get(event_property) is not None:
             track_payload['attributes'][0][event_property] = properties.get(event_property)
@@ -149,6 +150,7 @@ def get_license_tracking_properties(license_obj):
         renewed_from_formatted = str(license_obj.renewed_from.uuid)
     license_data = {
         "license_uuid": str(license_obj.uuid),
+        "license_activation_key": str(license_obj.activation_key),
         "previous_license_uuid": renewed_from_formatted,
         "assigned_date": assigned_date_formatted,
         "activation_date": activation_date_formatted,

--- a/license_manager/apps/subscriptions/tests/test_event_utils.py
+++ b/license_manager/apps/subscriptions/tests/test_event_utils.py
@@ -27,6 +27,7 @@ def test_get_license_tracking_properties():
         status=ASSIGNED)
     flat_data = get_license_tracking_properties(assigned_license)
     assert flat_data['license_uuid'] == str(assigned_license.uuid)
+    assert flat_data['license_activation_key'] == str(assigned_license.activation_key)
     assert flat_data['previous_license_uuid'] == ''
     assert flat_data['assigned_date'] == _iso_8601_format_string(assigned_license.assigned_date)
     assert flat_data['activation_date'] == _iso_8601_format_string(assigned_license.activation_date)


### PR DESCRIPTION
While working on personalization for license activation CTAs in Braze we realized that the activation links use an activation key (rather than the license UUID) so we need to pass that into Braze as well.

- [ENT-5029](https://openedx.atlassian.net/browse/ENT-5029)
