### PR TITLE
fix: add history when toggling auto apply on subscription plan

### DIFF
--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -266,13 +266,15 @@ def toggle_auto_apply_licenses(customer_agreement_uuid, subscription_uuid):
     off for the current plan.
 
     """
-    # there should only be one plan for auto-applied licenses
-    current_subs_for_auto_appled_licenses = SubscriptionPlan.objects.filter(
+    # There should only be one plan for auto-applied licenses at any given time
+    current_plan_for_auto_applied_licenses = SubscriptionPlan.objects.filter(
         customer_agreement_id=customer_agreement_uuid,
         should_auto_apply_licenses=True
-    )
+    ).first()
 
-    current_subs_for_auto_appled_licenses.update(should_auto_apply_licenses=False)
+    if current_plan_for_auto_applied_licenses:
+        current_plan_for_auto_applied_licenses.should_auto_apply_licenses = False
+        current_plan_for_auto_applied_licenses.save()
 
     if not subscription_uuid:
         return

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -528,8 +528,8 @@ class ToggleAutoApplyLicensesTests(TestCase):
 
     @ddt.data(None, '')
     def test_toggle_auto_apply_licenses_no_subscription_uuid(self, subscription_uuid):
-        SubscriptionPlan.objects.all().update(should_auto_apply_licenses=True)
-        self.assertEqual(len(SubscriptionPlan.objects.filter(should_auto_apply_licenses=True)), 2)
+        self.subscription_plan_1.should_auto_apply_licenses = True
+        self.subscription_plan_1.save()
         api.toggle_auto_apply_licenses(
             customer_agreement_uuid=self.customer_agreement.uuid,
             subscription_uuid=subscription_uuid


### PR DESCRIPTION
## Description

A history record wasn't being created on the subscription plan when toggling auto applied licenses because bulk_update was being used. We need the change to be recorded and this fixes that.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
