### PR TITLE
feat: make the Braze event tracking of license assignment asynchronous.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ django_shell: ## run Django shell
 	python manage.py shell
 
 test: clean ## run tests and generate coverage report
-	pytest
+	## ``--ds`` Has the highest settings precedence:
+	## https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings
+	pytest --ds=license_manager.settings.test
 
 # To be run from CI context
 coverage: clean
@@ -91,6 +93,9 @@ validate: test quality pii_check ## run tests, quality, and PII annotation check
 
 migrate: ## apply database migrations
 	python manage.py migrate
+
+app-migrate: ## apply database migrations without having to type `make app-shell` first
+	docker exec -u 0 -it license_manager.app python manage.py migrate
 
 html_coverage: ## generate and view HTML coverage report
 	coverage html && open htmlcov/index.html

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1018,6 +1018,7 @@ class LicenseViewSetActionMixin:
         """
         unassigned_licenses = LicenseFactory.create_batch(num_licenses)
         self.subscription_plan.licenses.set(unassigned_licenses)
+        return unassigned_licenses
 
     def _assert_licenses_assigned(self, user_emails):
         """
@@ -1362,6 +1363,14 @@ class LicenseViewSetActionTests(LicenseViewSetActionMixin, TestCase):
             'api:v1:licenses-csv',
             kwargs={'subscription_uuid': cls.subscription_plan.uuid},
         )
+
+    def setUp(self):
+        super().setUp()
+        self.mock_track_test_mocker = mock.patch('license_manager.apps.api.v1.views.track_license_changes_task')
+        self.mock_track_test_mocker.start()
+
+    def tearDown(self):
+        self.mock_track_test_mocker.stop()
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.activation_email_task.si')
@@ -1861,6 +1870,14 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             'api:v1:licenses-assign',
             kwargs={'subscription_uuid': cls.subscription_plan.uuid},
         )
+
+    def setUp(self):
+        super().setUp()
+        self.mock_track_test_mocker = mock.patch('license_manager.apps.api.v1.views.track_license_changes_task')
+        self.mock_track_test_mocker.start()
+
+    def tearDown(self):
+        self.mock_track_test_mocker.stop()
 
     @mock.patch('license_manager.apps.api.v1.views.execute_post_revocation_tasks')
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -38,6 +38,7 @@ from license_manager.apps.api.tasks import (
     send_onboarding_email_task,
     send_reminder_email_task,
     send_utilization_threshold_reached_email_task,
+    track_license_changes_task,
 )
 from license_manager.apps.api_client.enterprise import EnterpriseApiClient
 from license_manager.apps.subscriptions import constants, event_utils
@@ -130,7 +131,11 @@ def assign_new_licenses(subscription_plan, user_emails):
         batch_size=10,
     )
 
-    event_utils.track_license_changes(list(licenses), constants.SegmentEvents.LICENSE_ASSIGNED)
+    license_uuid_strs = [str(_license.uuid) for _license in licenses]
+    track_license_changes_task.delay(
+        license_uuid_strs,
+        constants.SegmentEvents.LICENSE_ASSIGNED,
+    )
     return licenses
 
 

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -219,7 +219,7 @@ def get_license_tracking_properties(license_obj):
     return license_data
 
 
-def track_license_changes(licenses, event_name, properties={}):
+def track_license_changes(licenses, event_name, properties=None):
     """
     Send tracking events for changes to a list of licenses, useful when bulk changes are made.
     Prefetches related objects for licenses to prevent additional queries
@@ -231,15 +231,17 @@ def track_license_changes(licenses, event_name, properties={}):
     Returns:
         None
     """
-
+    properties = properties or {}
     # prefetch related objects used in get_license_tracking_properties
     prefetch_related_objects(licenses, '_renewed_from', 'subscription_plan', 'subscription_plan__customer_agreement')
 
     for lcs in licenses:
         event_properties = {**get_license_tracking_properties(lcs), **properties}
-        track_event(lcs.lms_user_id,  # None for unassigned licenses, track_event will handle users with unregistered emails
-                    event_name,
-                    event_properties)
+        track_event(
+            lcs.lms_user_id,  # None for unassigned licenses, track_event will handle users with unregistered emails
+            event_name,
+            event_properties,
+        )
 
 
 def get_enterprise_tracking_properties(customer_agreement):


### PR DESCRIPTION
Prior to this change, there were two synchronous requests made to the Braze tracking endpoints
for each learner being assigned in the request.  This change creates a new celery
task that wraps the ``track_license_changes()`` function.  The new task
is now called from the license assignment API action, so that requests to assign
a batch of licenses do not take too long (or time out).  

https://openedx.atlassian.net/browse/ENT-5234

## Testing considerations

- Checkout code, restart containers
- Spin up admin portal MFE
- `make worker-logs`
- Assign a batch of licenses to some fake email addresses
- Notice in worker logs that tasks are called to send tracking events (though the tasks might fail b/c Braze API key is not set).

## Post-review

Squash commits into discrete sets of changes
