### PR TITLE
feat: Limit license search to associated subscription plan only

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2414,6 +2414,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyViewTests(LicenseViewTestMixin, Test
             'course_run_keys': [self.course_key],
             'notify': True,
         }
+        # pass an active subscription_uuid
         url = self._get_url_with_params(subscription_uuid=self.active_subscription_for_customer.uuid)
         response = self.api_client.post(url, data)
 
@@ -2463,6 +2464,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyViewTests(LicenseViewTestMixin, Test
             'course_run_keys': [self.course_key],
             'notify': True,
         }
+        # pass a random, invalid subscription_uuid
         url = self._get_url_with_params(subscription_uuid=SubscriptionPlanFactory().uuid)
         response = self.api_client.post(url, data)
 


### PR DESCRIPTION
These are the backend changes related to [ENT-4833](https://openedx.atlassian.net/browse/ENT-4833).

This changes the bulk enrollment endpoint to accept an optional subscription uuid and filter the license checks with that subscription, rather than all subscriptions associated with the customer agreement. Positive and negative tests added ensure the param subscription uuid alters the license check logic. 

Next the UI project will need to be alerted to pass the appropriate subscription uuid.

- [ENT-4833](https://openedx.atlassian.net/browse/ENT-4833)