### PR TITLE
feat: add migration to back populate product

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -160,8 +160,6 @@ class SubscriptionPlanAdmin(SimpleHistoryAdmin):
         'expiration_date',
         'enterprise_catalog_uuid',
         'salesforce_opportunity_id',
-        'netsuite_product_id',
-        'plan_type',
         'product',
         'revoke_max_percentage',
         'is_revocation_cap_enabled',
@@ -248,6 +246,10 @@ class SubscriptionPlanAdmin(SimpleHistoryAdmin):
         # If a uuid is not specified on the subscription itself, use the default one for the CustomerAgreement
         customer_agreement_catalog = obj.customer_agreement.default_enterprise_catalog_uuid
         obj.enterprise_catalog_uuid = (obj.enterprise_catalog_uuid or customer_agreement_catalog)
+
+        # assign netsuite_id using and plan_type using product until column is fully deprecated
+        obj.netsuite_product_id = obj.product.netsuite_id
+        obj.plan_type = obj.product.plan_type
 
         # Create licenses to be associated with the subscription plan after creating the subscription plan
         num_new_licenses = form.cleaned_data.get('num_licenses', 0) - obj.num_licenses

--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -82,18 +82,19 @@ class SubscriptionPlanForm(forms.ModelForm):
             self.add_error('revoke_max_percentage', 'Must be a valid percentage (0-100).')
             return False
 
-        # Ensure plan_type has appropriate ids
-        plan_type = self.cleaned_data.get('plan_type')
-        if plan_type.sf_id_required and self.cleaned_data.get('salesforce_opportunity_id') is None:
+        product = self.cleaned_data.get('product')
+
+        if not product:
             self.add_error(
-                'plan_type',
-                'You must specify Salesforce ID for selected plan type.',
+                'product',
+                'You must specify a product.',
             )
             return False
-        elif plan_type.ns_id_required and self.cleaned_data.get('netsuite_product_id') is None:
+
+        if product.plan_type.sf_id_required and self.cleaned_data.get('salesforce_opportunity_id') is None:
             self.add_error(
-                'plan_type',
-                'You must specify Netsuite ID for selected plan type.',
+                'salesforce_opportunity_id',
+                'You must specify Salesforce ID for selected product.',
             )
             return False
 

--- a/license_manager/apps/subscriptions/management/commands/seed_development_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_development_data.py
@@ -1,0 +1,38 @@
+from django.core.management.base import BaseCommand
+
+from license_manager.apps.subscriptions.models import PlanType, Product
+
+
+class Command(BaseCommand):
+    """
+    Management command for populating License Manager data required for development.
+    """
+
+    help = 'Seeds all the data required for development.'
+
+    def _create_products(self):
+        Product.objects.get_or_create(
+            name='B2B Paid',
+            description='B2B Catalog',
+            plan_type=PlanType.objects.get(label="Standard Paid"),
+            netsuite_id=106
+        )
+        Product.objects.get_or_create(
+            name='OC Paid',
+            description='OC Catalog',
+            plan_type=PlanType.objects.get(label="Standard Paid"),
+            netsuite_id=110
+        )
+        Product.objects.get_or_create(
+            name='Trial',
+            description='Trial Catalog',
+            plan_type=PlanType.objects.get(label="Trial")
+        )
+        Product.objects.get_or_create(
+            name='Test',
+            description='Test Catalog',
+            plan_type=PlanType.objects.get(label="Test")
+        )
+
+    def handle(self, *args, **options):
+        self._create_products()

--- a/license_manager/apps/subscriptions/migrations/0047_populate_subscription_product.py
+++ b/license_manager/apps/subscriptions/migrations/0047_populate_subscription_product.py
@@ -1,0 +1,53 @@
+from django.db import migrations
+from collections import defaultdict
+
+def populate_product(apps, schema_editor):
+    SubscriptionPlan = apps.get_model('subscriptions', 'SubscriptionPlan')
+    Product = apps.get_model("subscriptions", "Product")
+
+    product_by_ns_id = {}
+    products_by_plan_type_id = defaultdict(list)
+
+    for product in Product.objects.all():
+        if product.netsuite_id:
+            # Netsuite Id is unique amongst plans
+            product_by_ns_id[product.netsuite_id] = product
+
+        products_by_plan_type_id[product.plan_type_id].append(product)
+
+    for plan in SubscriptionPlan.objects.all().iterator():
+        plan_uuid = plan.uuid
+        ns_id = plan.netsuite_product_id
+        plan_type_id = plan.plan_type_id
+        products_with_plan_type = products_by_plan_type_id.get(plan_type_id)
+
+        if ns_id:
+            # Netsuite Id must be correct for each plan before this migration is run
+            product_to_associate = product_by_ns_id.get(ns_id)
+
+            if not product_to_associate:
+                product_to_associate = products_with_plan_type[0]
+                print(f"Associated subscription plan {plan_uuid} to {product_to_associate}, Netsuite Id {ns_id} was ignored.")
+
+            plan.product = product_to_associate
+            plan.save()
+        else:
+            product_to_associate = products_with_plan_type[0]
+            plan.product = product_to_associate
+            plan.save()
+
+
+def depopulate_product(apps, schema_editor):
+    SubscriptionPlan = apps.get_model('subscriptions', 'SubscriptionPlan')
+    for row in SubscriptionPlan.objects.all():
+        row.product = None
+        row.save()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('subscriptions', '0046_add_product_and_association_to_subscription_plan'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_product, depopulate_product),
+    ]

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -15,6 +15,7 @@ from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
     PlanType,
