### PR TITLE
fix: handle duplicate licenses during the activation flow. ENT-6761

### DIFF
--- a/license_manager/apps/api/v1/tests/test_license_activation_view.py
+++ b/license_manager/apps/api/v1/tests/test_license_activation_view.py
@@ -1,0 +1,352 @@
+"""
+Tests for the LicenseActivationView.
+"""
+import datetime
+from unittest import mock
+from uuid import uuid4
+
+import ddt
+from django.http import QueryDict
+from django.test import TestCase
+from django.urls import reverse
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from license_manager.apps.subscriptions import constants
+from license_manager.apps.subscriptions.models import License
+from license_manager.apps.subscriptions.tests.factories import (
+    SubscriptionPlanFactory,
+)
+from license_manager.apps.subscriptions.utils import localized_utcnow
+
+from .test_views import LicenseViewTestMixin, _assign_role_via_jwt_or_db
+
+
+@ddt.ddt
+class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
+    """
+    Tests for the license activation view.
+    """
+
+    def tearDown(self):
+        """
+        Deletes all licenses after each test method is run.
+        """
+        super().tearDown()
+
+        License.objects.all().delete()
+
+    def _post_request(self, activation_key):
+        """
+        Helper to make the POST request to the license activation endpoint.
+
+        Will update the test client's cookies to contain an lms_user_id and email,
+        which can be overridden from those defined in the class ``setUpTestData()``
+        method with the optional params provided here.
+        """
+        query_params = QueryDict(mutable=True)
+        query_params['activation_key'] = str(activation_key)
+        url = reverse('api:v1:license-activation') + '/?' + query_params.urlencode()
+        return self.api_client.post(url)
+
+    def test_activation_no_auth(self):
+        """
+        Unauthenticated requests should result in a 401.
+        """
+        # Create a new client with no authentication present.
+        self.api_client = APIClient()
+
+        response = self._post_request(uuid4())
+
+        assert status.HTTP_401_UNAUTHORIZED == response.status_code
+
+    def test_activation_no_jwt_roles(self):
+        """
+        JWT Authenticated requests without the appropriate learner role should result in a 403.
+        """
+        _assign_role_via_jwt_or_db(
+            self.api_client,
+            self.user,
+            self.enterprise_customer_uuid,
+            assign_via_jwt=True,
+            system_role=None,
+        )
+        self._create_license()
+
+        response = self._post_request(self.activation_key)
+
+        assert status.HTTP_403_FORBIDDEN == response.status_code
+
+    @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
+    def test_activation_no_jwt(self, mock_get_decoded_jwt):
+        """
+        Verify that license activation returns a 400 if the user's email could not be found in the JWT.
+        """
+        mock_get_decoded_jwt.return_value = {}
+        response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_400_BAD_REQUEST == response.status_code
+        assert '`email` is required and could not be found in your jwt' in str(response.content)
+
+    def test_activation_key_is_malformed(self):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+
+        response = self._post_request('deadbeef')
+
+        assert status.HTTP_400_BAD_REQUEST == response.status_code
+        assert 'deadbeef is not a valid activation key' in str(response.content)
+
+    def test_activation_key_does_not_exist(self):
+        """
+        When the user is authenticated and has the appropriate role,
+        but no corresponding license exists for the given ``activation_key``,
+        we should return a 404.
+        """
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+
+        response = self._post_request(uuid4())
+
+        assert status.HTTP_404_NOT_FOUND == response.status_code
+
+    @ddt.data(
+        {'disable_onboarding_notifications': False},
+        {'disable_onboarding_notifications': True}
+    )
+    @ddt.unpack
+    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
+    def test_activate_an_assigned_license(self, mock_send_post_activation_email_task, disable_onboarding_notifications):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_uuid': str(self.active_subscription_for_customer.uuid),
+            }
+        )
+        license_to_be_activated = self._create_license()
+
+        if disable_onboarding_notifications:
+            customer_agreement = license_to_be_activated.subscription_plan.customer_agreement
+            customer_agreement.disable_onboarding_notifications = True
+            customer_agreement.save()
+
+        with freeze_time(self.now):
+            response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+        license_to_be_activated.refresh_from_db()
+        assert constants.ACTIVATED == license_to_be_activated.status
+        assert self.lms_user_id == license_to_be_activated.lms_user_id
+        assert self.now == license_to_be_activated.activation_date
+
+        if disable_onboarding_notifications:
+            mock_send_post_activation_email_task.assert_not_called()
+        else:
+            mock_send_post_activation_email_task.assert_called_with(
+                self.enterprise_customer_uuid,
+                self.user.email,
+            )
+
+    def test_license_already_activated_returns_204(self):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+        already_activated_license = self._create_license(
+            status=constants.ACTIVATED,
+            activation_date=self.now,
+        )
+
+        response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+        already_activated_license.refresh_from_db()
+        assert constants.ACTIVATED == already_activated_license.status
+        assert self.lms_user_id == already_activated_license.lms_user_id
+        assert self.now == already_activated_license.activation_date
+
+    # pylint: disable=unused-argument
+    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.models.License.clean', return_value=None)
+    def test_duplicate_licenses_are_cleaned_up(self, mock_license_clean, mock_email_task_delay):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+        # Make sure to use an activation key that's different from the
+        # activation_key of the license  we want to keep.
+        revoked_license = self._create_license(
+            status=constants.REVOKED,
+            assigned_date=self.now,
+            activation_key=uuid4(),
+        )
+        license_a = self._create_license(
+            status=constants.ASSIGNED,
+            assigned_date=self.now - datetime.timedelta(days=1),
+            activation_key=uuid4(),
+        )
+        license_b = self._create_license(
+            status=constants.ASSIGNED,
+            assigned_date=self.now,
+            activation_key=self.activation_key,
+        )
+        license_c = self._create_license(
+            status=constants.ASSIGNED,
+            assigned_date=self.now - datetime.timedelta(days=2),
+            activation_key=uuid4(),
+        )
+
+        with freeze_time(self.now):
+            response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+        license_b.refresh_from_db()
+        assert constants.ACTIVATED == license_b.status
+        assert self.lms_user_id == license_b.lms_user_id
+        assert self.now == license_b.activation_date
+        assert self.now == license_b.assigned_date
+        assert self.activation_key == license_b.activation_key
+
+        license_a.refresh_from_db()
+        assert constants.UNASSIGNED == license_a.status
+        self.assertIsNone(license_a.lms_user_id)
+        self.assertIsNone(license_a.activation_key)
+
+        license_c.refresh_from_db()
+        assert constants.UNASSIGNED == license_c.status
+        self.assertIsNone(license_c.lms_user_id)
+        self.assertIsNone(license_c.activation_key)
+
+        revoked_license.refresh_from_db()
+        assert constants.REVOKED == revoked_license.status
+
+    # pylint: disable=unused-argument
+    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
+    @mock.patch('license_manager.apps.subscriptions.models.License.clean', return_value=None)
+    def test_activated_license_exists_with_duplicates(self, mock_license_clean, mock_email_task_delay):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+        # Make sure to use an activation key that's different from the
+        # activation_key of the license  we want to keep.
+        license_a_activation_key = uuid4()
+        license_a = self._create_license(
+            status=constants.ASSIGNED,
+            assigned_date=self.now - datetime.timedelta(days=1),
+            activation_key=license_a_activation_key,
+        )
+        license_b = self._create_license(
+            status=constants.ACTIVATED,
+            assigned_date=self.now,
+            activation_date=self.now,
+            activation_key=self.activation_key,
+        )
+
+        with freeze_time(self.now):
+            response = self._post_request(str(license_a_activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+        license_b.refresh_from_db()
+        assert constants.ACTIVATED == license_b.status
+        assert self.lms_user_id == license_b.lms_user_id
+        assert self.now == license_b.activation_date
+        assert self.now == license_b.assigned_date
+        assert self.activation_key == license_b.activation_key
+
+        license_a.refresh_from_db()
+        assert constants.UNASSIGNED == license_a.status
+        self.assertIsNone(license_a.lms_user_id)
+        self.assertIsNone(license_a.activation_key)
+        self.assertIsNone(license_a.activation_date)
+
+    def test_activating_revoked_license_returns_422(self):
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
+            }
+        )
+        revoked_license = self._create_license(
+            status=constants.REVOKED,
+            activation_date=self.now,
+        )
+
+        response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
+        revoked_license.refresh_from_db()
+        assert constants.REVOKED == revoked_license.status
+        assert self.lms_user_id == revoked_license.lms_user_id
+        assert self.now == revoked_license.activation_date
+
+    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
+    def test_activating_renewed_assigned_license(self, mock_send_post_activation_email_task):
+        yesterday = localized_utcnow() - datetime.timedelta(days=1)
+        # create an expired plan and a current plan
+        subscription_plan_original = SubscriptionPlanFactory.create(
+            customer_agreement=self.customer_agreement,
+            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
+            is_active=True,
+            start_date=localized_utcnow() - datetime.timedelta(days=366),
+            expiration_date=yesterday,
+        )
+        subscription_plan_renewed = SubscriptionPlanFactory.create(
+            customer_agreement=self.customer_agreement,
+            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
+            is_active=True,
+            product=subscription_plan_original.product
+        )
+
+        self._assign_learner_roles(
+            jwt_payload_extra={
+                'user_id': self.lms_user_id,
+                'email': self.user.email,
+                'subscription_plan_type': subscription_plan_original.product.plan_type_id,
+            }
+        )
+
+        prior_assigned_license = self._create_license(
+            subscription_plan=subscription_plan_original,
+            # explicitly set activation_date to assert that this license
+            # is *not* the one that gets activated during the POST request.
+            activation_date=yesterday,
+        )
+        current_assigned_license = self._create_license(subscription_plan=subscription_plan_renewed)
+
+        with freeze_time(self.now):
+            response = self._post_request(str(self.activation_key))
+
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+        current_assigned_license.refresh_from_db()
+        prior_assigned_license.refresh_from_db()
+        assert prior_assigned_license.activation_date != self.now
+        assert current_assigned_license.activation_date == self.now
+        mock_send_post_activation_email_task.assert_called_with(
+            self.enterprise_customer_uuid,
+            self.user.email,
+        )

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -23,7 +23,6 @@ from edx_rest_framework_extensions.auth.jwt.tests.utils import (
     generate_jwt_token,
     generate_unversioned_payload,
 )
