### PR TITLE
feat: accept notify_users flag for /assign

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -174,6 +174,7 @@ class StaffLicenseSerializer(serializers.ModelSerializer):
         ]
 
 
+# Action Serializers
 class SingleEmailSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
     Serializer for specifying a single email
@@ -352,3 +353,16 @@ class LicenseAdminRemindActionSerializer(  # pylint: disable=abstract-method
 
     class Meta:
         fields = LicenseAdminBulkActionSerializer.Meta.fields + CustomTextSerializer.Meta.fields
+
+
+class LicenseAdminAssignActionSerializer(CustomTextWithMultipleEmailsSerializer):  # pylint: disable=abstract-method
+    """
+    Serializer for the license admin assign action.
+    """
+
+    notify_users = serializers.BooleanField(required=False)
+
+    class Meta:
+        fields = CustomTextWithMultipleEmailsSerializer.Meta.fields + [
+            'notify_users',
+        ]


### PR DESCRIPTION
## Description

Accept a new flag to determine if users should receive the license assignment email.
Return license_assignments in response.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5470

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
