### PR TITLE
feat: send segment events to Kafka message bus

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ omit =
     *admin.py
     *static*
     *templates*
+    license_manager/apps/subscriptions/event_bus_utils.py

--- a/license_manager/apps/subscriptions/apps.py
+++ b/license_manager/apps/subscriptions/apps.py
@@ -1,6 +1,8 @@
 import logging
 
 import analytics
+from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka.admin import AdminClient, NewTopic
 from django.apps import AppConfig
 from django.conf import settings
 
@@ -16,3 +18,35 @@ class SubscriptionsConfig(AppConfig):
         if getattr(settings, 'SEGMENT_KEY', None):
             logger.debug("Found segment key, setting up")
             analytics.write_key = settings.SEGMENT_KEY
+
+        # TODO: (ARCHBOM-2004) remove pragma and add tests when finalizing
+        if getattr(settings, 'KAFKA_ENABLED', False):  # pragma: no cover
+            KAFKA_ACCESS_CONF_BASE = {'bootstrap.servers': getattr(settings, 'KAFKA_BOOTSTRAP_SERVER', ''),
+                                      'sasl.mechanism': 'PLAIN',
+                                      'security.protocol': 'SASL_SSL',
+                                      'sasl.username': getattr(settings, 'KAFKA_API_KEY', ''),
+                                      'sasl.password': getattr(settings, 'KAFKA_API_SECRET', '')
+                                      }
+
+            a = AdminClient(KAFKA_ACCESS_CONF_BASE)
+
+            license_event_topic = NewTopic(settings.LICENSE_TOPIC_NAME,
+                                           num_partitions=settings.KAFKA_PARTITIONS_PER_TOPIC,
+                                           replication_factor=settings.KAFKA_REPLICATION_FACTOR_PER_TOPIC)
+            # Call create_topics to asynchronously create topic.
+            # Wait for each operation to finish.
+            topic_futures = a.create_topics([license_event_topic])
+
+            # TODO: (ARCHBOM-2004) programmatically update permissions so the calling app can write to the created topic
+
+            # ideally we could check beforehand if the topic already exists instead of using exceptions as control flow
+            # but that is not in the AdminClient API
+            for topic, f in topic_futures.items():
+                try:
+                    f.result()  # The result itself is None
+                    logger.info(f"Topic {topic} created")
+                except KafkaException as ke:
+                    if ke.args[0].code() == KafkaError.TOPIC_ALREADY_EXISTS:
+                        logger.info(f"Topic {topic} already exists")
+                    else:
+                        raise

--- a/license_manager/apps/subscriptions/apps.py
+++ b/license_manager/apps/subscriptions/apps.py
@@ -1,10 +1,10 @@
 import logging
 
 import analytics
-from confluent_kafka import KafkaError, KafkaException
-from confluent_kafka.admin import AdminClient, NewTopic
 from django.apps import AppConfig
 from django.conf import settings
+
+from .event_bus_utils import create_topic_if_not_exists
 
 
 logger = logging.getLogger(__name__)
@@ -21,32 +21,7 @@ class SubscriptionsConfig(AppConfig):
 
         # TODO: (ARCHBOM-2004) remove pragma and add tests when finalizing
         if getattr(settings, 'KAFKA_ENABLED', False):  # pragma: no cover
-            KAFKA_ACCESS_CONF_BASE = {'bootstrap.servers': getattr(settings, 'KAFKA_BOOTSTRAP_SERVER', ''),
-                                      'sasl.mechanism': 'PLAIN',
-                                      'security.protocol': 'SASL_SSL',
-                                      'sasl.username': getattr(settings, 'KAFKA_API_KEY', ''),
-                                      'sasl.password': getattr(settings, 'KAFKA_API_SECRET', '')
-                                      }
-
-            a = AdminClient(KAFKA_ACCESS_CONF_BASE)
-
-            license_event_topic = NewTopic(settings.LICENSE_TOPIC_NAME,
-                                           num_partitions=settings.KAFKA_PARTITIONS_PER_TOPIC,
-                                           replication_factor=settings.KAFKA_REPLICATION_FACTOR_PER_TOPIC)
-            # Call create_topics to asynchronously create topic.
-            # Wait for each operation to finish.
-            topic_futures = a.create_topics([license_event_topic])
-
-            # TODO: (ARCHBOM-2004) programmatically update permissions so the calling app can write to the created topic
-
-            # ideally we could check beforehand if the topic already exists instead of using exceptions as control flow
-            # but that is not in the AdminClient API
-            for topic, f in topic_futures.items():
-                try:
-                    f.result()  # The result itself is None
-                    logger.info(f"Topic {topic} created")
-                except KafkaException as ke:
-                    if ke.args[0].code() == KafkaError.TOPIC_ALREADY_EXISTS:
-                        logger.info(f"Topic {topic} already exists")
-                    else:
-                        raise
+            try:
+                create_topic_if_not_exists(settings.LICENSE_TOPIC_NAME)
+            except Exception as e:
+                logger.error(f"Error creating topic {settings.LICENSE_TOPIC_NAME}: {e}")

