### PR TITLE
fix: Cleanup test suite warnings in license manager

### DIFF
--- a/license_manager/apps/api/urls.py
+++ b/license_manager/apps/api/urls.py
@@ -4,12 +4,12 @@ Root API URLs.
 All API URLs should be versioned, so urlpatterns should only
 contain namespaces for the active versions of the API.
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from license_manager.apps.api.v1 import urls as v1_urls
 
 
 app_name = 'api'
 urlpatterns = [
-    url(r'^v1/', include(v1_urls)),
+    re_path(r'^v1/', include(v1_urls)),
 ]

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -7,7 +7,7 @@ nested routes backed by the `SubscriptionViewSet`.  That is:
 /api/v1/subscriptions/{subscription_uuid}/licenses/
 /api/v1/subscriptions/{subscription_uuid}/licenses/{license_uuid}/
 """
-from django.conf.urls import url
+from django.urls import re_path
 from rest_framework_nested import routers
 
 from license_manager.apps.api.v1 import views
@@ -89,27 +89,27 @@ subscription_router.register(
 )
 
 urlpatterns = [
-    url(
+    re_path(
         r'bulk-license-enrollment',
         views.EnterpriseEnrollmentWithLicenseSubsidyView.as_view(),
         name='bulk-license-enrollment',
     ),
-    url(
+    re_path(
         r'license-subsidy',
         views.LicenseSubsidyView.as_view(),
         name='license-subsidy',
     ),
-    url(
+    re_path(
         r'license-activation',
         views.LicenseActivationView.as_view(),
         name='license-activation',
     ),
-    url(
+    re_path(
         r'retire_user',
         views.UserRetirementView.as_view(),
         name='user-retirement',
     ),
-    url(
+    re_path(
         r'staff_lookup_licenses',
         views.StaffLicenseLookupView.as_view(),
         name='staff-lookup-licenses',

--- a/license_manager/apps/subscriptions/management/commands/tests/test_expire_subscriptions.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_expire_subscriptions.py
@@ -12,15 +12,15 @@ from license_manager.apps.subscriptions.constants import (
     LICENSE_EXPIRATION_BATCH_SIZE,
     REVOKED,
 )
-from license_manager.apps.subscriptions.management.commands.expire_subscriptions import (
-    DATE_FORMAT,
-)
 from license_manager.apps.subscriptions.models import License, SubscriptionPlan
 from license_manager.apps.subscriptions.tests.factories import (
     LicenseFactory,
     SubscriptionPlanFactory,
 )
-from license_manager.apps.subscriptions.utils import localized_utcnow
+from license_manager.apps.subscriptions.utils import (
+    localized_datetime,
+    localized_utcnow,
+)
 
 
 @pytest.mark.django_db
@@ -114,18 +114,18 @@ class ExpireSubscriptionsCommandTests(TestCase):
         Verifies that all expired and unprocessed subscriptions within the expired range have their license uuids sent to edx-enterprise.
         """
         expired_subscription_1 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2013-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2014-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2013, 1, 1),
+            expiration_date=localized_datetime(2014, 1, 1),
         )
 
         expired_subscription_2 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2015-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2016-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2015, 1, 1),
+            expiration_date=localized_datetime(2016, 1, 1),
         )
 
         expired_subscription_3 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2015-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2016-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2015, 1, 1),
+            expiration_date=localized_datetime(2016, 1, 1),
             expiration_processed=True
         )
 
@@ -163,14 +163,14 @@ class ExpireSubscriptionsCommandTests(TestCase):
         """
 
         expired_subscription_1 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2013-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2014-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2013, 1, 1),
+            expiration_date=localized_datetime(2014, 1, 1),
             expiration_processed=True
         )
 
         expired_subscription_2 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2015-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2016-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2015, 1, 1),
+            expiration_date=localized_datetime(2016, 1, 1),
             expiration_processed=True
         )
 
@@ -212,14 +212,14 @@ class ExpireSubscriptionsCommandTests(TestCase):
         """
 
         expired_subscription_1 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2013-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2014-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2013, 1, 1),
+            expiration_date=localized_datetime(2014, 1, 1),
             expiration_processed=True
         )
 
         expired_subscription_2 = SubscriptionPlanFactory.create(
-            start_date=datetime.strptime('2015-1-01T00:00:00', DATE_FORMAT),
-            expiration_date=datetime.strptime('2016-1-01T00:00:00', DATE_FORMAT),
+            start_date=localized_datetime(2015, 1, 1),
+            expiration_date=localized_datetime(2016, 1, 1),
             expiration_processed=False
         )
 

