### PR TITLE
feat: add ability to revert licenses to snapshot

### DIFF
--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -399,3 +399,7 @@ LIMITED_ALLOCATIONS_REMAINING_CAMPAIGN = os.environ.get('LIMITED_ALLOCATIONS_REM
 BRAZE_API_URL = ''
 BRAZE_API_KEY = os.environ.get('BRAZE_API_KEY', '')
 BRAZE_APP_ID = os.environ.get('BRAZE_APP_ID', '')
+
+# Set a datetime that a django action can reset license state to
+# Use year-month-day hour:minute:second format
+LICENSE_REVERT_SNAPSHOT_TIMESTAMP = '9999-12-31 23:59:59'


### PR DESCRIPTION
## Description

Allows an admin user to revert a selected set of licenses to their historical state as of a timestamp defined in django settings.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
