### PR TITLE
fix: use lms_user_id when fetching learner licenses, minor refactors

### DIFF
--- a/docs/decisions/0013-keeping-license-emails-up-to-date.rst
+++ b/docs/decisions/0013-keeping-license-emails-up-to-date.rst
@@ -1,0 +1,41 @@
+13. Keeping license emails up to date
+=====================================
+
+Status
+======
+
+Accepted
+
+Context
+=======
+
+Currently, the `/learner-licenses/` endpoint returns licenses that match with the user's email provided in the JWT.
+However a user's email could change, and the endpoint would fail to return the user's licenses if that occurs.
+
+We want to return the correct licenses even if a user has changed their email and also update the `user_email` field
+on their licenses to reflect the new email.
+
+Decision
+========
+
+In an event driven architecture, an event would be dispatched by the LMS when a user changes their information. License
+Manager would consume this event and update all of the licenses associated with the user. However we do not have
+such an infrastructure set up yet and will have to rely on the JWT passed in with each request to determine if a user
+has changed their email.
+
+Whenever a user fetches their learner licenses, we will query for licenses that are associated with **both**
+the email and the lms_user_id that is present in the JWT payload. This will ensure that even if a user has changed their email,
+licenses associated with the lms_user_id will still be returned. We have to query by email as well because an assigned license might not have
+an lms_user_id yet. If we detect that the user's email has changed (i.e. the `user_email` field on the licenses do not match with the one in the JWT),
+we will update the `user_email` field on all of the user's licenses.
+
+Consequences
+============
+* If a user has an assigned license but changes their email before activating their license, there is no way for us to update
+  the unassigned license because the lms_user_id has not been set. Until we have access to a better solution (i.e. consuming an event), there is no workaround
+  for this problem. The admin will have to reassign a new license in this case.
+
+Alternatives Considered
+=======================
+* We could also set the lms_user_id on unassigned licenses whenever the user hits the `/learner-licenses/` endpoint.
+  However it is unlikely that the user will visit the learner portal but change their email before activating their license in the same session.

--- a/license_manager/apps/api/mixins.py
+++ b/license_manager/apps/api/mixins.py
@@ -1,0 +1,27 @@
+from functools import cached_property
+
+from license_manager.apps.api import utils
+
+
+class UserDetailsFromJwtMixin:
+    """
+    Mixin for retrieving user information from the jwt.
+    """
+
+    @cached_property
+    def decoded_jwt(self):
+        """
+        Expects `self.request` to be explicitly defined.
+        """
+        if not getattr(self, 'request', None):
+            raise Exception(f'{self.__class__} must have a request field.')
+
+        return utils.get_decoded_jwt(self.request)
+
+    @property
+    def lms_user_id(self):
+        return utils.get_key_from_jwt(self.decoded_jwt, 'user_id')
+
+    @property
+    def user_email(self):
+        return utils.get_key_from_jwt(self.decoded_jwt, 'email')

