### PR TITLE
fix: optimize license admin

### DIFF
--- a/license_manager/apps/api_client/enterprise_catalog.py
+++ b/license_manager/apps/api_client/enterprise_catalog.py
@@ -26,8 +26,10 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         """
         query_params = {'course_run_ids': content_ids}
         endpoint = self.enterprise_catalog_endpoint + str(catalog_uuid) + '/contains_content_items/'
-        response = self.client.get(endpoint, params=query_params).json()
-        return response.get('contains_content_items', False)
+        response = self.client.get(endpoint, params=query_params)
+        response.raise_for_status()
+        response_json = response.json()
+        return response_json.get('contains_content_items', False)
 
     def get_distinct_catalog_queries(self, enterprise_catalog_uuids):
         """
@@ -45,10 +47,12 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         request_data = {
             'enterprise_catalog_uuids': enterprise_catalog_uuids,
         }
-        return self.client.post(
+        response = self.client.post(
             self.distinct_catalog_queries_endpoint,
             json=request_data,
-        ).json()
+        )
+        response.raise_for_status()
+        return response.json()
 
     def get_enterprise_catalog(self, catalog_uuid):
         """

--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -33,7 +33,7 @@ from license_manager.apps.subscriptions.models import (
 )
 
 
-def _related_object_link(admin_viewname, object_pk, object_str):
+def get_related_object_link(admin_viewname, object_pk, object_str):
     return mark_safe('<a href="{href}">{object_string}</a><br/>'.format(
         href=reverse(admin_viewname, args=(object_pk,)),
         object_string=object_str,
@@ -57,11 +57,6 @@ class LicenseAdmin(admin.ModelAdmin):
         'activation_date',
         'user_email',
     )
-    ordering = (
-        'assigned_date',
-        'status',
-        'user_email',
-    )
     sortable_by = (
         'assigned_date',
         'status',
@@ -74,7 +69,6 @@ class LicenseAdmin(admin.ModelAdmin):
         'uuid__startswith',
         'user_email',
         'subscription_plan__title',
-        'subscription_plan__uuid__startswith',
         'subscription_plan__customer_agreement__enterprise_customer_uuid__startswith',
         'subscription_plan__customer_agreement__enterprise_customer_slug__startswith'
     )
@@ -84,13 +78,10 @@ class LicenseAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related(
             'subscription_plan',
-            'renewed_to'
-        ).prefetch_related(
-            'subscription_plan__customer_agreement'
         )
 
     def get_subscription_plan_title(self, obj):
-        return _related_object_link(
+        return get_related_object_link(
             'admin:subscriptions_subscriptionplan_change',
             obj.subscription_plan.uuid,
             obj.subscription_plan.title,
@@ -100,7 +91,7 @@ class LicenseAdmin(admin.ModelAdmin):
     def get_renewed_to(self, obj):
         if not obj.renewed_to:
             return ''
-        return _related_object_link(
+        return get_related_object_link(
             'admin:subscriptions_license_change',
             obj.renewed_to.uuid,
             obj.renewed_to.uuid,
@@ -110,7 +101,7 @@ class LicenseAdmin(admin.ModelAdmin):
     def get_renewed_from(self, obj):
         if not obj.renewed_from:
             return ''
-        return _related_object_link(
+        return get_related_object_link(
             'admin:subscriptions_license_change',
             obj.renewed_from.uuid,
             obj.renewed_from.uuid,
@@ -265,7 +256,7 @@ class SubscriptionPlanAdmin(SimpleHistoryAdmin):
         Returns a link to the customer agreement for this plan.
         """
         if obj.customer_agreement:
