### PR TITLE
feat: apple silicon m1 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0.28-oracle
     container_name: license-manager.mysql
     environment:
       MYSQL_ROOT_PASSWORD: ""


### PR DESCRIPTION
Putting together a branch that supports Apple M1 macs. Hopefully backwards compatible with Intel macs but reserving the right to make breaking changes.

Also depends on https://github.com/openedx/devstack/pull/920.

## Testing instructions

Follow the README to setup the IDA. 
* [x] Runs on Silicon M1-based Macbook.
* [x] Runs on Intel-based Macbook.