### PR TITLE
fix: identify braze alias for auto-applied licenses

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -103,6 +103,7 @@ def auto_apply_new_license(subscription_plan, user_email, lms_user_id):
 
     auto_applied_license.save()
     event_utils.track_license_changes([auto_applied_license], constants.SegmentEvents.LICENSE_ACTIVATED)
+    event_utils.identify_braze_alias(lms_user_id, user_email)
     return auto_applied_license
 
 


### PR DESCRIPTION
## Description

Adds a call to identity the authenticated user with their Braze user alias when granted an auto-applied license. This was discovered to be needed after reviewing a similar change made for the LicenseActivationView `POST`.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
