### PR TITLE
fix: do license assignment UPDATEs in batches of 10, not 100.

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -127,6 +127,7 @@ def assign_new_licenses(subscription_plan, user_emails):
     License.bulk_update(
         licenses,
         ['user_email', 'status', 'activation_key', 'assigned_date', 'last_remind_date'],
+        batch_size=10,
     )
 
     event_utils.track_license_changes(list(licenses), constants.SegmentEvents.LICENSE_ASSIGNED)


### PR DESCRIPTION
This potentially addresses an issue from https://openedx.atlassian.net/browse/ENT-5162
in which an admin's request to assign 100ish users in one transaction
is resulting in some MySQL -> Django -> nginx timeouts and 422 errors.  Maybe.

The resulting SQL right now for this bulk_update is about 500 lines worth of
```UPDATE `subscriptions_license` SET `user_email` = CASE WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN (`subscriptions_license`.`uuid` = %s) THEN %s WHEN 
...```
because we're trying to do an update in batches of 100 (and there are 5 columns to update).