### PR TITLE
fix: improve the validate_num_catalog_queries mgmt command

### DIFF
--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -73,8 +73,8 @@ class ProductFactory(factory.django.DjangoModelFactory):
     """
     Test factory for the `Product` model.
     """
-    name = 'Test Product'
-    description = 'Test Product'
+    name = factory.LazyAttribute(lambda p: 'Test Product {} {}'.format(FAKER.word(), random.randint(0, 1000000)))
+    description = factory.LazyAttribute(lambda p: 'Test Product {} {}'.format(FAKER.word(), random.randint(0, 1000000)))
     plan_type = factory.SubFactory(PlanTypeFactory)
     netsuite_id = factory.Faker('random_int', min=0, max=9999999)
 

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -1,0 +1,13 @@
+# This makes it easier to get coverage reports for only specific modules
+# when running pytest locally, for example:
+# pytest -W ignore license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py -c pytest.local.ini  --reuse-db
+[pytest]
+DJANGO_SETTINGS_MODULE = license_manager.settings.test
+addopts = --cov-report term-missing --cov-report xml -W ignore
+norecursedirs = .* docs requirements
+
+# Filter depr warnings coming from packages that we can't control.
+filterwarnings =
+	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
+	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
+	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*


### PR DESCRIPTION
The expected number of catalog queries should be determined from the distinct number of products, not the distinct number of netsuite ids, because many products have no netsuite id.
Also improves readability and usefulness of error message in case the expected number of catalog queries differs from the actual number.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