+    Product,
     SubscriptionPlan,
     SubscriptionPlanRenewal,
 )
@@ -67,6 +68,18 @@ class PlanTypeFactory(factory.django.DjangoModelFactory):
         model = PlanType
 
 
+class ProductFactory(factory.django.DjangoModelFactory):
+    """
+    Test factory for the `Product` model.
+    """
+    name = 'Test Product'
+    description = 'Test Product'
+    plan_type = factory.SubFactory(PlanTypeFactory)
+
+    class Meta:
+        model = Product
+
+
 class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `SubscriptionPlan` model.
@@ -89,6 +102,7 @@ class SubscriptionPlanFactory(factory.django.DjangoModelFactory):
     enterprise_catalog_uuid = factory.LazyFunction(uuid4)
     netsuite_product_id = factory.Faker('random_int')
     salesforce_opportunity_id = factory.LazyFunction(get_random_salesforce_id)
+    product = factory.SubFactory(ProductFactory)
     # By default, all the subscription plans created are Test type,
     # though this can be overridden to test others
     plan_type_id = 4

--- a/license_manager/apps/subscriptions/tests/test_admin.py
+++ b/license_manager/apps/subscriptions/tests/test_admin.py
@@ -33,9 +33,8 @@ def test_licenses_subscription_creation():
     subscription_admin = SubscriptionPlanAdmin(SubscriptionPlan, AdminSite())
     request = RequestFactory()
     request.user = UserFactory()
-    plan_type = PlanTypeFactory.create()
     num_licenses = 5
-    form = make_bound_subscription_form(num_licenses=num_licenses, plan_type=plan_type)
+    form = make_bound_subscription_form(num_licenses=num_licenses)
     obj = form.save()  # Get the object returned from saving the form to save to the database
     assert obj.licenses.count() == 0  # Verify no Licenses have been created yet
     change = False

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -17,6 +17,8 @@ from license_manager.apps.subscriptions.forms import (
 from license_manager.apps.subscriptions.tests.factories import (
     CustomerAgreementFactory,
     LicenseFactory,
+    PlanTypeFactory,
+    ProductFactory,
     SubscriptionPlanFactory,
     get_random_salesforce_id,
 )
@@ -36,7 +38,8 @@ def make_bound_subscription_form(
     num_licenses=0,
     is_active=False,
     for_internal_use_only=False,
-    plan_type=None,
+    has_product=True,
+    is_sf_id_required=False,
     has_customer_agreement=True,
     customer_agreement_has_default_catalog=True,
     change_reason="new"
@@ -49,13 +52,16 @@ def make_bound_subscription_form(
     else:
         customer_agreement = CustomerAgreementFactory(default_enterprise_catalog_uuid=None)
 
+    product = ProductFactory(plan_type=PlanTypeFactory(sf_id_required=is_sf_id_required))
+
     form_data = {
         'title': title,
         'start_date': start_date,
         'expiration_date': expiration_date,
         'enterprise_catalog_uuid': enterprise_catalog_uuid,
+        'product': product.id if has_product else None,
         'netsuite_product_id': netsuite_product_id,
-        'plan_type': plan_type.id,
+        'plan_type': product.plan_type.id,
         'salesforce_opportunity_id': salesforce_opportunity_id,
         'num_licenses': num_licenses,
         'is_active': is_active,

--- a/provision-license-manager.sh
+++ b/provision-license-manager.sh
@@ -19,6 +19,10 @@ sleep 5
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
 docker exec -t license_manager.app bash -c "cd /edx/app/${name}/ && make migrate"
 
+# Seed data for development
+echo -e "${GREEN}Seeding development data..."
+docker exec -t license_manager.app bash -c "python manage.py seed_development_data"
+
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
 docker exec -t license_manager.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"


### PR DESCRIPTION
## Description

Migration to be run when products are created in stage/prod. Back populates the product on a subscription plan depending on the current Netsuite Id/plan type.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5066

## Testing considerations

Check records after to see that everything matched correctly.

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
