### PR TITLE
fix: handle null instance when populating customer agreement form

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -169,7 +169,8 @@ class CustomerAgreementAdminForm(forms.ModelForm):
 
         if 'instance' in kwargs:
             instance = kwargs['instance']
-            self.populate_subscription_for_auto_applied_licenses_choices(instance)
+            if instance:
+                self.populate_subscription_for_auto_applied_licenses_choices(instance)
 
     def populate_subscription_for_auto_applied_licenses_choices(self, instance):
         now = localized_utcnow()


### PR DESCRIPTION
## Description

The instance can exist in kwargs but be None, breaking the form when saving 😢 . Nothing is broken in prod yet.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4996

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
