### PR TITLE
fix: ignore_null_emails filter should only apply to revoked licenses

### DIFF
--- a/license_manager/apps/api/filters.py
+++ b/license_manager/apps/api/filters.py
@@ -2,8 +2,10 @@
 Filters for the License API.
 """
 
+from django.db.models import Q
 from django_filters import rest_framework as filters
 
+from license_manager.apps.subscriptions.constants import UNASSIGNED
 from license_manager.apps.subscriptions.models import License
 
 
@@ -24,7 +26,8 @@ class LicenseFilter(filters.FilterSet):
         status_values = value.strip().split(',')
         return queryset.filter(status__in=status_values).distinct()
 
+    # ignores revoked licenses that have been cleared of PII
     def filter_by_ignore_null_emails(self, queryset, name, value):  # pylint: disable=unused-argument
         if not value:
             return queryset
-        return queryset.exclude(user_email__isnull=True)
+        return queryset.exclude(Q(user_email__isnull=True) & ~Q(status=UNASSIGNED))

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -789,7 +789,7 @@ def test_license_list_ignore_null_emails_query_param(api_client, staff_user, boo
     """
     Assert the endpoint respects the ``ignore_null_emails`` query parameter.
     """
-    subscription, _, _, _, revoked_license = _subscription_and_licenses()
+    subscription, assigned_license, unassigned_license, active_license, revoked_license = _subscription_and_licenses()
     _assign_role_via_jwt_or_db(
         api_client,
         staff_user,
@@ -802,12 +802,20 @@ def test_license_list_ignore_null_emails_query_param(api_client, staff_user, boo
     response = _licenses_list_request(
         api_client,
         subscription.uuid,
-        ignore_null_emails=boolean_toggle,
-        status='revoked',
+        ignore_null_emails=boolean_toggle
     )
-    expected_license_uuids = [] if boolean_toggle else [str(revoked_license.uuid)]
+    expected_license_uuids = [
+        str(assigned_license.uuid),
+        str(unassigned_license.uuid),
+        str(active_license.uuid)
+    ] if boolean_toggle else [
+        str(assigned_license.uuid),
+        str(unassigned_license.uuid),
+        str(active_license.uuid),
+        str(revoked_license.uuid)
+    ]
     actual_license_uuids = [user_license['uuid'] for user_license in response.json()['results']]
-    assert actual_license_uuids == expected_license_uuids
+    assert sorted(actual_license_uuids) == sorted(expected_license_uuids)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

The ignore_null_email is meant to ignore revoked licenses that have been scrubbed of pii.
Existing test case already covers.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5417--

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
