### PR TITLE
feat: license assignment is linearizable

### DIFF
--- a/docs/decisions/0014-linearizable-license-assignment.rst
+++ b/docs/decisions/0014-linearizable-license-assignment.rst
@@ -1,0 +1,62 @@
+14. Linearizable license assignment
+###################################
+
+
+Status
+******
+
+Accepted (March 2023)
+
+
+Context
+*******
+The ``/assign`` API endpoint assigns unassigned licenses for a list of user emails
+provided as input - it works "in bulk" by default. The core components of this operation
+are currently synchronous, so for large inputs, the operation can take quite a long time
+to complete (perhaps several minutes).  For large inputs, clients of this endpoint
+may see a browser-level timeout before the operation actually completes in the backend.
+This opens up a fairly high risk of race-conditions occuring.
+
+We don’t set a unique constraint on ``(user_email, status)`` in the ``License`` model.
+The best validation we have is via the ``License.clean()`` method,
+which checks for existing assigned or activated licenses for a given email.
+We updated ``License.save()`` to call ``full_clean()`` to do this validation.
+However, ``License.bulk_update()`` relies on (the simple-history version of) Django's bulk_update ,
+which does not call ``save()`` on each instance, and therefore, skips this validation.  The ``/assign``
+endpoint uses ``License.bulk_update()`` to assign licenses to the provided list of user emails.
+See https://github.com/openedx/license-manager/blob/master/docs/decisions/0012-assigning-new-license-to-revoked-user.rst
+for more context on the decision to design our constrains in this way.
+
+The ``/assign`` endpoint `does` have logic to find email addresses
+that already have a license associated with the subscription plan from which licenses are assigned.
+However, due to the high risk of race-conditions mentioned above, this logic is currently
+not strong enough to prevent subsequent, long-running assignment operations from over-writing
+state between concurrent requests.
+
+Decision
+********
+We'll make license assignment `Linearizable`_ by introducing a lock at the ``SubscriptionPlan``
+level.  The lock is currently only considered during the assignment operation.
+
+.. _Linearizable: https://en.wikipedia.org/wiki/Linearizability
+
+
+Consequences
+************
+Multiple requests to assign licenses from the same subscription plan cannot operate concurrently - the first
+such request will acquire the lock, and all following requests will fail.  The first request will
+release the lock when it returns, successfully or not.
+This means that assignment operations for which the lock cannot be acquired will fail, and clients
+should eventually handle this failure with grace.
+
+Alternatives Considered
+***********************
+We should, in the future, wrap the entire license assignment operation in an asynchronous task,
+because this operation can be quite long-running.
+It'd be even better to constrain License ``(user_email, status)`` at the database level, but
+we can't currently do that in a way that meets our usage requirements (see linked ADR above).
+
+Additionally, we considered using Redis to implement the lock mechanism, via the
+https://github.com/brainix/pottery#redlock, but at the time of this writing, we don't
+yet have a good "paved road" for using Redis as a store of application-level data; it's only
+well-supported within the edX ecosystem as a Celery broker.

--- a/license_manager/settings/test.py
+++ b/license_manager/settings/test.py
@@ -40,3 +40,4 @@ logging.getLogger('event_utils').setLevel(logging.ERROR)
 
 # Django Admin Settings
 VALIDATE_FORM_EXTERNAL_FIELDS = False
+DEBUG = False

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,15 +10,17 @@ analytics-python==1.4.0
     # via -r requirements/base.in
 asgiref==3.6.0
     # via django
+async-timeout==4.0.2
+    # via redis
 backoff==1.10.0
     # via
     #   -r requirements/base.in
     #   analytics-python
 billiard==3.6.4.0
     # via celery
-boto3==1.26.64
+boto3==1.26.81
     # via django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   boto3
     #   s3transfer
@@ -57,7 +59,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -65,7 +67,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -90,7 +92,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/base.in
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -137,7 +139,7 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/base.in
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via edx-api-doc-tools
 edx-api-doc-tools==1.6.0
     # via -r requirements/base.in
@@ -191,7 +193,7 @@ monotonic==1.6
     # via analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.in
-newrelic==8.5.0
+newrelic==8.7.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -203,7 +205,7 @@ pbr==5.11.1
     # via stevedore
 ply==3.11
     # via djangoql
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via click-repl
 psutil==5.9.4
     # via edx-django-utils
@@ -229,7 +231,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   botocore
     #   edx-drf-extensions
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via code-annotations
 python3-openid==3.2.0
     # via social-auth-core
