### PR TITLE
feat: add notification admin

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -25,6 +25,7 @@ from license_manager.apps.subscriptions.forms import (
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
+    Notification,
     PlanType,
     Product,
     SubscriptionPlan,
@@ -548,3 +549,25 @@ class ProductAdmin(admin.ModelAdmin):
         'name',
         'netsuite_id',
     )
+
+
+@admin.register(Notification)
+class NotificationAdmin(admin.ModelAdmin):
+    list_display = (
+        'enterprise_customer_uuid',
+        'enterprise_customer_user_uuid',
+        'subscripton_plan_id',
+        'notification_type',
+        'last_sent',
+    )
+
+    list_filter = (
+        'notification_type',
+    )
+
+    search_fields = (
+        'subscripton_plan__uuid__startswith',
+    )
+
+    def has_change_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
## Description

Add read-only notification admin model so that admins can see what notifications has been sent.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5157

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
