### PR TITLE
build: add backup/restore Make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ docs/_build/
 scripts/
 
 .vscode/
+
+.dev/

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,12 @@ app-restart-devserver: ## Kill the license-manager development server. Watcher s
 dev.stats: ## Get per-container CPU and memory utilization data.
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
+dev.backup: dev.up
+	docker run --rm --volumes-from license-manager.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql57.tar.gz /var/lib/mysql
+
+dev.restore: dev.up
+	docker run --rm --volumes-from license-manager.mysql -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql57.tar.gz
+
 docker_build:
 	docker build . -f Dockerfile --target app -t openedx/license-manager
 	docker build . -f Dockerfile --target devstack -t openedx/license-manager:latest-devstack

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,27 @@ Running migrations
   $ make app-shell
   # ./manage.py migrate
 
+Running backup/restore to switch mysql volumes
+----------------------------------------------
+Sometimes the names of volumes must change due to upgrades, etc.
+To dump data from an old mysql volume to the new mysql8 volume:
+
+- Temporarily modify docker-compose.yml to switch the mysql volume name from mysql8 to just mysql
+- Create a backup directory in your license-manager repo: ``mkdir -p .dev/backups``
+  (although the next steps might actually do this for you)
+
+Then::
+
+  make dev.down
+  make dev.backup
+  make dev.down
+
+Next:
+
+- Remove your temp changes from above in docker-compose.yml
+- ``make dev.restore``
+- ``make dev.down dev.up`` - might be necessary if you lost connection between the app container and the mysql container.
+
 Documentation
 -------------
 .. |ReadtheDocs| image:: https://readthedocs.org/projects/license-manager/badge/?version=latest


### PR DESCRIPTION
## Description

Allows one to backup and restore `/var/lib/mysql`.  Particularly useful if switching mysql docker volumes.

To dump data from the old `mysql` volume to the new `mysql8` volume:
* `make dev.down`
* Temporarily modify `docker-compose.yml` to switch the mysql volume name from `mysql8` to just `mysql`
* Create a backup directory in your license-manager repo: `mkdir -p .dev/backups` (although the next step might actually do this for you)
* `make dev.backup`
* `make dev.down`
* Remove your temp changes from above in `docker-compose.yml`
* `make dev.restore`
* `make dev.down dev.up` - might be necessary if you lost connection between the `app` container and the `mysql` container.

