### PR TITLE
fix: prevent by_user_email_or_lms_user_id from grabbing every license…

### DIFF
--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1111,9 +1111,14 @@ class License(TimeStampedModel):
         """
         Returns all licenses asssociated with the given user email or lms_user_id.
         """
-        return cls.objects.filter(
-            Q(user_email=user_email) | Q(lms_user_id=lms_user_id)
-        ).select_related(
+        if lms_user_id is not None:
+            qs = cls.objects.filter(
+                Q(user_email=user_email) | Q(lms_user_id=lms_user_id)
+            )
+        else:
+            qs = cls.objects.filter(Q(user_email=user_email))
+
+        return qs.select_related(
             'subscription_plan',
             'subscription_plan__customer_agreement',
         )


### PR DESCRIPTION

## Description

StaffLookupLicenseView is timing out when people calling it with a user_email.

Stop the by_user_email_or_lms_user_id helper method, used by StaffLookupLicenseView, from pulling every license that doesn't have an lms_user_id if the argument is not set, as this was resulting in timeouts/very large querysets when only a user_email is passed in.

Other option not implemented here is to simply not use this helper method and do our own query in the view.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5492

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