@@ -243,10 +245,8 @@ pytz==2022.7.1
     #   drf-yasg
 pyyaml==6.0
     # via code-annotations
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+redis==4.5.1
+    # via -r requirements/base.in
 requests==2.28.2
     # via
     #   analytics-python
@@ -291,7 +291,7 @@ social-auth-core==4.3.0
     #   social-auth-app-django
 sqlparse==0.4.3
     # via django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -315,5 +315,5 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-zipp==3.12.1
+zipp==3.15.0
     # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,9 +19,6 @@ diff-cover==4.0.0
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
 
-# redis 4 causes fires
-redis<4
-
 # edx-lint>=5.3.0 and/or pylint>=2.15 throws a bunch of unknown option value errors
 edx-lint<5.3
 pylint<2.15

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,6 +20,10 @@ astroid==2.11.7
     #   -r requirements/validation.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/validation.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/validation.txt
@@ -32,11 +36,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -106,11 +110,11 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.1.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -132,7 +136,7 @@ dill==0.3.6
     # via
     #   -r requirements/validation.txt
     #   pylint
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/validation.txt
@@ -159,7 +163,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/validation.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -215,7 +219,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/validation.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/validation.txt
     #   edx-api-doc-tools
@@ -259,7 +263,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==16.6.1
+faker==17.4.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -335,7 +339,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/validation.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -363,7 +367,7 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.12.2
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -376,11 +380,11 @@ ply==3.11
     # via
     #   -r requirements/validation.txt
     #   djangoql
-polib==1.1.1
+polib==1.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-i18n-tools
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/validation.txt
     #   click-repl
@@ -398,7 +402,7 @@ pycryptodomex==3.17
     # via
     #   -r requirements/validation.txt
     #   pyjwkest
-pydantic==1.10.4
+pydantic==1.10.5
     # via inflect
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
@@ -466,7 +470,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -489,10 +493,8 @@ pyyaml==6.0
     #   -r requirements/validation.txt
     #   code-annotations
     #   edx-i18n-tools
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/validation.txt
+redis==4.5.1
+    # via -r requirements/validation.txt
 requests==2.28.2
     # via
     #   -r requirements/validation.txt
@@ -564,7 +566,7 @@ sqlparse==0.4.3
     #   -r requirements/validation.txt
     #   django
     #   django-debug-toolbar
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -587,7 +589,7 @@ tomlkit==0.11.6
     # via
     #   -r requirements/validation.txt
     #   pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/validation.txt
     #   astroid
@@ -626,7 +628,7 @@ wrapt==1.11.2
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt
     #   astroid
-zipp==3.12.1
+zipp==3.15.0
     # via -r requirements/validation.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,11 +22,15 @@ astroid==2.11.7
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/test.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 backoff==1.10.0
     # via
@@ -38,11 +42,11 @@ billiard==3.6.4.0
     #   celery
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -106,11 +110,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.1.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -126,7 +130,7 @@ dill==0.3.6
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -151,7 +155,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/test.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -211,7 +215,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/test.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
@@ -255,7 +259,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==16.6.1
+faker==17.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -326,7 +330,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -345,7 +349,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -357,7 +361,7 @@ ply==3.11
     # via
     #   -r requirements/test.txt
     #   djangoql
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -436,7 +440,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -459,10 +463,8 @@ pyyaml==6.0
     #   code-annotations
 readme-renderer==37.3
     # via -r requirements/doc.in
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+redis==4.5.1
+    # via -r requirements/test.txt
 requests==2.28.2
     # via
     #   -r requirements/test.txt
@@ -552,7 +554,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -574,7 +576,7 @@ tomlkit==0.11.6
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/test.txt
     #   astroid
@@ -610,7 +612,7 @@ wrapt==1.11.2
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   astroid
-zipp==3.12.1
+zipp==3.15.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.38.4
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0
+pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.1.0
+setuptools==67.4.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,6 +14,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
+async-timeout==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   redis
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -22,11 +26,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -83,7 +87,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -93,7 +97,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -118,7 +122,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/base.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -168,7 +172,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/base.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -250,7 +254,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -271,7 +275,7 @@ ply==3.11
     # via
     #   -r requirements/base.txt
     #   djangoql
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -315,7 +319,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
 python-memcached==1.59
     # via -r requirements/production.in
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -336,10 +340,8 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   code-annotations
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+redis==4.5.1
+    # via -r requirements/base.txt
 requests==2.28.2
     # via
     #   -r requirements/base.txt
