### PR TITLE
feat: set user throttling thresholds higher, REST_FRAMEWORK updated from settings

### DIFF
--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -145,8 +145,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'anon': '60/minute',
-        'user_burst': '6/second',
-        'user_sustained': '180/minute',
+        'user_burst': '18/second',
+        'user_sustained': '360/minute',
     }
 }
 

--- a/license_manager/settings/production.py
+++ b/license_manager/settings/production.py
@@ -14,7 +14,7 @@ LOGGING = get_logger_config()
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('JWT_AUTH',)
+DICT_UPDATE_KEYS = ('JWT_AUTH', 'REST_FRAMEWORK')
 
 # This may be overridden by the YAML in license_manager_CFG,
 # but it should be here as a default.


### PR DESCRIPTION
* Changes throttling thresholds to be more permissive.
* Allows `REST_FRAMEWORK` to be updated (instead of replaced) from yaml settings, so we can change the DRF config (including throttling) in the future via settings, instead of needing to deploy new license-manager code.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
