### PR TITLE
feat: change several celery tasks to auto-retry up to 3 times

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -149,7 +149,7 @@ def send_assignment_email_task(custom_template_text, email_recipient_list, subsc
             raise exc
 
 
-@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
+@shared_task(base=LoggedTaskWithRetry, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def link_learners_to_enterprise_task(learner_emails, enterprise_customer_uuid):
     """
     Links learners to an enterprise asynchronously.
@@ -382,7 +382,7 @@ def execute_post_revocation_tasks(revoked_license, original_status):
     logger.info('License {} has been revoked'.format(revoked_license.uuid))
 
 
-@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
+@shared_task(base=LoggedTaskWithRetry, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def license_expiration_task(license_uuids, ignore_enrollments_modified_after=None):
     """
     Sends terminating the licensed course enrollments for the submitted license_uuids asynchronously
@@ -468,7 +468,7 @@ def _aliased_recipient_object_from_email(user_email):
     }
 
 
-@shared_task(base=LoggedTask)
+@shared_task(base=LoggedTaskWithRetry)
 def revoke_all_licenses_task(subscription_uuid):
     """
     Revokes all licenses associated with a subscription plan.
@@ -862,7 +862,7 @@ def send_utilization_threshold_reached_email_task(subscription_uuid):
             )
 
 
-@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT, bind=True)
+@shared_task(base=LoggedTaskWithRetry, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT, bind=True)
 def track_license_changes_task(self, license_uuids, event_name, properties=None):
     """
     Calls ``track_license_changes()`` on some chunks of licenses.
@@ -888,7 +888,7 @@ def track_license_changes_task(self, license_uuids, event_name, properties=None)
         ))
 
 
-@shared_task(base=LoggedTask, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
+@shared_task(base=LoggedTaskWithRetry, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT)
 def update_user_email_for_licenses_task(lms_user_id, new_email):
     """
     Updates the user_email field on all licenses associated with the given lms_user_id.


### PR DESCRIPTION
## Description
Helps retry for read timeouts when linking learners to enterprises.
```requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='courses.edx.org', port=443): Read timed out. (read timeout=5)```

I also changed the base task for most other tasks (excluding the bulk enroll task) to retry (as long as the task seemed like one we could safely retry).