@@ -404,7 +406,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -438,7 +440,7 @@ wcwidth==0.2.6
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-zipp==3.12.1
+zipp==3.15.0
     # via -r requirements/base.txt
 zope-event==4.6
     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,6 +19,10 @@ astroid==2.11.7
     #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   redis
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -27,11 +31,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -93,7 +97,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -105,7 +109,7 @@ defusedxml==0.7.1
     #   social-auth-core
 dill==0.3.6
     # via pylint
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -130,7 +134,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/base.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -180,7 +184,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/base.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -268,7 +272,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -285,13 +289,13 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via pylint
 ply==3.11
     # via
     #   -r requirements/base.txt
     #   djangoql
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -352,7 +356,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   botocore
     #   edx-drf-extensions
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -372,10 +376,8 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+redis==4.5.1
+    # via -r requirements/base.txt
 requests==2.28.2
     # via
     #   -r requirements/base.txt
@@ -442,7 +444,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -456,7 +458,7 @@ tomli==2.0.1
     # via pylint
 tomlkit==0.11.6
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
@@ -488,7 +490,7 @@ wrapt==1.11.2
     # via
     #   -c requirements/constraints.txt
     #   astroid
-zipp==3.12.1
+zipp==3.15.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,6 +19,10 @@ astroid==2.11.7
     #   -c requirements/constraints.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   redis
 attrs==22.2.0
     # via pytest
 backoff==1.10.0
@@ -29,11 +33,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -96,11 +100,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.1.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -114,7 +118,7 @@ defusedxml==0.7.1
     #   social-auth-core
 dill==0.3.6
     # via pylint
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -139,7 +143,7 @@ django==3.2.17
     #   jsonfield
 django-celery-results==2.4.0
     # via -r requirements/base.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -191,7 +195,7 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-nested-routers==0.93.4
     # via -r requirements/base.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
@@ -231,7 +235,7 @@ exceptiongroup==1.1.0
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.6.1
+faker==17.4.0
     # via factory-boy
 freezegun==1.2.2
     # via -r requirements/test.in
@@ -287,7 +291,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -305,7 +309,7 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -313,7 +317,7 @@ ply==3.11
     # via
     #   -r requirements/base.txt
     #   djangoql
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -380,7 +384,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -400,10 +404,8 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
-redis==3.5.3
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+redis==4.5.1
+    # via -r requirements/base.txt
 requests==2.28.2
     # via
     #   -r requirements/base.txt
@@ -469,7 +471,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -486,7 +488,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.6
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
@@ -518,7 +520,7 @@ wrapt==1.11.2
     # via
     #   -c requirements/constraints.txt
     #   astroid
-zipp==3.12.1
+zipp==3.15.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -25,6 +25,11 @@ astroid==2.11.7
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
@@ -39,12 +44,12 @@ billiard==3.6.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.26.64
+boto3==1.26.81
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.29.64
+botocore==1.29.81
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -121,11 +126,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.1.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -144,7 +149,7 @@ dill==0.3.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/quality.txt
@@ -173,7 +178,7 @@ django-celery-results==2.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -247,7 +252,7 @@ drf-nested-routers==0.93.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -310,7 +315,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==16.6.1
+faker==17.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -391,7 +396,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -417,7 +422,7 @@ pbr==5.11.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -431,9 +436,9 @@ ply==3.11
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   djangoql
-polib==1.1.1
+polib==1.2.0
     # via edx-i18n-tools
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -524,7 +529,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -549,9 +554,8 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-i18n-tools
-redis==3.5.3
+redis==4.5.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 requests==2.28.2
@@ -639,7 +643,7 @@ sqlparse==0.4.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -663,7 +667,7 @@ tomlkit==0.11.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -704,7 +708,7 @@ wrapt==1.11.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-zipp==3.12.1
+zipp==3.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
This makes license assignment `Linearizable` by introducing a lock at the `SubscriptionPlan`
level.  The lock is currently only considered during the assignment operation.  This is necessary
to handle race-conditions during long-running assignment operations, within which we cannot
rely on DB-level constraints to maintain valid license state.

https://2u-internal.atlassian.net/browse/ENT-6834

See the ADR for more information.

## Testing considerations

To test this manually, I added a brief `time.sleep(4)` in the `/assign` body and prepared two different browser sessions to assign licenses from the same plan. Picture below - left went first, right went second, and you can see the LOCK response on the right:
![image](https://user-images.githubusercontent.com/2307986/222549785-2173b5c7-6982-4766-8121-a1e75e9262e2.png)

I also verified in a subsequent request that:
1. the lock was released after the first assigner was done.
2. subsequent calls respected the logic that checks for previous assignment of licenses to emails in the assignment request.