--- a/license_manager/apps/subscriptions/event_bus_utils.py
+++ b/license_manager/apps/subscriptions/event_bus_utils.py
@@ -1,0 +1,179 @@
+"""
+Util classes and methods for producing license events to the event bus. Likely
+temporary.
+"""
+
+import logging
+
+from confluent_kafka import SerializingProducer
+from confluent_kafka.error import ValueSerializationError
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+from confluent_kafka.serialization import StringSerializer
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+# Eventually this class should be moved to openedx_events and changed to an attrib class, and
+# the Attr<->Avro bridge used as a serializer
+# TODO: (ARCHBOM-2004) remove this file from the omit list in coverage.py and add tests when finalized
+
+
+class TrackingEvent:
+    """
+    License events to be put on event bus
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.license_uuid = kwargs['license_uuid']
+        self.license_activation_key = kwargs['license_activation_key']
+        self.previous_license_uuid = kwargs['previous_license_uuid']
+        self.assigned_date = kwargs['assigned_date']
+        self.activation_date = kwargs['activation_date']
+        self.assigned_lms_user_id = kwargs['assigned_lms_user_id']
+        self.assigned_email = kwargs['assigned_email']
+        self.expiration_processed = kwargs['expiration_processed']
+        self.auto_applied = kwargs['auto_applied']
+        self.enterprise_customer_uuid = kwargs.get('enterprise_customer_uuid', None)
+        self.enterprise_customer_slug = kwargs.get('enterprise_customer_slug', None)
+        self.enterprise_customer_name = kwargs.get('enterprise_customer_name', None)
+        self.customer_agreement_uuid = kwargs.get('customer_agreement_uuid', None)
+
+    # Some paths will set assigned_lms_user_id to '' if empty, so need to allow strings in the schema
+    TRACKING_EVENT_AVRO_SCHEMA = """
+        {
+            "namespace": "license_manager.apps.subscriptions",
+            "name": "TrackingEvent",
+            "type": "record",
+            "fields": [
+                {"name": "license_uuid", "type": "string"},
+                {"name": "license_activation_key", "type": "string"},
+                {"name": "previous_license_uuid", "type": "string"},
+                {"name": "assigned_date", "type": "string"},
+                {"name": "assigned_lms_user_id", "type": ["int", "string", "null"], "default": "null"},
+                {"name": "assigned_email", "type":"string"},
+                {"name": "expiration_processed", "type": "boolean"},
+                {"name": "auto_applied", "type": "boolean", "default": "false"},
+                {"name": "enterprise_customer_uuid", "type": ["string", "null"], "default": "null"},
+                {"name": "customer_agreement_uuid", "type": ["string", "null"], "default": "null"},
+                {"name": "enterprise_customer_slug", "type": ["string", "null"], "default": "null"},
+                {"name": "enterprise_customer_name", "type": ["string", "null"], "default": "null"}
+            ]
+        }
+
+    """
+
+    @staticmethod
+    def from_dict(dict_instance, ctx):  # pylint: disable=unused-argument
+        return TrackingEvent(dict_instance)
+
+    @staticmethod
+    def to_dict(obj, ctx):  # pylint: disable=unused-argument
+        return {
+            'enterprise_customer_uuid': obj.enterprise_customer_uuid,
+            'customer_agreement_uuid': obj.customer_agreement_uuid,
+            'enterprise_customer_slug': obj.enterprise_customer_slug,
+            'enterprise_customer_name': obj.enterprise_customer_name,
+            "license_uuid": obj.license_uuid,
+            "license_activation_key": obj.license_activation_key,
+            "previous_license_uuid": obj.previous_license_uuid,
+            "assigned_date": obj.assigned_date,
+            "activation_date": obj.activation_date,
+            "assigned_lms_user_id": obj.assigned_lms_user_id,
+            "assigned_email": (obj.assigned_email or ''),
+            "expiration_processed": obj.expiration_processed,
+            "auto_applied": (obj.auto_applied or False),
+        }
+
+
+# Eventually the following should be moved into a plugin, app, library, or something more reusable
+
+class TrackingEventSerializer:
+    """ Wrapper class used to ensure a single instance of the tracking event serializer.
+     This avoids errors on startup."""
+    TRACKING_EVENT_SERIALIZER = None
+
+    @classmethod
+    def get_serializer(cls):
+        """
+        Get or create a single instance of the TrackingEvent serializer to be used throughout the life of the app
+        :return: AvroSerializer
+        """
+        if cls.TRACKING_EVENT_SERIALIZER is None:
+            KAFKA_SCHEMA_REGISTRY_CONFIG = {
+                'url': getattr(settings, 'SCHEMA_REGISTRY_URL', ''),
+                'basic.auth.user.info': f"{getattr(settings,'SCHEMA_REGISTRY_API_KEY','')}"
+                f":{getattr(settings,'SCHEMA_REGISTRY_API_SECRET','')}",
+            }
+            schema_registry_client = SchemaRegistryClient(KAFKA_SCHEMA_REGISTRY_CONFIG)
+            cls.TRACKING_EVENT_SERIALIZER = AvroSerializer(schema_str=TrackingEvent.TRACKING_EVENT_AVRO_SCHEMA,
+                                                           schema_registry_client=schema_registry_client,
+                                                           to_dict=TrackingEvent.to_dict)
+            return cls.TRACKING_EVENT_SERIALIZER
+
+
+class ProducerFactory:
+    """ Factory class to create event producers.
+    The factory pattern is used to ensure only one producer per event type, which is the confluent recommendation"""
+    _type_to_producer = {}
+
+    @classmethod
+    def get_or_create_event_producer(cls, event_type, event_key_serializer, event_value_serializer):
+        """
+        Factory method to return the correct producer for the event type, or
+        create a new producer if none exists
+        :param event_type: name of event (same as segment events)
+        :param event_key_serializer:  AvroSerializer instance for serializing event key
+        :param event_value_serializer: AvroSerializer instance for serializing event value
+        :return: SerializingProducer
+        """
+        existing_producer = cls._type_to_producer.get(event_type)
+        if existing_producer is not None:
+            return existing_producer
+        producer_settings = {
+            'bootstrap.servers': getattr(settings, 'KAFKA_BOOTSTRAP_SERVER', ''),
+            'sasl.mechanism': 'PLAIN',
+            'security.protocol': 'SASL_SSL',
+            'sasl.username': getattr(settings, 'KAFKA_API_KEY', ''),
+            'sasl.password': getattr(settings, 'KAFKA_API_SECRET', ''),
+            'key.serializer': event_key_serializer,
+            'value.serializer': event_value_serializer,
+        }
+
+        new_producer = SerializingProducer(producer_settings)
+        cls._type_to_producer[event_type] = new_producer
+        return new_producer
+
+
+def send_event_to_message_bus(event_name, event_properties):
+    """
+    Create a TrackingEvent from event_properties and send it to the settings.LICENSE_TOPIC_NAME queue on
+    the event bus
+    :param event_name: same as segment event name
+    :param event_properties: same as segment event properties
+    """
+    try:
+        license_event_producer = ProducerFactory.get_or_create_event_producer(
+            settings.LICENSE_TOPIC_NAME,
+            StringSerializer('utf-8'),
+            TrackingEventSerializer.get_serializer()
+        )
+        license_event_producer.produce(settings.LICENSE_TOPIC_NAME, key=str(event_name),
+                                       value=TrackingEvent(**event_properties), on_delivery=verify_event)
+        license_event_producer.poll()
+    except ValueSerializationError as vse:
+        logger.exception(vse)
+
+
+def verify_event(err, evt):
+    """ Simple callback method for debugging event production
+    :param err: Error if event production failed
+    :param evt: Event that was delivered
+    """
+    if err is not None:
+        logger.warning(f"Event delivery failed: {err}")
+    else:
+        # Don't log msg.value() because it may contain userids and/or emails
+        logger.debug(f"Event delivered to {evt.topic()}: key(bytes) - {evt.key()}; "
+                     f"partition - {evt.partition()}")

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -6,7 +6,10 @@ import requests
 from django.conf import settings
 from django.db.models import prefetch_related_objects
 
+from license_manager.apps.subscriptions.constants import SegmentEvents
 from license_manager.apps.subscriptions.utils import localized_utcnow
+
+from .event_bus_utils import send_event_to_message_bus
 
 
 logger = logging.getLogger(__name__)
@@ -156,6 +159,7 @@ def track_event(lms_user_id, event_name, properties):
     Returns:
         None
     """