--- a/license_manager/settings/production.py
+++ b/license_manager/settings/production.py
@@ -23,7 +23,7 @@ FILE_STORAGE_BACKEND = {}
 
 CONFIG_FILE = get_env_setting('LICENSE_MANAGER_CFG')
 with open(CONFIG_FILE, encoding='utf-8') as f:
-    config_from_yaml = yaml.load(f)
+    config_from_yaml = yaml.safe_load(f)
 
     # Remove the items that should be used to update dicts, and apply them separately rather
     # than pumping them into the local vars.

--- a/license_manager/settings/test.py
+++ b/license_manager/settings/test.py
@@ -28,3 +28,5 @@ import logging
 
 for logger_to_silence in ['faker', 'jwkest', 'edx_rest_framework_extensions']:
     logging.getLogger(logger_to_silence).setLevel(logging.WARNING)
+# Specifically silence license manager event_utils warnings
+logging.getLogger('event_utils').setLevel(logging.ERROR)

--- a/license_manager/urls.py
+++ b/license_manager/urls.py
@@ -4,21 +4,21 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
 
 import os
 
 from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, re_path
 from drf_yasg.views import get_schema_view
 from edx_api_doc_tools import make_api_info
 from rest_framework import permissions
@@ -38,13 +38,13 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    url(r'', include(oauth2_urlpatterns)),
-    url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
-    url(r'^admin/', admin.site.urls),
-    url(r'^api/', include(api_urls)),
-    url(r'^api-docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
-    url(r'^health/$', core_views.health, name='health'),
+    re_path(r'', include(oauth2_urlpatterns)),
+    re_path(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^api/', include(api_urls)),
+    re_path(r'^api-docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
+    re_path(r'^health/$', core_views.health, name='health'),
 ]
 
 
@@ -52,4 +52,4 @@ if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma:
     # Disable pylint import error because we don't install django-debug-toolbar
     # for CI build
     import debug_toolbar  # pylint: disable=import-error,useless-suppression
-    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(re_path(r'^__debug__/', include(debug_toolbar.urls)))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,9 +16,9 @@ backoff==1.10.0
     #   analytics-python
 billiard==3.6.4.0
     # via celery
-boto3==1.18.60
+boto3==1.19.8
     # via django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   boto3
     #   s3transfer
@@ -29,7 +29,7 @@ celery==4.4.7
     #   edx-celeryutils
 certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.7
     # via requests
@@ -47,7 +47,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -81,7 +81,7 @@ django-extensions==3.1.3
     # via -r requirements/base.in
 django-filter==21.1
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
@@ -108,13 +108,13 @@ djangorestframework-csv==2.1.1
     # via -r requirements/base.in
 drf-jwt==1.19.1
     # via edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/base.in
 drf-yasg==1.20.0
     # via edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/base.in
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/base.in
 edx-celeryutils==1.1.1
     # via -r requirements/base.in
@@ -123,13 +123,13 @@ edx-django-utils==4.4.0
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/base.in
     #   edx-rbac
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/base.in
 edx-rest-api-client==5.4.0
     # via -r requirements/base.in
@@ -164,13 +164,13 @@ monotonic==1.6
     # via analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via edx-django-utils
 oauthlib==3.1.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via drf-yasg
 pbr==5.6.0
     # via stevedore
@@ -182,14 +182,14 @@ pycryptodomex==3.11.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
@@ -220,7 +220,7 @@ requests==2.26.0
     #   social-auth-core
 requests-oauthlib==1.3.0
     # via social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via drf-yasg
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
@@ -251,7 +251,7 @@ social-auth-core==4.1.0
     #   social-auth-app-django
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,11 +31,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -49,7 +49,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/validation.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/validation.txt
     #   cryptography
@@ -83,7 +83,7 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0.2
+coverage[toml]==6.1.1
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -105,7 +105,7 @@ diff-cover==4.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.in
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
@@ -148,7 +148,7 @@ django-extensions==3.1.3
     #   -r requirements/validation.txt
 django-filter==21.1
     # via -r requirements/validation.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-celeryutils
@@ -177,7 +177,7 @@ drf-jwt==1.19.1
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/validation.txt
 drf-yasg==1.20.0
     # via
@@ -185,7 +185,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/validation.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/validation.txt
 edx-celeryutils==1.1.1
     # via -r requirements/validation.txt
@@ -194,23 +194,23 @@ edx-django-utils==4.4.0
     #   -r requirements/validation.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
 edx-i18n-tools==0.8.1
     # via -r requirements/validation.txt
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/validation.txt
 edx-opaque-keys==2.2.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/validation.txt
 edx-rest-api-client==5.4.0
     # via -r requirements/validation.txt
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/validation.txt
 faker==8.1.3
     # via
@@ -293,7 +293,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/validation.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -302,7 +302,7 @@ oauthlib==3.1.1
     #   -r requirements/validation.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/validation.txt
     #   drf-yasg
@@ -317,7 +317,7 @@ pbr==5.6.0
     # via
     #   -r requirements/validation.txt
     #   stevedore
-pep517==0.11.0
+pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -358,7 +358,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/validation.txt
     #   drf-jwt
@@ -387,7 +387,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/validation.txt
     #   edx-opaque-keys
@@ -428,7 +428,7 @@ pytz==2021.3
     #   django-ses
 pywatchman==1.4.1
     # via -r requirements/dev.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
@@ -451,7 +451,7 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/validation.txt
     #   social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/validation.txt
     #   drf-yasg
@@ -506,7 +506,7 @@ sqlparse==0.4.2
     #   -r requirements/validation.txt
     #   django
     #   django-debug-toolbar
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -522,7 +522,7 @@ toml==0.10.2
     #   -r requirements/validation.txt
     #   pylint
     #   pytest
-tomli==1.2.1
+tomli==1.2.2
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -37,11 +37,11 @@ billiard==3.6.4.0
     #   celery
 bleach==4.1.0
     # via readme-renderer
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -55,7 +55,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
@@ -87,7 +87,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0.2
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -103,7 +103,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -140,7 +140,7 @@ django-extensions==3.1.3
     # via -r requirements/test.txt
 django-filter==21.1
     # via -r requirements/test.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -177,7 +177,7 @@ drf-jwt==1.19.1
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/test.txt
 drf-yasg==1.20.0
     # via
@@ -185,7 +185,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/test.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/test.txt
 edx-celeryutils==1.1.1
     # via -r requirements/test.txt
@@ -194,23 +194,23 @@ edx-django-utils==4.4.0
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/test.txt
 edx-opaque-keys==2.2.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/test.txt
 edx-rest-api-client==5.4.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/test.txt
 faker==8.1.3
     # via
@@ -286,7 +286,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -295,7 +295,7 @@ oauthlib==3.1.1
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/test.txt
     #   bleach
@@ -335,7 +335,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -364,7 +364,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -404,7 +404,7 @@ pytz==2021.3
     #   celery
     #   django
     #   django-ses
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -431,7 +431,7 @@ requests-oauthlib==1.3.0
     #   social-auth-core
 restructuredtext-lint==1.3.2
     # via doc8
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -501,7 +501,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -518,7 +518,7 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
-tomli==1.2.1
+tomli==1.2.2
     # via
     #   -r requirements/test.txt
     #   coverage

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,11 +8,11 @@ click==7.1.2
     # via
     #   -c requirements/constraints.txt
     #   pip-tools
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip-tools.in
-tomli==1.2.1
+tomli==1.2.2
     # via pep517
 wheel==0.37.0
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,11 +22,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -40,7 +40,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -67,7 +67,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -102,7 +102,7 @@ django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -131,7 +131,7 @@ drf-jwt==1.19.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0
     # via
@@ -139,7 +139,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/base.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/base.txt
 edx-celeryutils==1.1.1
     # via -r requirements/base.txt
@@ -148,7 +148,7 @@ edx-django-utils==4.4.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -156,7 +156,7 @@ edx-opaque-keys==2.2.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/base.txt
 edx-rest-api-client==5.4.0
     # via -r requirements/base.txt
@@ -213,7 +213,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -222,7 +222,7 @@ oauthlib==3.1.1
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -246,7 +246,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -254,7 +254,7 @@ pyjwt[crypto]==2.2.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -280,7 +280,7 @@ pytz==2021.3
     #   celery
     #   django
     #   django-ses
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
@@ -301,7 +301,7 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -349,7 +349,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,11 +26,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -44,7 +44,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -81,7 +81,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -116,7 +116,7 @@ django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -145,7 +145,7 @@ drf-jwt==1.19.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0
     # via
@@ -153,7 +153,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/base.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/base.txt
 edx-celeryutils==1.1.1
     # via -r requirements/base.txt
@@ -162,17 +162,17 @@ edx-django-utils==4.4.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/quality.in
 edx-opaque-keys==2.2.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/base.txt
 edx-rest-api-client==5.4.0
     # via -r requirements/base.txt
@@ -232,7 +232,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -241,7 +241,7 @@ oauthlib==3.1.1
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -269,7 +269,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -292,7 +292,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -318,7 +318,7 @@ pytz==2021.3
     #   celery
     #   django
     #   django-ses
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   code-annotations
@@ -339,7 +339,7 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -389,7 +389,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -46,7 +46,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -75,7 +75,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0.2
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -127,7 +127,7 @@ django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -156,7 +156,7 @@ drf-jwt==1.19.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0
     # via
@@ -164,7 +164,7 @@ drf-yasg==1.20.0
     #   edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/base.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via -r requirements/base.txt
 edx-celeryutils==1.1.1
     # via -r requirements/base.txt
@@ -173,21 +173,21 @@ edx-django-utils==4.4.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/test.in
 edx-opaque-keys==2.2.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via -r requirements/base.txt
 edx-rest-api-client==5.4.0
     # via -r requirements/base.txt
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/test.in
 faker==8.1.3
     # via
@@ -251,7 +251,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -260,7 +260,7 @@ oauthlib==3.1.1
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -289,7 +289,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -312,7 +312,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -348,7 +348,7 @@ pytz==2021.3
     #   celery
     #   django
     #   django-ses
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   code-annotations
@@ -369,7 +369,7 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -418,7 +418,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -432,7 +432,7 @@ toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.1
+tomli==1.2.2
     # via coverage
 unicodecsv==0.14.1
     # via

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,17 +12,17 @@ charset-normalizer==2.0.7
     # via requests
 codecov==2.1.12
     # via -r requirements/travis.in
-coverage==6.0.2
+coverage==6.1.1
     # via codecov
 distlib==0.3.3
     # via virtualenv
-filelock==3.3.0
+filelock==3.3.2
     # via
     #   tox
     #   virtualenv
 idna==3.3
     # via requests
-packaging==21.0
+packaging==21.2
     # via tox
 platformdirs==2.4.0
     # via virtualenv
@@ -44,5 +44,5 @@ tox==3.24.4
     # via -r requirements/travis.in
 urllib3==1.26.7
     # via requests
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via tox

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -38,12 +38,12 @@ billiard==3.6.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.18.60
+boto3==1.19.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.21.60
+botocore==1.22.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -60,7 +60,7 @@ certifi==2021.10.8
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -99,7 +99,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0.2
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -117,7 +117,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.8
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -165,7 +165,7 @@ django-filter==21.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -204,7 +204,7 @@ drf-jwt==1.19.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-nested-routers==0.93.3
+drf-nested-routers==0.93.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -217,7 +217,7 @@ edx-api-doc-tools==1.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-auth-backends==4.0.0
+edx-auth-backends==4.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -231,14 +231,14 @@ edx-django-utils==4.4.0
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
 edx-i18n-tools==0.8.1
     # via -r requirements/validation.in
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -247,7 +247,7 @@ edx-opaque-keys==2.2.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.5.0
+edx-rbac==1.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -255,7 +255,7 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/test.txt
 faker==8.1.3
     # via
@@ -343,7 +343,7 @@ mysqlclient==2.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==7.2.1.168
+newrelic==7.2.2.169
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -354,7 +354,7 @@ oauthlib==3.1.1
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -403,7 +403,7 @@ pyjwkest==1.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -437,7 +437,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -482,7 +482,7 @@ pytz==2021.3
     #   celery
     #   django
     #   django-ses
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -510,7 +510,7 @@ requests-oauthlib==1.3.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-ruamel.yaml==0.17.16
+ruamel.yaml==0.17.17
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -577,7 +577,7 @@ sqlparse==0.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -596,7 +596,7 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
-tomli==1.2.1
+tomli==1.2.2
     # via
     #   -r requirements/test.txt
     #   coverage


### PR DESCRIPTION
## Description

Cleaning up test warnings, running `make upgrade`
NOTE: pyyaml 6.0 will break if you use `yaml.load()` so I've changed that to `yaml.safe_load()` (which demographics also has done)

Link to the associated ticket: n/a

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
