### PR TITLE
fix update container names

### DIFF
--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   mysql:
     image: mysql:5.7
-    container_name: license_manager.mysql
+    container_name: license-manager.mysql
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -15,7 +15,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    container_name: license_manager.app
+    container_name: license-manager.app
     volumes:
       - ..:/edx/app/license_manager
     # Use the Django devserver, so that we can hot-reload code changes

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ migrate: ## apply database migrations
 	python manage.py migrate
 
 app-migrate: ## apply database migrations without having to type `make app-shell` first
-	docker exec -u 0 -it license_manager.app python manage.py migrate
+	docker exec -u 0 -it license-manager.app python manage.py migrate
 
 html_coverage: ## generate and view HTML coverage report
 	coverage html && open htmlcov/index.html
@@ -158,10 +158,10 @@ push_translations: ## push source translation files (.po) from Transifex
 	tx push -s
 
 open-devstack: ## open a shell on the server started by start-devstack
-	docker exec -it license_manager /edx/app/license_manager/devstack.sh open
+	docker exec -it license-manager /edx/app/license_manager/devstack.sh open
 
-pkg-devstack: ## build the license_manager image from the latest configuration and code
-	docker build -t license_manager:latest -f docker/build/license_manager/Dockerfile git://github.com/edx/configuration
+pkg-devstack: ## build the license-manager image from the latest configuration and code
+	docker build -t license-manager:latest -f docker/build/license_manager/Dockerfile git://github.com/edx/configuration
 
 detect_changed_source_translations: ## check if translation files are up-to-date
 	cd license_manager && i18n_tool changed
@@ -189,10 +189,10 @@ dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
 %-shell: # Run a shell, as root, on the specified service container
-	docker exec -u 0 -it license_manager.$* bash
+	docker exec -u 0 -it license-manager.$* bash
 
 mysql-client-shell: # Will drop you directly into a mysql client shell.
-	docker exec -u 0 -it license_manager.mysql mysql license_manager
+	docker exec -u 0 -it license-manager.mysql mysql license_manager
 
 %-logs: # View the logs of the specified service container
 	docker-compose logs -f --tail=500 $*
@@ -201,7 +201,7 @@ mysql-client-shell: # Will drop you directly into a mysql client shell.
 	docker-compose restart $*
 
 %-attach:
-	docker attach license_manager.$*
+	docker attach license-manager.$*
 
 app-restart-devserver: ## Kill the license-manager development server. Watcher should restart it.
 	docker-compose exec app bash -c 'kill $$(ps aux | egrep "manage.py ?\w* runserver" | egrep -v "while|grep" | awk "{print \$$2}")'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   mysql:
     image: mysql:5.7
-    container_name: license_manager.mysql
+    container_name: license-manager.mysql
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -17,7 +17,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: license_manager.app
+    container_name: license-manager.app
     volumes:
       - .:/edx/app/license_manager/
       - ../src:/edx/src:cached
@@ -45,7 +45,7 @@ services:
 
   memcached:
     image: memcached:1.4.24
-    container_name: license_manager.memcache
+    container_name: license-manager.memcache
 
   worker:
     image: openedx/license-manager.worker
@@ -53,7 +53,7 @@ services:
       context: .
       dockerfile: Dockerfile
     command: bash -c 'cd /edx/app/license_manager/license_manager && celery -A license_manager worker -l DEBUG'
-    container_name: license_manager.worker
+    container_name: license-manager.worker
     depends_on:
       - mysql
     environment:

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -2,6 +2,7 @@ from license_manager.settings.local import *
 
 # Generic OAuth2 variables irrespective of SSO/backend service key types.
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
+ALLOWED_HOSTS = ['*']
 
 DATABASES = {
     'default': {
@@ -9,7 +10,7 @@ DATABASES = {
         'NAME': 'license_manager',
         'USER': 'root',
         'PASSWORD': '',
-        'HOST': 'license_manager.mysql',
+        'HOST': 'license-manager.mysql',
         'PORT': '3306',
     }
 }

--- a/provision-license-manager.sh
+++ b/provision-license-manager.sh
@@ -8,7 +8,7 @@ docker-compose up -d --build
 
 # Wait for MySQL
 echo "Waiting for MySQL"
-until docker exec -i license_manager.mysql mysql -u root -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+until docker exec -i license-manager.mysql mysql -u root -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
   sleep 1
@@ -17,17 +17,17 @@ sleep 5
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t license_manager.app bash -c "cd /edx/app/${name}/ && make migrate"
+docker exec -t license-manager.app bash -c "cd /edx/app/${name}/ && make migrate"
 
 # Seed data for development
 echo -e "${GREEN}Seeding development data..."
-docker exec -t license_manager.app bash -c "python manage.py seed_development_data"
+docker exec -t license-manager.app bash -c "python manage.py seed_development_data"
 # Some migrations require development data to be seeded, hence migrating again.
-docker exec -t license_manager.app bash -c "make migrate"
+docker exec -t license-manager.app bash -c "make migrate"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t license_manager.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"
+docker exec -t license-manager.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"
 
 # Provision IDA User in LMS
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"


### PR DESCRIPTION
## Description

* change container names from using underscores, i.e. license_manager.app -> license-manager.app, this is so we don't run into `Invalid HTTP_HOST header: 'license_manager.app:18170'. The domain name provided is not valid according to RFC 1034/1035` while developing locally
* update allowed hosts in devstack settings

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
