### PR TITLE
feat: clean up serializers

### DIFF
--- a/license_manager/apps/api/tests/test_serializers.py
+++ b/license_manager/apps/api/tests/test_serializers.py
@@ -38,15 +38,9 @@ class TestCustomerAgreementSerializer(TestCase):
         )
         data = serializer.data
 
-        only_active_expirations = all(
-            expiration['is_active'] for expiration in data['ordered_subscription_plan_expirations']
-        )
-        only_active_plans = all(
-            plan['is_active'] for plan in data['subscriptions']
-        )
+        only_active_plans = all(plan['is_active'] for plan in data['subscriptions'])
 
-        all_active = only_active_expirations and only_active_plans
-        self.assertEqual(all_active, active_plans_only)
+        self.assertEqual(only_active_plans, active_plans_only)
 
 
 @ddt.ddt

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -3,7 +3,6 @@ Models for the subscriptions app.
 """
 from datetime import timedelta
 from math import ceil, inf
-from operator import itemgetter
 from uuid import uuid4
 
 from django.conf import settings
@@ -129,30 +128,6 @@ class CustomerAgreement(TimeStampedModel):
     )
 
     history = HistoricalRecords()
-
-    @property
-    def ordered_subscription_plan_expirations(self):
-        """
-        Returns a sorted list of dicts about expiration data
-        for the Subscription Plans in this agreement.
-        """
-        subscription_plan_expiration_data = [
-            {
-                'uuid': subscription.uuid,
-                'days_until_expiration': subscription.days_until_expiration,
-                'days_until_expiration_including_renewals': subscription.days_until_expiration_including_renewals,
-                'is_active': subscription.is_active,
-            }
-            for subscription in self.subscriptions.all()
-        ]
-
-        ordered_subscription_plan_data = sorted(
-            subscription_plan_expiration_data,
-            key=itemgetter('is_active', 'days_until_expiration_including_renewals'),
-            reverse=True,
-        )
-
-        return ordered_subscription_plan_data
 
     @property
     def net_days_until_expiration(self):


### PR DESCRIPTION
## Description

- removed ordered_subscription_plan_expirations, it's no longer used by the admin portal, the frontend should also be able to sort the subscription plans if needed
- updated license serializer so that subscription plan is not serialized, we only need the uuid

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5220

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