+
     if hasattr(settings, "SEGMENT_KEY") and settings.SEGMENT_KEY:
         try:  # We should never raise an exception when not able to send a tracking event
             if not lms_user_id:
@@ -175,6 +179,9 @@ def track_event(lms_user_id, event_name, properties):
         logger.warning(
             "Event {} for user_id {} not tracked because SEGMENT_KEY not set".format(event_name, lms_user_id)
         )
+
+    if getattr(settings, "KAFKA_ENABLED", False):  # pragma: no cover
+        send_event_to_message_bus(event_name, properties)
 
 
 def get_license_tracking_properties(license_obj):

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -181,7 +181,10 @@ def track_event(lms_user_id, event_name, properties):
         )
 
     if getattr(settings, "KAFKA_ENABLED", False):  # pragma: no cover
-        send_event_to_message_bus(event_name, properties)
+        try:
+            send_event_to_message_bus(event_name, properties)
+        except Exception as e:
+            logger.error("Exception sending event to message bus: {}".format(e))
 
 
 def get_license_tracking_properties(license_obj):

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -408,3 +408,18 @@ BRAZE_APP_ID = os.environ.get('BRAZE_APP_ID', '')
 # Set a datetime that a django action can reset license state to
 # Use year-month-day hour:minute:second format
 LICENSE_REVERT_SNAPSHOT_TIMESTAMP = '9999-12-31 23:59:59'