-from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -2414,7 +2413,7 @@ class LicenseViewTestMixin:
             lms_user_id=self.lms_user_id,
             user_email=self.user.email,
             subscription_plan=subscription_plan,
-            activation_key=self.activation_key,
+            activation_key=kwargs.pop('activation_key', self.activation_key),
             activation_date=kwargs.pop('activation_date', None),
             **kwargs,
         )
@@ -3201,232 +3200,6 @@ class LicenseSubsidyViewTests(LicenseViewTestMixin, TestCase):
 
 
 @ddt.ddt
-class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
-    """
-    Tests for the license activation view.
-    """
-
-    def tearDown(self):
-        """
-        Deletes all licenses after each test method is run.
-        """
-        super().tearDown()
-
-        License.objects.all().delete()
-
-    def _post_request(self, activation_key):
-        """
-        Helper to make the POST request to the license activation endpoint.
-
-        Will update the test client's cookies to contain an lms_user_id and email,
-        which can be overridden from those defined in the class ``setUpTestData()``
-        method with the optional params provided here.
-        """
-        query_params = QueryDict(mutable=True)
-        query_params['activation_key'] = str(activation_key)
-        url = reverse('api:v1:license-activation') + '/?' + query_params.urlencode()
-        return self.api_client.post(url)
-
-    def test_activation_no_auth(self):
-        """
-        Unauthenticated requests should result in a 401.
-        """
-        # Create a new client with no authentication present.
-        self.api_client = APIClient()
-
-        response = self._post_request(uuid4())
-
-        assert status.HTTP_401_UNAUTHORIZED == response.status_code
-
-    def test_activation_no_jwt_roles(self):
-        """
-        JWT Authenticated requests without the appropriate learner role should result in a 403.
-        """
-        _assign_role_via_jwt_or_db(
-            self.api_client,
-            self.user,
-            self.enterprise_customer_uuid,
-            assign_via_jwt=True,
-            system_role=None,
-        )
-        self._create_license()
-
-        response = self._post_request(self.activation_key)
-
-        assert status.HTTP_403_FORBIDDEN == response.status_code
-
-    @mock.patch('license_manager.apps.api.v1.views.utils.get_decoded_jwt')
-    def test_activation_no_jwt(self, mock_get_decoded_jwt):
-        """
-        Verify that license activation returns a 400 if the user's email could not be found in the JWT.
-        """
-        mock_get_decoded_jwt.return_value = {}
-        response = self._post_request(str(self.activation_key))
-
-        assert status.HTTP_400_BAD_REQUEST == response.status_code
-        assert '`email` is required and could not be found in your jwt' in str(response.content)
-
-    def test_activation_key_is_malformed(self):
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
-            }
-        )
-
-        response = self._post_request('deadbeef')
-
-        assert status.HTTP_400_BAD_REQUEST == response.status_code
-        assert 'deadbeef is not a valid activation key' in str(response.content)
-
-    def test_activation_key_does_not_exist(self):
-        """
-        When the user is authenticated and has the appropriate role,
-        but no corresponding license exists for the given ``activation_key``,
-        we should return a 404.
-        """
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
-            }
-        )
-
-        response = self._post_request(uuid4())
-
-        assert status.HTTP_404_NOT_FOUND == response.status_code
-
-    @ddt.data(
-        {'disable_onboarding_notifications': False},
-        {'disable_onboarding_notifications': True}
-    )
-    @ddt.unpack
-    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
-    def test_activate_an_assigned_license(self, mock_send_post_activation_email_task, disable_onboarding_notifications):
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_uuid': str(self.active_subscription_for_customer.uuid),
-            }
-        )
-        license_to_be_activated = self._create_license()
-
-        if disable_onboarding_notifications:
-            customer_agreement = license_to_be_activated.subscription_plan.customer_agreement
-            customer_agreement.disable_onboarding_notifications = True
-            customer_agreement.save()
-
-        with freeze_time(self.now):
-            response = self._post_request(str(self.activation_key))
-
-        assert status.HTTP_204_NO_CONTENT == response.status_code
-        license_to_be_activated.refresh_from_db()
-        assert constants.ACTIVATED == license_to_be_activated.status
-        assert self.lms_user_id == license_to_be_activated.lms_user_id
-        assert self.now == license_to_be_activated.activation_date
-
-        if disable_onboarding_notifications:
-            mock_send_post_activation_email_task.assert_not_called()
-        else:
-            mock_send_post_activation_email_task.assert_called_with(
-                self.enterprise_customer_uuid,
-                self.user.email,
-            )
-
-    def test_license_already_activated_returns_204(self):
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
-            }
-        )
-        already_activated_license = self._create_license(
-            status=constants.ACTIVATED,
-            activation_date=self.now,
-        )
-
-        response = self._post_request(str(self.activation_key))
-
-        assert status.HTTP_204_NO_CONTENT == response.status_code
-        already_activated_license.refresh_from_db()
-        assert constants.ACTIVATED == already_activated_license.status
-        assert self.lms_user_id == already_activated_license.lms_user_id
-        assert self.now == already_activated_license.activation_date
-
-    def test_activating_revoked_license_returns_422(self):
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_plan_type': self.active_subscription_for_customer.product.plan_type_id,
-            }
-        )
-        revoked_license = self._create_license(
-            status=constants.REVOKED,
-            activation_date=self.now,
-        )
-
-        response = self._post_request(str(self.activation_key))
-
-        assert status.HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
-        revoked_license.refresh_from_db()
-        assert constants.REVOKED == revoked_license.status
-        assert self.lms_user_id == revoked_license.lms_user_id
-        assert self.now == revoked_license.activation_date
-
-    @mock.patch('license_manager.apps.api.v1.views.send_post_activation_email_task.delay')
-    def test_activating_renewed_assigned_license(self, mock_send_post_activation_email_task):
-        yesterday = localized_utcnow() - datetime.timedelta(days=1)
-        # create an expired plan and a current plan
-        subscription_plan_original = SubscriptionPlanFactory.create(
-            customer_agreement=self.customer_agreement,
-            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
-            is_active=True,
-            start_date=localized_utcnow() - datetime.timedelta(days=366),
-            expiration_date=yesterday,
-        )
-        subscription_plan_renewed = SubscriptionPlanFactory.create(
-            customer_agreement=self.customer_agreement,
-            enterprise_catalog_uuid=self.enterprise_catalog_uuid,
-            is_active=True,
-            product=subscription_plan_original.product
-        )
-
-        self._assign_learner_roles(
-            jwt_payload_extra={
-                'user_id': self.lms_user_id,
-                'email': self.user.email,
-                'subscription_plan_type': subscription_plan_original.product.plan_type_id,
-            }
-        )
-
-        prior_assigned_license = self._create_license(
-            subscription_plan=subscription_plan_original,
-            # explicitly set activation_date to assert that this license
-            # is *not* the one that gets activated during the POST request.
-            activation_date=yesterday,
-        )
-        current_assigned_license = self._create_license(subscription_plan=subscription_plan_renewed)
-
-        with freeze_time(self.now):
-            response = self._post_request(str(self.activation_key))
-
-        assert status.HTTP_204_NO_CONTENT == response.status_code
-        current_assigned_license.refresh_from_db()
-        prior_assigned_license.refresh_from_db()
-        assert prior_assigned_license.activation_date != self.now
-        assert current_assigned_license.activation_date == self.now
-        mock_send_post_activation_email_task.assert_called_with(
-            self.enterprise_customer_uuid,
-            self.user.email,
-        )
-
-
-@ddt.ddt
 class UserRetirementViewTests(TestCase):
     """
     Tests for the user retirement view.
@@ -3549,13 +3322,13 @@ class UserRetirementViewTests(TestCase):
                 sorted([self.revoked_license.uuid, self.assigned_license.uuid, self.activated_license.uuid]),
                 self.lms_user_id,
             )
-            assert license_message in log.output[0]
+            assert license_message in ' '.join(log.output)
 
             user_retirement_message = 'Retiring user with id {} and lms_user_id {}'.format(
                 self.user_to_retire.id,
                 self.lms_user_id,
             )
-            assert user_retirement_message in log.output[1]
+            assert user_retirement_message in ' '.join(log.output)
 
         # Verify the revoked license was cleared correctly
         self.revoked_license.refresh_from_db()

--- a/license_manager/apps/subscriptions/exceptions.py
+++ b/license_manager/apps/subscriptions/exceptions.py
@@ -78,3 +78,31 @@ class UnprocessableSubscriptionPlanFreezeError(Exception):
     An exception indicating that a subscription plan cannot be
     frozen to delete unused licenses.
     """
