### PR TITLE
feat: improves the SubscriptionPlanRenewal admin experience

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -144,7 +144,7 @@ class LicenseAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
 
 
 @admin.register(SubscriptionPlan)
-class SubscriptionPlanAdmin(SimpleHistoryAdmin):
+class SubscriptionPlanAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
     form = SubscriptionPlanForm
     # This is not to be confused with readonly_fields of the BaseModelAdmin class
     read_only_fields = [
@@ -417,9 +417,10 @@ class CustomerAgreementAdmin(admin.ModelAdmin):
 
 
 @admin.register(SubscriptionPlanRenewal)
-class SubscriptionPlanRenewalAdmin(admin.ModelAdmin):
+class SubscriptionPlanRenewalAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     form = SubscriptionPlanRenewalForm
-    readonly_fields = ['renewed_subscription_plan']
+    readonly_fields = ['renewed_subscription_plan', 'processed', 'processed_datetime']
+    raw_id_fields = ['prior_subscription_plan']
     list_display = (
         'get_prior_subscription_plan_title',
         'effective_date',


### PR DESCRIPTION
* Makes SubscriptionPlanAdmin and SubscriptionPlanRenewal admin searchable with DjangoQL.
* Makes the renewal model's `processed` and `processed_datetime` fields read-only
* Improves page load performance by changing renewal admin's `prior_subscription_plan` field to be a [raw_id_field](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields). Utilizing DjangoQL on the SubscriptionPlanAdmin makes it easy for a user to find the UUID of the prior plan they want via the magnifying glass icon.

ENT-6322

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-6322

Try it out: http://localhost:18170/admin/subscriptions/subscriptionplanrenewal/add/

Read-only fields now:
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/2307986/194104415-df017c7f-73ab-424b-bc27-30bfcc70c3dc.png">

Search for the raw id prior subscription plan value:
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/2307986/194104555-371f4bc7-1906-4c34-9139-e72f43580b21.png">

Power-search renewal records:
<img width="1773" alt="image" src="https://user-images.githubusercontent.com/2307986/194104732-32490325-960f-4a3b-acac-5a3072d18c7f.png">
