### PR TITLE
fix: Remove remaining Kafka references

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,3 @@ omit =
     *admin.py
     *static*
     *templates*
-    license_manager/apps/subscriptions/event_bus_utils.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,6 @@ apt-get upgrade -qy && apt-get install language-pack-en locales git \
 python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip -qy && \
 rm -rf /var/lib/apt/lists/*
 
-WORKDIR /tmp
-RUN wget https://packages.confluent.io/clients/deb/pool/main/libr/librdkafka/librdkafka_1.8.2.orig.tar.gz
-RUN tar -xf librdkafka_1.8.2.orig.tar.gz
-WORKDIR /tmp/librdkafka-1.8.2
-RUN ./configure && make && make install && ldconfig
-
 ENV VIRTUAL_ENV=/edx/app/license-manager/venvs/license-manager
 RUN python3.8 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -418,18 +418,3 @@ LICENSE_REVERT_SNAPSHOT_TIMESTAMP = '9999-12-31 23:59:59'
 
 # Django Admin Settings
 VALIDATE_FORM_EXTERNAL_FIELDS = True
-
-################### Kafka Related Settings ##############################
-KAFKA_BOOTSTRAP_SERVER = ''
-KAFKA_API_KEY = ''
-KAFKA_API_SECRET = ''
-SCHEMA_REGISTRY_API_KEY = ''
-SCHEMA_REGISTRY_API_SECRET=''
-SCHEMA_REGISTRY_URL=''
-
-
-KAFKA_PARTITIONS_PER_TOPIC=1
-# This number is dictated by the cluster setup
-KAFKA_REPLICATION_FACTOR_PER_TOPIC=3
-
-KAFKA_ENABLED = False


### PR DESCRIPTION
We're no longer using license-manager as our Kafka event-bus prototype, but there were a couple of loose ends left over. (See 526abc29 for main cleanup, and https://github.com/edx/edx-arch-experiments/issues/41 for work ticket.)

This reverts parts of the following commits:

- aaf9947cba7b223a52c6cb526306a9d9dfb41dad
- d93c9cee7615aefda116650effe9caebafcb733c