### PR TITLE
fix: update seed commands to reflect current schema

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -108,9 +108,7 @@ class Command(BaseCommand):
             expiration_date=timestamp + timedelta(days=365),
             is_active=True,
             for_internal_use_only=True,
-            netsuite_product_id=0,
             salesforce_opportunity_id=123456789123456789,
-            plan_type=PlanType.objects.get(label="Standard Paid"),
             product=Product.objects.get(name="B2B Paid")
         )
         with transaction.atomic():


### PR DESCRIPTION
## Description

- updating commands to reflect up2date schema

## References

- https://github.com/edx/license-manager/blob/jnagro/ENT-5355/0/docs/decisions/0011-product-model.rst#L43
- [ENT-5355](https://openedx.atlassian.net/browse/ENT-5355)
- https://openedx.atlassian.net/wiki/spaces/SOL/pages/3105718339/2021+Provision+Devstack+Enterprise+Data+Entirely+from+scripts
