### PR TITLE
fix: Error importing BAR_TYPES with new pip 22.1 release

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -321,7 +321,7 @@ pep517==0.11.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.txt
 pluggy==1.0.0
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==7.1.2
     #   pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517


### PR DESCRIPTION
Changes:
- upgrade pip-tools to 6.6.1 according to
https://github.com/jazzband/pip-tools/issues/1617#issuecomment-1126245586

## Description

pip-tools doesn't work properly with pip 22.1 release

It can be fixed by pining the pip version <22.1.
But also it looks like the issue can be fixed by upgrading pip-tools to the [latest](https://pypi.org/project/pip-tools/6.6.1/) version.
According to the [issue](https://github.com/jazzband/pip-tools/issues/1617) discussion -  `Fix released as part of pip-tools v6.6.1.`


## How to reproduce

```
> pip --version
pip 22.1 
> pip install -U pip-tools==6.4.0
> pip-compile --version                                                                                                                                                 cmltawt0/fix/piptools
Traceback (most recent call last):
  File "/code/openedx/license-manager/.venv/bin/pip-compile", line 5, in <module>
    from piptools.scripts.compile import cli
  File "/code/openedx/license-manager/.venv/lib/python3.8/site-packages/piptools/scripts/compile.py", line 21, in <module>
    from ..repositories import LocalRequirementsRepository, PyPIRepository
  File "/code/openedx/license-manager/.venv/lib/python3.8/site-packages/piptools/repositories/__init__.py", line 1, in <module>
    from .local import LocalRequirementsRepository
  File "/code/openedx/license-manager/.venv/lib/python3.8/site-packages/piptools/repositories/local.py", line 14, in <module>
    from .pypi import PyPIRepository
  File "/code/openedx/license-manager/.venv/lib/python3.8/site-packages/piptools/repositories/pypi.py", line 22, in <module>
    from pip._internal.cli.progress_bars import BAR_TYPES
ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars' 
```

## How to check fix

```
> make production-requirements                                                                                                                                          
pip install -r requirements/pip-tools.txt
............
Requirement already satisfied: pip>=21.2 in ./.venv/lib/python3.8/site-packages (from pip-tools==6.6.1->-r requirements/pip-tools.txt (line 13)) (22.1)
Requirement already satisfied: setuptools in ./.venv/lib/python3.8/site-packages (from pip-tools==6.6.1->-r requirements/pip-tools.txt (line 13)) (62.0.0)
Installing collected packages: pip-tools
  Attempting uninstall: pip-tools
    Found existing installation: pip-tools 6.4.0
    Uninstalling pip-tools-6.4.0:
      Successfully uninstalled pip-tools-6.4.0
Successfully installed pip-tools-6.6.1
> pip-compile --version                                                                                                                                                 
pip-compile, version 6.6.1
```

