### PR TITLE
fix: check if instance exists in CustomerAgreementAdminForm

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -157,13 +157,19 @@ class CustomerAgreementAdminForm(forms.ModelForm):
     Helps convert the unuseful database value, stored in microseconds,
     of ``license_duration_before_purge`` to a useful value, and vica versa.
     """
-    subscription_for_auto_applied_licenses = forms.ChoiceField()
+
+    # Hide this field when creating a new CustomerAgreement
+    subscription_for_auto_applied_licenses = forms.ChoiceField(
+        required=False,
+        widget=forms.HiddenInput()
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        instance = kwargs['instance']
-        self.populate_subscription_for_auto_applied_licenses_choices(instance)
+        if 'instance' in kwargs:
+            instance = kwargs['instance']
+            self.populate_subscription_for_auto_applied_licenses_choices(instance)
 
     def populate_subscription_for_auto_applied_licenses_choices(self, instance):
         now = localized_utcnow()
@@ -175,6 +181,7 @@ class CustomerAgreementAdminForm(forms.ModelForm):
         )
 
         current_plan = SubscriptionPlan.objects.filter(
+            customer_agreement=instance,
             should_auto_apply_licenses=True
         ).first()
 

--- a/license_manager/apps/subscriptions/tests/test_forms.py
+++ b/license_manager/apps/subscriptions/tests/test_forms.py
@@ -226,3 +226,25 @@ class TestCustomerAgreementAdminForm(TestCase):
         self.assertEqual(choices[0], ('', '------'))
         self.assertEqual(choices[1], (current_sub_for_auto_applied_licenses.uuid, current_sub_for_auto_applied_licenses.title))
         self.assertEqual(field.initial, (current_sub_for_auto_applied_licenses.uuid, current_sub_for_auto_applied_licenses.title))
+
+    def test_populate_subscription_for_auto_applied_licenses_plans_outside_agreement_not_included(self):
+        customer_agreement_1 = CustomerAgreementFactory()
+        customer_agreement_2 = CustomerAgreementFactory()
+
+        sub_for_customer_agreement_1 = SubscriptionPlanFactory(
+            customer_agreement=customer_agreement_1,
+            should_auto_apply_licenses=False
+        )
+        SubscriptionPlanFactory(customer_agreement=customer_agreement_2, should_auto_apply_licenses=True)
+
+        form = make_bound_customer_agreement_form(
+            customer_agreement=customer_agreement_1,
+            subscription_for_auto_applied_licenses=None
+        )
+
+        field = form.fields['subscription_for_auto_applied_licenses']
+        choices = field.choices
+        self.assertEqual(len(choices), 2)
+        self.assertEqual(choices[0], ('', '------'))
+        self.assertEqual(choices[1], (sub_for_customer_agreement_1.uuid, sub_for_customer_agreement_1.title))
+        self.assertEqual(field.initial, choices[0], ('', '------'))


### PR DESCRIPTION
## Description

Fixing the customer agreement form creation where the instance doesn't exist yet.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
