### PR TITLE
fix: remove all references to PlanEmailTemplates

### DIFF
--- a/license_manager/apps/subscriptions/migrations/0032_populate_email_templates.py
+++ b/license_manager/apps/subscriptions/migrations/0032_populate_email_templates.py
@@ -899,6 +899,9 @@ Please alert Account Management (if applicable) and take appropriate steps to en
 
 
     PlanEmailTemplates = apps.get_model("subscriptions", "PlanEmailTemplates")
+    if not PlanEmailTemplates:
+      # defensively exit early if PlanEmailTemplates doesn't exist since this model is now deleted
+      return
     PlanType = apps.get_model('subscriptions', 'PlanType')
 
     # Standard Paid    
@@ -1003,6 +1006,9 @@ Please alert Account Management (if applicable) and take appropriate steps to en
 
 def depopulate_table(apps, schema_editor):
     PlanEmailTemplates = apps.get_model("subscriptions", "PlanEmailTemplates")
+    if not PlanEmailTemplates:
+      # defensively exit early if PlanEmailTemplates doesn't exist since this model is now deleted
+      return
     PlanEmailTemplates.objects.all().delete()
 
 class Migration(migrations.Migration):

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -286,35 +286,6 @@ class Product(models.Model):
         return self.name
 
 
-class PlanEmailTemplates(models.Model):
-    """
-    Stores email templates associated with each enterprise Subscription plan type.
-    .. no_pii: This model has no PII
-    """
-    plaintext_template = models.TextField(
-        blank=False,
-    )
-    html_template = models.TextField(
-        blank=False,
-    )
-    subject_line = models.CharField(
-        max_length=100,
-        blank=False,
-        null=False,
-    )
-    plan_type = models.ForeignKey(
-        PlanType,
-        related_name='subscriptions',
-        on_delete=models.CASCADE,
-        blank=True,
-        null=True,
-    )
-    template_type = models.TextField(
-        blank=False,
-        null=False,
-    )
-
-
 class Notification(TimeStampedModel):
     """
     Stores information regarding when notifications were sent out to users.


### PR DESCRIPTION
## Description

Removes `PlanEmailTemplates` model such that the only references to the model that remain are in previous migration files through `apps.get_model()`.

Per the ticket, a follow-up PR will run `makemigrations` and actually remove the field from the database.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5203

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