-            return _related_object_link(
+            return get_related_object_link(
                 'admin:subscriptions_customeragreement_change',
                 obj.customer_agreement.uuid,
                 obj.customer_agreement.enterprise_customer_slug,
@@ -414,7 +405,7 @@ class CustomerAgreementAdmin(admin.ModelAdmin):
         for subscription_plan in obj.subscriptions.all():
             if subscription_plan.is_active:
                 links.append(
-                    _related_object_link(
+                    get_related_object_link(
                         'admin:subscriptions_subscriptionplan_change',
                         subscription_plan.uuid,
                         '{}: {}'.format(subscription_plan.title, subscription_plan.uuid),
@@ -482,7 +473,7 @@ class SubscriptionPlanRenewalAdmin(admin.ModelAdmin):
         Returns a link to the renewed subscription plan.
         """
         if obj.renewed_subscription_plan:
-            return _related_object_link(
+            return get_related_object_link(
                 'admin:subscriptions_subscriptionplan_change',
                 obj.renewed_subscription_plan.uuid,
                 '{}: {}'.format(obj.renewed_subscription_plan.title, obj.renewed_subscription_plan.uuid),


### PR DESCRIPTION
## Description

To speed up our poor ol' license admin which is very very slow in prod.

- Removed ordering, the ordering by multiple columns kills performance since it's not utilized.
- Removed search fields that we'll likely never use, `subscription_plan__uuid` and `subscription_plan__customer_agreement__enterprise_customer_uuid`.
- Removed unnecessary select_related and prefetch_related calls. 

Few minor clean ups.


Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-4408

SQL Explains for those interested:

List (before):
```{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "331.06"
    },
    "ordering_operation": {
      "using_temporary_table": true,
      "using_filesort": true,
      "nested_loop": [
        {
          "table": {
            "table_name": "subscriptions_license",
            "access_type": "ALL",
            "possible_keys": [
              "subscriptions_license_subscription_plan_id_476673e5"
            ],
            "rows_examined_per_scan": 505,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "1.75",
              "eval_cost": "50.50",
              "prefix_cost": "52.25",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_subscriptionplan",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY"
            ],
            "rows_examined_per_scan": 2,
            "rows_produced_per_join": 505,
            "filtered": "50.00",
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.06",
              "eval_cost": "50.50",
              "prefix_cost": "154.31",
              "data_read_per_join": "508K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "start_date",
              "expiration_date",
              "enterprise_catalog_uuid",
              "is_active",
              "title",
              "salesforce_opportunity_id",
              "for_internal_use_only",
              "num_revocations_applied",
              "revoke_max_percentage",
              "customer_agreement_id",
              "expiration_processed",
              "is_revocation_cap_enabled",
              "can_freeze_unused_licenses",
              "last_freeze_timestamp",
              "should_auto_apply_licenses",
              "product_id"
            ],
            "attached_condition": "(`license_manager`.`subscriptions_subscriptionplan`.`uuid` = `license_manager`.`subscriptions_license`.`subscription_plan_id`)"
          }
        },
        {
          "table": {
            "table_name": "T3",
            "access_type": "eq_ref",
            "possible_keys": [
              "PRIMARY"
            ],
            "key": "PRIMARY",
            "used_key_parts": [
              "uuid"
            ],
            "key_length": "128",
            "ref": [
              "license_manager.subscriptions_license.renewed_to_id"
            ],
            "rows_examined_per_scan": 1,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "126.25",
              "eval_cost": "50.50",
              "prefix_cost": "331.06",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        }
      ]
    }
  }
}
```

List (after)
```
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "154.31"
    },
    "ordering_operation": {
      "using_temporary_table": true,
      "using_filesort": true,
      "nested_loop": [
        {
          "table": {
            "table_name": "subscriptions_license",
            "access_type": "ALL",
            "possible_keys": [
              "subscriptions_license_subscription_plan_id_476673e5"
            ],
            "rows_examined_per_scan": 505,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "1.75",
              "eval_cost": "50.50",
              "prefix_cost": "52.25",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_subscriptionplan",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY"
            ],
            "rows_examined_per_scan": 2,
            "rows_produced_per_join": 505,
            "filtered": "50.00",
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.06",
              "eval_cost": "50.50",
              "prefix_cost": "154.31",
              "data_read_per_join": "508K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "start_date",
              "expiration_date",
              "enterprise_catalog_uuid",
              "is_active",
              "title",
              "salesforce_opportunity_id",
              "for_internal_use_only",
              "num_revocations_applied",
              "revoke_max_percentage",
              "customer_agreement_id",
              "expiration_processed",
              "is_revocation_cap_enabled",
              "can_freeze_unused_licenses",
              "last_freeze_timestamp",
              "should_auto_apply_licenses",
              "product_id"
            ],
            "attached_condition": "(`license_manager`.`subscriptions_subscriptionplan`.`uuid` = `license_manager`.`subscriptions_license`.`subscription_plan_id`)"
          }
        }
      ]
    }
  }
}
```



Search (before):
```
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "382.99"
    },
    "ordering_operation": {
      "using_temporary_table": true,
      "using_filesort": true,
      "nested_loop": [
        {
          "table": {
            "table_name": "subscriptions_license",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY",
              "subscriptions_license_subscription_plan_id_476673e5"
            ],
            "rows_examined_per_scan": 505,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "1.75",
              "eval_cost": "50.50",
              "prefix_cost": "52.25",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_customeragreement",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY",
              "enterprise_customer_uuid",
              "enterprise_customer_slug"
            ],
            "rows_examined_per_scan": 1,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.06",
              "eval_cost": "50.50",
              "prefix_cost": "103.81",
              "data_read_per_join": "962K"
            },
            "used_columns": [
              "uuid",
              "enterprise_customer_uuid",
              "enterprise_customer_slug"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_subscriptionplan",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY",
              "subscriptions_subscr_customer_agreement_i_e53d9d9a_fk_subscript"
            ],
            "rows_examined_per_scan": 2,
            "rows_produced_per_join": 505,
            "filtered": "50.00",
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.43",
              "eval_cost": "50.50",
              "prefix_cost": "206.25",
              "data_read_per_join": "508K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "start_date",
              "expiration_date",
              "enterprise_catalog_uuid",
              "is_active",
              "title",
              "salesforce_opportunity_id",
              "for_internal_use_only",
              "num_revocations_applied",
              "revoke_max_percentage",
              "customer_agreement_id",
              "expiration_processed",
              "is_revocation_cap_enabled",
              "can_freeze_unused_licenses",
              "last_freeze_timestamp",
              "should_auto_apply_licenses",
              "product_id"
            ],
            "attached_condition": "((`license_manager`.`subscriptions_subscriptionplan`.`uuid` = `license_manager`.`subscriptions_license`.`subscription_plan_id`) and (`license_manager`.`subscriptions_subscriptionplan`.`customer_agreement_id` = `license_manager`.`subscriptions_customeragreement`.`uuid`) and ((`license_manager`.`subscriptions_license`.`uuid` like <cache>(cast(concat(replace(replace(replace(replace(replace('subby','-',''),'-',''),'\\\\','\\\\\\\\'),'%','\\\\%'),'_','\\\\_'),'%') as char charset binary))) or (`license_manager`.`subscriptions_license`.`user_email` like '%subby%') or (`license_manager`.`subscriptions_subscriptionplan`.`title` like '%subby%') or (`license_manager`.`subscriptions_license`.`subscription_plan_id` like <cache>(cast(concat(replace(replace(replace(replace(replace('subby','-',''),'-',''),'\\\\','\\\\\\\\'),'%','\\\\%'),'_','\\\\_'),'%') as char charset binary))) or (`license_manager`.`subscriptions_customeragreement`.`enterprise_customer_uuid` like <cache>(cast(concat(replace(replace(replace(replace(replace('subby','-',''),'-',''),'\\\\','\\\\\\\\'),'%','\\\\%'),'_','\\\\_'),'%') as char charset binary))) or (`license_manager`.`subscriptions_customeragreement`.`enterprise_customer_slug` like <cache>(cast('subby%' as char charset binary)))))"
          }
        },
        {
          "table": {
            "table_name": "T4",
            "access_type": "eq_ref",
            "possible_keys": [
              "PRIMARY"
            ],
            "key": "PRIMARY",
            "used_key_parts": [
              "uuid"
            ],
            "key_length": "128",
            "ref": [
              "license_manager.subscriptions_license.renewed_to_id"
            ],
            "rows_examined_per_scan": 1,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "126.25",
              "eval_cost": "50.50",
              "prefix_cost": "383.00",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        }
      ]
    }
  }
}
```

Search (after)
```
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "206.18"
    },
    "ordering_operation": {
      "using_temporary_table": true,
      "using_filesort": true,
      "nested_loop": [
        {
          "table": {
            "table_name": "subscriptions_license",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY",
              "subscriptions_license_subscription_plan_id_476673e5"
            ],
            "rows_examined_per_scan": 505,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "cost_info": {
              "read_cost": "1.75",
              "eval_cost": "50.50",
              "prefix_cost": "52.25",
              "data_read_per_join": "832K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "status",
              "activation_date",
              "last_remind_date",
              "user_email",
              "lms_user_id",
              "subscription_plan_id",
              "activation_key",
              "assigned_date",
              "revoked_date",
              "renewed_to_id",
              "auto_applied"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_customeragreement",
            "access_type": "index",
            "possible_keys": [
              "PRIMARY",
              "enterprise_customer_slug"
            ],
            "key": "enterprise_customer_slug",
            "used_key_parts": [
              "enterprise_customer_slug"
            ],
            "key_length": "515",
            "rows_examined_per_scan": 1,
            "rows_produced_per_join": 505,
            "filtered": "100.00",
            "using_index": true,
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.06",
              "eval_cost": "50.50",
              "prefix_cost": "103.81",
              "data_read_per_join": "962K"
            },
            "used_columns": [
              "uuid",
              "enterprise_customer_slug"
            ]
          }
        },
        {
          "table": {
            "table_name": "subscriptions_subscriptionplan",
            "access_type": "ALL",
            "possible_keys": [
              "PRIMARY",
              "subscriptions_subscr_customer_agreement_i_e53d9d9a_fk_subscript"
            ],
            "rows_examined_per_scan": 2,
            "rows_produced_per_join": 505,
            "filtered": "50.00",
            "using_join_buffer": "hash join",
            "cost_info": {
              "read_cost": "1.37",
              "eval_cost": "50.50",
              "prefix_cost": "206.18",
              "data_read_per_join": "508K"
            },
            "used_columns": [
              "created",
              "modified",
              "uuid",
              "start_date",
              "expiration_date",
              "enterprise_catalog_uuid",
              "is_active",
              "title",
              "salesforce_opportunity_id",
              "for_internal_use_only",
              "num_revocations_applied",
              "revoke_max_percentage",
              "customer_agreement_id",
              "expiration_processed",
              "is_revocation_cap_enabled",
              "can_freeze_unused_licenses",
              "last_freeze_timestamp",
              "should_auto_apply_licenses",
              "product_id"
            ],
            "attached_condition": "((`license_manager`.`subscriptions_subscriptionplan`.`uuid` = `license_manager`.`subscriptions_license`.`subscription_plan_id`) and (`license_manager`.`subscriptions_subscriptionplan`.`customer_agreement_id` = `license_manager`.`subscriptions_customeragreement`.`uuid`) and ((`license_manager`.`subscriptions_license`.`uuid` like <cache>(cast(concat(replace(replace(replace(replace(replace('subby','-',''),'-',''),'\\\\','\\\\\\\\'),'%','\\\\%'),'_','\\\\_'),'%') as char charset binary))) or (`license_manager`.`subscriptions_license`.`user_email` like '%subby%') or (`license_manager`.`subscriptions_subscriptionplan`.`title` like '%subby%') or (`license_manager`.`subscriptions_customeragreement`.`enterprise_customer_slug` like <cache>(cast('subby%' as char charset binary)))))"
          }
        }
      ]
    }
  }
}
```


## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
