### PR TITLE
fix: set task retry_backoff to 60 (up from 10)

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -66,8 +66,11 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     )
     retry_kwargs = {'max_retries': 3}
     # Use exponential backoff for retrying tasks
-    retry_backoff = 10  # delay factor of 10 seconds
-    # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
+    # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
+    # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
+    retry_backoff = 60
+    # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously.
+    # The actual delay value will be a random number in the range (0, retry_backoff)
     retry_jitter = True
 
 


### PR DESCRIPTION
## Description

We've seen a somewhat-high and persistent incidence of read timeouts (and thus, celery retry "errors") to Braze in New Relic, so we're tweaking the retry backoff for all our celery tasks.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
