### PR TITLE
feat: ENT-4992 | Add auto-apply endpoint for CustomerAgreement view

### DIFF
--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -64,6 +64,7 @@ class SegmentEvents:
     LICENSE_EXPIRED = 'edx.server.license-manager.license-lifecycle.expired'
     LICENSE_RENEWED = 'edx.server.license-manager.license-lifecycle.renewed'
     LICENSE_REVOKED = 'edx.server.license-manager.license-lifecycle.revoked'
+    LICENSE_NOT_ASSIGNED = 'edx.server.license-manager.license-lifecycle.not-assigned'
 
 
 # Template names used for emails

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -204,7 +204,8 @@ def get_license_tracking_properties(license_obj):
         "activation_date": activation_date_formatted,
         "assigned_lms_user_id": (license_obj.lms_user_id or ''),
         "assigned_email": (license_obj.user_email or ''),
-        "expiration_processed": license_obj.subscription_plan.expiration_processed
+        "expiration_processed": license_obj.subscription_plan.expiration_processed,
+        "auto_applied": (license_obj.auto_applied or False),
     }
 
     if license_obj and license_obj.subscription_plan and license_obj.subscription_plan.customer_agreement:

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -146,6 +146,21 @@ class CustomerAgreement(TimeStampedModel):
             net_days = max(net_days, plan.days_until_expiration_including_renewals)
         return net_days
 
+    @property
+    def auto_applicable_subscription(self):
+        """
+        Get which subscription on CustomerAgreement is auto_appliable.
+        """
+        now = localized_utcnow()
+        plan = self.subscriptions.filter(
+            should_auto_apply_licenses=True,
+            is_active=True,
+            start_date__lte=now,
+            expiration_date__gte=now
+        ).first()
+
+        return plan
+
     def save(self, *args, **kwargs):
         """
         Before saving this CustomerAgreement instance, if the enterprise_customer_slug

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -93,6 +93,7 @@ class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
     # though this can be overridden to test others
     plan_type_id = 4
     can_freeze_unused_licenses = False
+    should_auto_apply_licenses = False
 
 
 class SubscriptionPlanRenewalFactory(factory.django.DjangoModelFactory):
@@ -127,6 +128,7 @@ class LicenseFactory(factory.django.DjangoModelFactory):
     status = UNASSIGNED
     subscription_plan = factory.SubFactory(SubscriptionPlanFactory)
     revoked_date = None
+    auto_applied = False
 
 
 class UserFactory(factory.django.DjangoModelFactory):

--- a/license_manager/apps/subscriptions/tests/test_event_utils.py
+++ b/license_manager/apps/subscriptions/tests/test_event_utils.py
@@ -24,7 +24,8 @@ def test_get_license_tracking_properties():
         subscription_plan=SubscriptionPlanFactory.create(),
         lms_user_id=5,
         user_email=test_email,
-        status=ASSIGNED)
+        status=ASSIGNED,
+        auto_applied=True)
     flat_data = get_license_tracking_properties(assigned_license)
     assert flat_data['license_uuid'] == str(assigned_license.uuid)
     assert flat_data['license_activation_key'] == str(assigned_license.activation_key)
@@ -33,6 +34,7 @@ def test_get_license_tracking_properties():
     assert flat_data['activation_date'] == _iso_8601_format_string(assigned_license.activation_date)
     assert flat_data['assigned_lms_user_id'] == assigned_license.lms_user_id
     assert flat_data['assigned_email'] == test_email
+    assert flat_data['auto_applied'] is True
     assert flat_data['enterprise_customer_uuid'] \
         == str(assigned_license.subscription_plan.customer_agreement.enterprise_customer_uuid)
     assert flat_data['enterprise_customer_slug'] \


### PR DESCRIPTION
## Description

Definitely read the code to make sure I'm not lying, but response-code-wise, the intent is:

```
No auto-applicable plan --> 422
Plan exists, but user has been revoked previously --> 422
Plan exists, but user has assigned/activated license --> 200 (and no new license associated)
Plan exists, user not revoked/assigned/activated on License already, but no remaining unassigned licenses on plan --> 422 
Plan exists, user not revoked/assigned/activated on License already, and unassigned licenses remaining --> 200 (new license associated with user)
```

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4992

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
