### PR TITLE
build: use a version-named mysql volume for mysql8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - devstack_default
     volumes:
-      - license_manager_mysql:/var/lib/mysql
+      - license_manager_mysql8:/var/lib/mysql
 
   app:
     image: openedx/license-manager
@@ -80,4 +80,4 @@ networks:
     external: true
 
 volumes:
-  license_manager_mysql:
+  license_manager_mysql8:


### PR DESCRIPTION
## Description

- help avoid migration issues
- leaves existing volumns untouched

## References

- ![image (3)](https://user-images.githubusercontent.com/31442/167886890-1bdeece4-0ac0-404e-b50f-f5912aacec10.png)

