### PR TITLE
refactor: Added check on user_activated_licenses which was causing 500 error in few cases.

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1300,7 +1300,6 @@ class LicenseSubsidyView(LicenseBaseView):
         if not self.requested_course_key:
             msg = 'You must supply the course_key query parameter'
             return Response(msg, status=status.HTTP_400_BAD_REQUEST)
-
         customer_agreement = utils.get_customer_agreement_from_request_enterprise_uuid(request)
         user_activated_licenses = License.objects.filter(
             subscription_plan__in=customer_agreement.subscriptions.all(),
@@ -1308,11 +1307,13 @@ class LicenseSubsidyView(LicenseBaseView):
             status=constants.ACTIVATED,
         )
         # order licenses by their associated subscription plan expiration date
-        ordered_licenses_by_expiration = sorted(
-            user_activated_licenses,
-            key=lambda user_license: user_license.subscription_plan.expiration_date,
-            reverse=True,
-        )
+        ordered_licenses_by_expiration = []
+        if user_activated_licenses:
+            ordered_licenses_by_expiration = sorted(
+                user_activated_licenses,
+                key=lambda user_license: user_license.subscription_plan.expiration_date,
+                reverse=True,
+            )
 
         # iterate through the ordered licenses to return the license subsidy data for the user's license
         # which is "valid" for the specified content key and expires furthest in the future.
@@ -1342,7 +1343,6 @@ class LicenseSubsidyView(LicenseBaseView):
                 'subsidy_checksum': checksum_for_license,
             })
             return Response(ordered_data)
-
         # user does not have an activated license that is applicable to the specified content key.
         msg = (
             'This course was not found in the subscription plan catalogs associated with the '


### PR DESCRIPTION
## Description

Description of changes made
In a few cases when the course is not part of the user catalog, it is showing the 500 error except for showing the right error. 
Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-6472

https://enterprise.edx.org/pied-piper-non-integrated-test/course/MITx+CTL.SC4x

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
