### PR TITLE
feat: add ignore_null_emails query param to licenses and overview endpoints

### DIFF
--- a/license_manager/apps/api/filters.py
+++ b/license_manager/apps/api/filters.py
@@ -7,9 +7,14 @@ from django_filters import rest_framework as filters
 from license_manager.apps.subscriptions.models import License
 
 
-class LicenseStatusFilter(filters.FilterSet):
-    """Filter for License Status"""
+class LicenseFilter(filters.FilterSet):
+    """
+    Filter for License.
+
+    Supports filtering by license status and whether null emails are included.
+    """
     status = filters.CharFilter(method='filter_by_status')
+    ignore_null_emails = filters.BooleanFilter(method='filter_by_ignore_null_emails')
 
     class Meta:
         model = License
@@ -18,3 +23,8 @@ class LicenseStatusFilter(filters.FilterSet):
     def filter_by_status(self, queryset, name, value):  # pylint: disable=unused-argument
         status_values = value.strip().split(',')
         return queryset.filter(status__in=status_values).distinct()
+
+    def filter_by_ignore_null_emails(self, queryset, name, value):  # pylint: disable=unused-argument
+        if not value:
+            return queryset
+        return queryset.exclude(user_email__isnull=True)

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -27,7 +27,7 @@ from rest_framework_csv.renderers import CSVRenderer
 from simplejson.errors import JSONDecodeError
 
 from license_manager.apps.api import serializers, utils
-from license_manager.apps.api.filters import LicenseStatusFilter
+from license_manager.apps.api.filters import LicenseFilter
 from license_manager.apps.api.permissions import CanRetireUser
 from license_manager.apps.api.tasks import (
     activation_email_task,
@@ -274,7 +274,7 @@ class LearnerLicensesViewSet(PermissionRequiredForListingMixin, ListModelMixin, 
     """
     authentication_classes = [JwtAuthentication]
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, filters.SearchFilter]
-    filterset_class = LicenseStatusFilter
+    filterset_class = LicenseFilter
     ordering_fields = [
         'user_email',
         'status',
@@ -381,7 +381,7 @@ class BaseLicenseViewSet(PermissionRequiredForListingMixin, viewsets.ReadOnlyMod
         'last_remind_date',
     ]
     search_fields = ['user_email']
-    filterset_class = LicenseStatusFilter
+    filterset_class = LicenseFilter
     permission_required = constants.SUBSCRIPTIONS_ADMIN_LEARNER_ACCESS_PERMISSION
 
     # The fields that control permissions for 'list' actions.
@@ -746,7 +746,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         # Send activation reminder email to all pending users
         send_reminder_email_task.delay(
             self._get_custom_text(request.data),
-            pending_user_emails,
+            sorted(pending_user_emails),
             subscription_uuid,
         )
 

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -123,6 +123,7 @@ class LicenseFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyFunction(uuid4)
     activation_key = factory.LazyFunction(uuid4)
+    user_email = factory.LazyAttribute(lambda a: f'{a.uuid}@example.com')
     status = UNASSIGNED
     subscription_plan = factory.SubFactory(SubscriptionPlanFactory)
     revoked_date = None


### PR DESCRIPTION
## Description

Adds support for a `ignore_null_emails` query parameter when retrieving licenses, such that licenses with a missing `user_email` are not included in the results.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4841

Related PR: https://github.com/edx/frontend-app-admin-portal/pull/636

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