+
+
+class LicenseActivationError(LicenseError):
+    """
+    An exception that occurs during license activation.
+    """
+    action = 'activation'
+
+
+class LicenseToActivateIsRevokedError(LicenseActivationError):
+    """
+    An exception that occurs when the license to activate is revoked.
+    """
+    action = 'activation'
+
+    def __init__(self, license_uuid):
+        """
+        Arguments:
+            license_uuid (uuid4): the unique identifier for a license
+        """
+        super().__init__(license_uuid, 'Cannot activate a revoked license.')
+
+
+class LicenseActivationMissingError(LicenseActivationError):
+    """
+    An exception that occurs when no license with a given activation_key is found.
+    """
+    action = 'activation'

--- a/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
@@ -149,7 +149,7 @@ class RetireOldLicensesCommandTests(TestCase):
                 expired_licenses.count(),
                 sorted([expired_license.uuid for expired_license in expired_licenses]),
             )
-            assert message in log.output[0]
+            assert message in ' '.join(log.output)
 
             # Verify all revoked licenses that were ready for retirement have been retired correctly
             for revoked_license in self.revoked_licenses_ready_for_retirement:
@@ -160,7 +160,7 @@ class RetireOldLicensesCommandTests(TestCase):
                 self.num_revoked_licenses_to_retire,
                 sorted([revoked_license.uuid for revoked_license in self.revoked_licenses_ready_for_retirement]),
             )
