### PR TITLE
fix: add should_auto_apply_licenses as hidden input 

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -27,10 +27,18 @@ class SubscriptionPlanForm(forms.ModelForm):
         min_value=MIN_NUM_LICENSES,
     )
 
-    # Using a HidenInput widget here allows us to hide the property
+    # Using a HiddenInput widget here allows us to hide the property
     # on the creation form while still displaying the property
     # as read-only on the SubscriptionPlan update form.
     num_revocations_remaining = forms.IntegerField(
+        required=False,
+        widget=forms.HiddenInput()
+    )
+
+    # Using a HiddenInput widget here allows us to hide the property
+    # on the creation form while still displaying the property
+    # as read-only on the SubscriptionPlan update form.
+    should_auto_apply_licenses = forms.ChoiceField(
         required=False,
         widget=forms.HiddenInput()
     )
@@ -96,7 +104,7 @@ class SubscriptionPlanForm(forms.ModelForm):
 
 
 class SubscriptionPlanRenewalForm(forms.ModelForm):
-    # Using a HidenInput widget here allows us to hide the property
+    # Using a HiddenInput widget here allows us to hide the property
     # on the creation form while still displaying the property
     # as read-only on the SubscriptionPlanRenewalForm update form.
     renewed_subscription_plan = forms.IntegerField(


### PR DESCRIPTION
## Description

This field showed up when creating a new subscription and it should be hidden.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4991

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
