### PR TITLE
fix: fix broken CustomerAgreement creation from Django Admin

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -336,7 +336,11 @@ class CustomerAgreementAdmin(admin.ModelAdmin):
         """
         if obj:
             return self.read_only_fields
-        return ('enterprise_customer_slug', 'license_duration_before_purge')
+        return (
+            'enterprise_customer_slug',
+            'license_duration_before_purge',
+            'get_subscription_plan_links',
+        )
 
     def get_subscription_plan_links(self, obj):
         links = []


### PR DESCRIPTION
A previous admin change broke our ability to add new CustomerAgreements,
because the get_subscription_plan_links field was not included in the set of
read-only fields for new agreements.  This change adds the field to that set.

ENT-5114

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5114

## Testing considerations

Check out branch and make sure you can create a new CustomerAgreement.

![image](https://user-images.githubusercontent.com/2307986/139917880-8991c527-56ef-444e-8f87-fd1345265180.png)

