### PR TITLE
feat: add braze alias identify during license activation

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1292,6 +1292,7 @@ class LicenseActivationView(LicenseBaseView):
             event_utils.track_event(self.lms_user_id,
                                     constants.SegmentEvents.LICENSE_ACTIVATED,
                                     event_properties)
+            event_utils.identify_braze_alias(self.lms_user_id, self.user_email)
 
             # Following successful license activation, send learner an email
             # to help them get started using the Enterprise Learner Portal.

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -94,6 +94,7 @@ def _track_event_via_braze_alias(email, event_name, properties):
                         track_response.status_code,
                         track_response.json()))
 
+
 def identify_braze_alias(lms_user_id, email_address):
     """
     Send `identify` event to Braze to link aliased Braze profiles.
@@ -107,7 +108,7 @@ def identify_braze_alias(lms_user_id, email_address):
         logger.warning("Alias {} not identified because BRAZE_API_KEY and BRAZE_URL not set".format(email_address))
         return
 
-    try: # We should never raise an exception when not able to send a tracking data
+    try:  # We should never raise an exception when not able to send a tracking data
         headers = {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer {}'.format(settings.BRAZE_API_KEY),
@@ -140,6 +141,7 @@ def identify_braze_alias(lms_user_id, email_address):
         )
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(exc)
+
 
 def track_event(lms_user_id, event_name, properties):
     """


### PR DESCRIPTION
During our Braze-based license activation nudge canvas we're realizing that there are circumstances in which Braze aliases are not getting properly linked to their long-term profiles because the registration events don't seem to always fire as expected. This seems to affect users of SSO and perhaps other edge cases we've not accounted for yet.

Lets add an additional identify call out to Braze during license activation to tighten up the analytics - this will give us cleaner data and prevent Braze from over-reminding users who have successfully activated.

- [ENT-5078](https://openedx.atlassian.net/browse/ENT-5078)