--- a/license_manager/apps/api/v1/tests/test_api_eventing.py
+++ b/license_manager/apps/api/v1/tests/test_api_eventing.py
@@ -127,8 +127,8 @@ class LicenseViewSetActionEventTests(LicenseViewSetActionMixin, EventTestCaseBas
 
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.send_assignment_email_task.si')
-    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
+    @mock.patch('license_manager.apps.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    @mock.patch('license_manager.apps.api.tasks.send_revocation_cap_notification_email_task.delay')
     def test_bulk_revoked_event(self, *_):
         """
         Test that bulk revoking licenses  triggers the right set of events:

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -365,48 +365,6 @@ class RevocationTests(TestCase):
         # There should now be 1 unassigned license
         self.assertEqual(subscription_plan.unassigned_licenses.count(), 1)
 
-    @ddt.data(
-        {'original_status': constants.ACTIVATED, 'revoke_max_percentage': 200},
-        {'original_status': constants.ACTIVATED, 'revoke_max_percentage': 100},
-        {'original_status': constants.ASSIGNED, 'revoke_max_percentage': 100}
-    )
-    @ddt.unpack
-    @mock.patch('license_manager.apps.subscriptions.api.tasks.revoke_course_enrollments_for_user_task.delay')
-    @mock.patch('license_manager.apps.subscriptions.api.tasks.send_revocation_cap_notification_email_task.delay')
-    def test_execute_post_revocation_tasks(
-        self,
-        mock_cap_email_delay,
-        mock_revoke_enrollments_delay,
-        original_status,
-        revoke_max_percentage
-    ):
-        agreement = CustomerAgreementFactory.create(
-            enterprise_customer_uuid=uuid.UUID('00000000-1111-2222-3333-444444444444'),
-        )
-
-        subscription_plan = SubscriptionPlanFactory.create(
-            customer_agreement=agreement,
-            is_revocation_cap_enabled=True,
-            num_revocations_applied=0,
-            revoke_max_percentage=revoke_max_percentage,
-        )
-
-        original_license = LicenseFactory.create(
-            status=original_status,
-            subscription_plan=subscription_plan,
-            lms_user_id=123,
-        )
-
-        with freezegun.freeze_time(NOW):
-            revocation_result = api.revoke_license(original_license)
-            api.execute_post_revocation_tasks(**revocation_result)
-
-        is_license_revoked = original_status == constants.ACTIVATED
-        revoke_limit_reached = is_license_revoked and revoke_max_percentage <= 100
-
-        self.assertEqual(mock_revoke_enrollments_delay.called, is_license_revoked)
-        self.assertEqual(mock_cap_email_delay.called, revoke_limit_reached)
-
 
 class SubscriptionFreezeTests(TestCase):
     """

--- a/license_manager/apps/subscriptions/tests/test_models.py
+++ b/license_manager/apps/subscriptions/tests/test_models.py
@@ -16,11 +16,7 @@ from license_manager.apps.subscriptions.constants import (
     SegmentEvents,
 )
 from license_manager.apps.subscriptions.exceptions import CustomerAgreementError
-from license_manager.apps.subscriptions.models import (
-    License,
-    Notification,
-    SubscriptionPlan,
-)
+from license_manager.apps.subscriptions.models import License, Notification
 from license_manager.apps.subscriptions.tests.factories import (
     CustomerAgreementFactory,
     LicenseFactory,
@@ -219,6 +215,7 @@ class LicenseModelTests(TestCase):
         """
         Removes all test instances of License that have been created.
         """
+        super().tearDownClass()
         License.objects.all().delete()
 
     def test_license_renewed_to_and_from(self):
@@ -282,7 +279,7 @@ class LicenseModelTests(TestCase):
             assert self.CREATE_HISTORY_TYPE == user_license.history.earliest().history_type
             assert self.UPDATE_HISTORY_TYPE == user_license.history.first().history_type
 
-    def test_for_email_and_customer_no_kwargs(self):
+    def test_for_user_and_customer_no_kwargs(self):
         expected_licenses = [
             self.active_current_license,
             self.inactive_current_license,
@@ -290,49 +287,53 @@ class LicenseModelTests(TestCase):
             self.non_current_inactive_license,
         ]
 
-        actual_licenses = License.for_email_and_customer(
-            self.user_email,
-            self.enterprise_customer_uuid,
+        actual_licenses = License.for_user_and_customer(
+            user_email=self.user_email,
+            lms_user_id=None,
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
         )
 
         self.assertCountEqual(actual_licenses, expected_licenses)
 
-    def test_for_email_and_customer_active_only(self):
+    def test_for_user_and_customer_active_only(self):
         expected_licenses = [
             self.active_current_license,
             self.non_current_active_license,
         ]
 
-        actual_licenses = License.for_email_and_customer(
-            self.user_email,
-            self.enterprise_customer_uuid,
+        actual_licenses = License.for_user_and_customer(
+            user_email=self.user_email,
+            lms_user_id=None,
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
             active_plans_only=True,
         )
 
         self.assertCountEqual(actual_licenses, expected_licenses)
 
-    def test_for_email_and_customer_current_only(self):
+    def test_for_user_and_customer_current_only(self):
         expected_licenses = [
             self.active_current_license,
             self.inactive_current_license,
         ]
 
-        actual_licenses = License.for_email_and_customer(
-            self.user_email,
-            self.enterprise_customer_uuid,
+        actual_licenses = License.for_user_and_customer(
+            user_email=self.user_email,
+            lms_user_id=None,
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
             current_plans_only=True,
         )
 
         self.assertCountEqual(actual_licenses, expected_licenses)
 
-    def test_for_email_and_customer_active_and_current_only(self):
+    def test_for_user_and_customer_active_and_current_only(self):
         expected_licenses = [
             self.active_current_license,
         ]
 
-        actual_licenses = License.for_email_and_customer(
-            self.user_email,
-            self.enterprise_customer_uuid,
+        actual_licenses = License.for_user_and_customer(
+            user_email=self.user_email,
+            lms_user_id=None,
+            enterprise_customer_uuid=self.enterprise_customer_uuid,
             active_plans_only=True,
             current_plans_only=True,
         )


### PR DESCRIPTION
## Description

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5442

- Refactors to slim down views.py and prevent subscriptions app from importing from the api app (keep it one way)
- Update user email on licenses if the email from the jwt does not match
