### PR TITLE
fix: cannot serialize uuid

### DIFF
--- a/license_manager/apps/api_client/enterprise.py
+++ b/license_manager/apps/api_client/enterprise.py
@@ -106,7 +106,7 @@ class EnterpriseApiClient(BaseOAuthClient):
         """
         data = [
             {
-                'enterprise_customer': enterprise_customer_uuid,
+                'enterprise_customer': str(enterprise_customer_uuid),
                 'user_email': user_email,
             }
             for user_email in user_emails

--- a/license_manager/apps/api_client/tests/test_enterprise_client.py
+++ b/license_manager/apps/api_client/tests/test_enterprise_client.py
@@ -46,7 +46,7 @@ class EnterpriseApiClientTests(TestCase):
         mock_oauth_client.return_value.post.assert_called_once_with(
             enterprise_client.pending_enterprise_learner_endpoint,
             json=[
-                {'enterprise_customer': self.uuid, 'user_email': user_email}
+                {'enterprise_customer': str(self.uuid), 'user_email': user_email}
                 for user_email in user_emails
             ],
         )
@@ -75,7 +75,7 @@ class EnterpriseApiClientTests(TestCase):
             mock_oauth_client.return_value.post.assert_called_once_with(
                 enterprise_client.pending_enterprise_learner_endpoint,
                 json=[
-                    {'enterprise_customer': self.uuid, 'user_email': user_email}
+                    {'enterprise_customer': str(self.uuid), 'user_email': user_email}
                     for user_email in user_emails
                 ],
             )


### PR DESCRIPTION
## Description

- "Object of type UUID is not JSON serializable"

```
Traceback (most recent call last):
File "/edx/app/license-manager/venvs/license-manager/bin/celery", line 8, in <module>
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/__main__.py", line 15, in main
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/bin/celery.py", line 235, in main
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/core.py", line 1055, in main
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/core.py", line 760, in invoke
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/bin/base.py", line 134, in caller
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/bin/worker.py", line 356, in worker
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/worker/worker.py", line 202, in start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/bootsteps.py", line 116, in start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/bootsteps.py", line 365, in start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/concurrency/base.py", line 130, in start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/concurrency/prefork.py", line 109, in on_start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 464, in __init__
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/pool.py", line 1045, in __init__
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 482, in _create_worker_process
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/pool.py", line 1157, in _create_worker_process
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/process.py", line 120, in start
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/context.py", line 331, in _Popen
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/popen_fork.py", line 22, in __init__
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/popen_fork.py", line 77, in _launch
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/process.py", line 323, in _bootstrap
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/process.py", line 110, in run
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/pool.py", line 291, in __call__
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/billiard/pool.py", line 361, in workloop
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/trace.py", line 675, in fast_trace_task
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/trace.py", line 477, in trace_task
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/trace.py", line 760, in __protected_call__
File "/edx/app/license_manager/license_manager/apps/api/tasks.py", line 164, in link_learners_to_enterprise_task
File "/edx/app/license_manager/license_manager/apps/api_client/enterprise.py", line 114, in create_pending_enterprise_users
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/requests/sessions.py", line 637, in post
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/edx_rest_api_client/client.py", line 301, in request
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/requests/sessions.py", line 575, in request
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/requests/sessions.py", line 486, in prepare_request
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/requests/models.py", line 371, in prepare
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/requests/models.py", line 511, in prepare_body
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/simplejson/__init__.py", line 378, in dumps
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/simplejson/encoder.py", line 298, in encode
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/simplejson/encoder.py", line 379, in iterencode
File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/simplejson/encoder.py", line 274, in default
```

https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/ODgxNzh8QVBNfEFQUExJQ0FUSU9OfDUyMDI1NDAwNg?begin=1685972361684&end=1686577161684&state=a20a38f3-1da2-907c-5665-980cd768ccfb