### PR TITLE
fix: make debug toolbar show up in debug mode

### DIFF
--- a/license_manager/settings/local.py
+++ b/license_manager/settings/local.py
@@ -38,6 +38,10 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
 
     DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: DEBUG,
+    }
+
 INTERNAL_IPS = ('127.0.0.1',)
 # END TOOLBAR CONFIGURATION
 


### PR DESCRIPTION
## Description

- make debug toolbar show up in debug mode

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
