### PR TITLE
fix: do not return early from tracking

### DIFF
--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -4,7 +4,6 @@ Utility methods for sending events to Braze or Segment.
 import logging
 
 import analytics
-import attrs
 import requests
 from braze.exceptions import BrazeClientError
 from django.conf import settings
@@ -171,10 +170,8 @@ def track_event(lms_user_id, event_name, properties):
                 )
                 if properties['assigned_email']:
                     _track_event_via_braze_alias(properties['assigned_email'], event_name, properties)
-
-                return
-
-            analytics.track(user_id=lms_user_id, event=event_name, properties=properties)
+            else:
+                analytics.track(user_id=lms_user_id, event=event_name, properties=properties)
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(exc)
     else:
@@ -183,18 +180,12 @@ def track_event(lms_user_id, event_name, properties):
         )
 
     if KAFKA_ENABLED.is_enabled():  # pragma: no cover
-        logger.info("Kafka is enabled. Creating SubscriptionLicenseData to emit.")
         try:
             # assigned_lms_user_id expects an integer or None, but elsewhere it is defaulted to ''
             properties_copy = properties.copy()
             if properties_copy['assigned_lms_user_id'] == "":
                 properties_copy['assigned_lms_user_id'] = None
             license_data = SubscriptionLicenseData(**properties_copy)
-            non_pii_fields = attrs.asdict(license_data,
-                                          filter=lambda attr, value: attr.name not in ["assigned_lms_user_id",
-                                                                                       "assigned_email"])
-            logger.info(f"Emitting SUBSCRIPTION_LICENSE_MODIFIED signal with license_data"
-                        f" with SubscriptionLicenseData {non_pii_fields}")
             SUBSCRIPTION_LICENSE_MODIFIED.send_event(license=license_data)
         except Exception:  # pylint: disable=broad-except
             logger.exception("Exception sending event to message.")

--- a/license_manager/apps/subscriptions/event_utils.py
+++ b/license_manager/apps/subscriptions/event_utils.py
@@ -179,7 +179,7 @@ def track_event(lms_user_id, event_name, properties):
             "Event {} for user_id {} not tracked because SEGMENT_KEY not set".format(event_name, lms_user_id)
         )
 
-    if KAFKA_ENABLED.is_enabled():  # pragma: no cover
+    if KAFKA_ENABLED.is_enabled():
         try:
             # assigned_lms_user_id expects an integer or None, but elsewhere it is defaulted to ''
             properties_copy = properties.copy()

--- a/license_manager/settings/devstack.py
+++ b/license_manager/settings/devstack.py
@@ -101,7 +101,7 @@ KAFKA_SCHEMA_REGISTRY_CONF = {
 }
 KAFKA_REPLICATION_FACTOR_PER_TOPIC=1
 LICENSE_TOPIC_NAME="license-event-dev"
-
+SCHEMA_REGISTRY_URL="http://edx.devstack.schema-registry:8081"
 # Make some loggers less noisy (useful during test failure)
 import logging
 


### PR DESCRIPTION
## Description

Fix early return that was preventing events from going to the event bus

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ARCHBOM-2105

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes