### PR TITLE
feat: add 10s delay factor for retried tasks

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -66,7 +66,7 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     )
     retry_kwargs = {'max_retries': 3}
     # Use exponential backoff for retrying tasks
-    retry_backoff = True
+    retry_backoff = 10  # delay factor of 10 seconds
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
     retry_jitter = True
 


### PR DESCRIPTION
## Description

Change retry_backoff to 10 so that the initial retry will happen 10s after failure instead of 1s.
This should reduce the number of failures we see from calling Braze immediately after an error.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-5491

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