+
+################### Kafka Related Settings ##############################
+KAFKA_BOOTSTRAP_SERVER = ''
+KAFKA_API_KEY = ''
+KAFKA_API_SECRET = ''
+SCHEMA_REGISTRY_API_KEY = ''
+SCHEMA_REGISTRY_API_SECRET=''
+SCHEMA_REGISTRY_URL=''
+
+
+KAFKA_PARTITIONS_PER_TOPIC=1
+# This number is dictated by the cluster setup
+KAFKA_REPLICATION_FACTOR_PER_TOPIC=3
+
+KAFKA_ENABLED = False

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -89,6 +89,17 @@ SOCIAL_MEDIA_FOOTER_URLS = {
 # https://github.com/django-extensions/django-extensions#using-it
 INSTALLED_APPS += ('django_extensions',)
 
+################### Kafka Related Settings ##############################
+KAFKA_ACCESS_CONF_BASE = { 'bootstrap.servers': "edx.devstack.kafka:29092", 'client.id': 'edx.devstack.lms' }
+
+KAFKA_CONSUMER_CONF_BASE = {'bootstrap.servers': "edx.devstack.kafka:29092", 'group.id': 'lms'}
+
+KAFKA_SCHEMA_REGISTRY_CONF = {
+    'url': "http://edx.devstack.schema-registry:8081",
+}
+KAFKA_REPLICATION_FACTOR_PER_TOPIC=1
+LICENSE_TOPIC_NAME="license-event-dev"
+
 # Make some loggers less noisy (useful during test failure)
 import logging
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@
 analytics-python
 backoff
 celery
+confluent-kafka
 Django
 django-cors-headers
 django-durationwidget
@@ -12,6 +13,7 @@ django-extensions
 django-filter
 django-model-utils
 django-ses
+fastavro
 rules
 django-simple-history
 django-waffle

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,6 +33,8 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.7
     # via requests
+confluent-kafka==1.7.0
+    # via -r requirements/base.in
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
@@ -134,6 +136,8 @@ edx-opaque-keys==2.2.2
 edx-rbac==1.5.1
     # via -r requirements/base.in
 edx-rest-api-client==5.4.0
+    # via -r requirements/base.in
+fastavro==1.4.7
     # via -r requirements/base.in
 future==0.18.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -74,6 +74,8 @@ code-annotations==1.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-lint
+confluent-kafka==1.7.0
+    # via -r requirements/validation.txt
 coreapi==2.3.3
     # via
     #   -r requirements/validation.txt
@@ -219,6 +221,8 @@ faker==8.1.3
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   factory-boy
+fastavro==1.4.7
+    # via -r requirements/validation.txt
 freezegun==1.1.0
     # via -r requirements/validation.txt
 future==0.18.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -78,6 +78,8 @@ code-annotations==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+confluent-kafka==1.7.0
+    # via -r requirements/test.txt
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
@@ -219,6 +221,8 @@ faker==8.1.3
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   factory-boy
+fastavro==1.4.7
+    # via -r requirements/test.txt
 freezegun==1.1.0
     # via -r requirements/test.txt
 future==0.18.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -48,6 +48,8 @@ charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
+confluent-kafka==1.7.0
+    # via -r requirements/base.txt
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -161,6 +163,8 @@ edx-opaque-keys==2.2.2
 edx-rbac==1.5.1
     # via -r requirements/base.txt
 edx-rest-api-client==5.4.0
+    # via -r requirements/base.txt
+fastavro==1.4.7
     # via -r requirements/base.txt
 future==0.18.2
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -62,6 +62,8 @@ click-log==0.3.2
     # via edx-lint
 code-annotations==1.2.0
     # via edx-lint
+confluent-kafka==1.7.0
+    # via -r requirements/base.txt
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -177,6 +179,8 @@ edx-opaque-keys==2.2.2
 edx-rbac==1.5.1
     # via -r requirements/base.txt
 edx-rest-api-client==5.4.0
+    # via -r requirements/base.txt
+fastavro==1.4.7
     # via -r requirements/base.txt
 future==0.18.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -66,6 +66,8 @@ code-annotations==1.2.0
     # via
     #   -r requirements/test.in
     #   edx-lint
+confluent-kafka==1.7.0
+    # via -r requirements/base.txt
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -91,6 +93,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
+django==3.2.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -195,6 +198,8 @@ faker==8.1.3
     # via
     #   -c requirements/constraints.txt
     #   factory-boy
+fastavro==1.4.7
+    # via -r requirements/base.txt
 freezegun==1.1.0
     # via -r requirements/test.in
 future==0.18.2

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -88,6 +88,10 @@ code-annotations==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
+confluent-kafka==1.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 coreapi==2.3.3
     # via
     #   -r requirements/quality.txt
@@ -266,6 +270,10 @@ faker==8.1.3
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   factory-boy
+fastavro==1.4.7
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 freezegun==1.1.0
     # via -r requirements/test.txt
 future==0.18.2


### PR DESCRIPTION
## Description

Send events to the message bus at the same time they are sent to Segment. Eventually these will hopefully replace the direct API calls to enterprise and edx-platform.
This is mostly a "make it work" ticket without too much architectural thought. Ideally, once we have more events live in production, we can make the work setting up producers, serializers, and events more modular and abstract out the actual message bus implementation. 

[ARCHBOM-1984](https://openedx.atlassian.net/browse/ARCHBOM-1984)

## Testing considerations
So far the only way I have been able to manual test this is by adding and deleting subscriptions in Django admin. I have not been able to fire the activate/revoke events locally.

To test:

1.  In devstack, `make dev.up.kafka-control-center && make dev.up.lms`. Kafka sometimes takes a few minutes. You can check by going to the control center at localhost:9021
2. In license-manager/requirements/private.py, set KAFKA_ENABLED=True
3. Bring up license manager (steps are in the repo README)
4. In the LMS Django admin, create an EnterpriseCustomerCatalog (can use an empty EnterpriseCatalogQuery and a fake EnterpriseCustomer, neither will need any real data)
5. In the License Manager Django admin, create a Subscription Plan with some >0 number of licenses using the uuid of the EnterpriseCustomerCatalog. You will also have to create a CustomerAgreement to do this, but that data can all be fake/empty
6. After you create the Subscription Plan, you should see 'license_event' in the Topics tab in the kafka control center
7. Click into 'license_event' > Messages
8. Back in License Manager django admin, delete or add new licenses to the Subscription Plan. Every time you do, you should see a new message appear in the control center. Note that page in the control center only shows messages that have come in since the page loaded so if you refresh, all the messages currently shown will disappear. 

To test on stage:
The only difference between testing on stage and devstack is the cluster used. Stage connects to an actual hosted confluent Kafka cluster. To test on stage, you will need to set 
```
KAFKA_ENABLED=True
KAFKA_BOOTSTRAP_SERVER="pkc-2396y.us-east-1.aws.confluent.cloud:9092"
SCHEMA_REGISTRY_URL="https://psrc-gk071.us-east-2.aws.confluent.cloud"
KAFKA_API_SECRET="<secret>"
SCHEMA_REGISTRY_API_SECRET="<secret>"
KAFKA_API_KEY="<key>"
SCHEMA_REGISTRY_API_KEY="<key>"
LICENSE_TOPIC_NAME="license-event-stage"
```
in the configurations and, in the confluent-cloud dashboard, make sure the api key you are using has CREATE and WRITE permissions for the "license-event-stage" topic.

## Post-review

Squash commits into discrete sets of changes