-            assert message in log.output[1]
+            assert message in ' '.join(log.output)
 
             # Verify all assigned licenses that were ready for retirement have been retired correctly
             for assigned_license in self.assigned_licenses_ready_for_retirement:
@@ -174,4 +174,4 @@ class RetireOldLicensesCommandTests(TestCase):
                 self.num_assigned_licenses_to_retire,
                 sorted([assigned_license.uuid for assigned_license in self.assigned_licenses_ready_for_retirement]),
             )
-            assert message in log.output[2]
+            assert message in ' '.join(log.output)

--- a/license_manager/settings/test.py
+++ b/license_manager/settings/test.py
@@ -41,3 +41,8 @@ logging.getLogger('event_utils').setLevel(logging.ERROR)
 # Django Admin Settings
 VALIDATE_FORM_EXTERNAL_FIELDS = False
 DEBUG = False
+
+# Disable toolbar callback
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": False,
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ include_trailing_comma=True
 skip=
     settings
     migrations
+
+[flake8]
+max-line-length=120


### PR DESCRIPTION
## Description
During the activation flow, this change will cause us to now reset to UNASSIGNED any duplicate licenses that may exist and activate the most recently assigned license for the learner.

https://2u-internal.atlassian.net/browse/ENT-6761

## Testing considerations
You'll have to sling some raw SQL, since we have `save()`-level validation that prevents a single email from being associated with multiple licenses that are assigned or activated.
1. Find or create an assigned license for some user email, say `foo6@example.com`.  Make sure the plan is active and current.
2. Create a second, `UNASSIGNED` license for that same user in the same plan.  Grab the uuid (in my case, it was `3dd8db1638924a9b80e52ea24174c892`)
3. Generate a uuid with python, this will be the new license's activation_key:
```
from uuid import uuid4
str(uuid4()).replace('-', '')
# '3d8290c28dc04cd98a64ce88628b4a6f'
```
4. Use `make mysql-client-shell` and update the unassigned license to 'assigned' and give it an activation_key e.g. 
```
update subscriptions_license set 
status = 'assigned', activation_key = '3d8290c28dc04cd98a64ce88628b4a6f' 
where uuid = '3dd8db1638924a9b80e52ea24174c892'\G
```
5. Run 
```
select uuid, activation_key, status, assigned_date 
from subscriptions_license where user_email = 'foo6@example.com'\G
``` 
to confirm you have duplicate assigned licenses for this plan and that they each have an activation key.   Or visit http://localhost:18170/admin/subscriptions/license/?q=user_email%3D%22foo6%40example.com%22&q-l=on
7. Use POSTMAN or curl to activate either of the licenses.  This code should cause the most recently assigned license to actually become activated, and set the other one to unassigned.  You'll have to use a JWT for your test user.
http://localhost:18170/api/v1/license-activation?activation_key=7f30e736-c310-407c-b722-68b0a1d361c2 
8. Confirm at http://localhost:18170/admin/subscriptions/license/?q-l=on&q=user_email%3D%22foo6%40example.com%22 (as an admin user, incognito window prolly) that there is now only 1, activated license for this user.  If desired, confirm from the result of your previous query that the previously duplicated license is now set to unassigned and cleared of data.  The most recently assigned license should be activated, the older one should be unassigned:
```
mysql> select * from subscriptions_license where uuid = '3dd8db1638924a9b80e52ea24174c892'\G
*************************** 1. row ***************************
             created: 2023-04-10 14:00:37.724827
            modified: 2023-04-10 14:33:12.968006
                uuid: 3dd8db1638924a9b80e52ea24174c892
              status: activated
     activation_date: 2023-04-10 14:33:12.960746
    last_remind_date: NULL
          user_email: foo6@example.com
         lms_user_id: 157
subscription_plan_id: 31837c0d8cdb4f4694da433e97b2f3ac
      activation_key: 3d8290c28dc04cd98a64ce88628b4a6f
       assigned_date: 2023-04-10 14:00:22.000000
        revoked_date: NULL
       renewed_to_id: NULL
        auto_applied: NULL
1 row in set (0.00 sec)

mysql> select * from subscriptions_license where uuid = 'aea5761ab6a142dfba8dc402b7d17275'\G
*************************** 1. row ***************************
             created: 2021-05-26 20:31:24.453208
            modified: 2023-04-10 14:33:12.943299
                uuid: aea5761ab6a142dfba8dc402b7d17275
              status: unassigned
     activation_date: NULL
    last_remind_date: NULL
          user_email: NULL
         lms_user_id: NULL
subscription_plan_id: 31837c0d8cdb4f4694da433e97b2f3ac
      activation_key: NULL
       assigned_date: NULL
        revoked_date: NULL
       renewed_to_id: NULL
        auto_applied: NULL
1 row in set (0.00 sec)
```

## Post-review

Squash commits into discrete sets of changes
