### PR TITLE
feat: Updates salesforce opportunity line item form validation

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -181,6 +181,14 @@ class SubscriptionPlanRenewalForm(forms.ModelForm):
         widget=forms.HiddenInput()
     )
 
+    salesforce_opportunity_id = forms.CharField(
+        help_text=(
+            "Locate the appropriate Salesforce Opportunity record and copy the Opportunity ID field "
+            "(18 characters and begin with '00k')."
+            " Note that this is not the same Salesforce Opportunity ID associated with the linked subscription."
+        )
+    )
+
     def is_valid(self):
         # Perform original validation and return if false
         if not super().is_valid():

--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -3,7 +3,6 @@ Forms to be used in the subscriptions django app.
 """
 
 import logging
-import re
 
 from django import forms
 from django.conf import settings
@@ -27,7 +26,10 @@ from license_manager.apps.subscriptions.models import (
     SubscriptionPlan,
     SubscriptionPlanRenewal,
 )
-from license_manager.apps.subscriptions.utils import localized_utcnow
+from license_manager.apps.subscriptions.utils import (
+    localized_utcnow,
+    verify_salesforce_opportunity_product_line_item,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -149,7 +151,7 @@ class SubscriptionPlanForm(forms.ModelForm):
 
         if product.plan_type.sf_id_required and \
                 self.cleaned_data.get('salesforce_opportunity_line_item') is None or \
-                not re.search(r'^00[kK]', self.cleaned_data.get('salesforce_opportunity_line_item')):
+                not verify_salesforce_opportunity_product_line_item(self.cleaned_data.get('salesforce_opportunity_line_item')):
             self._log_validation_error('no SF ID')
             self.add_error(
                 'salesforce_opportunity_line_item',
@@ -224,7 +226,7 @@ class SubscriptionPlanRenewalForm(forms.ModelForm):
             return False
 
         if form_future_salesforce_opportunity_line_item is None or \
-                not re.search(r'^00[kK]', form_future_salesforce_opportunity_line_item):
+                not verify_salesforce_opportunity_product_line_item(form_future_salesforce_opportunity_line_item):
             self.add_error(
                 'salesforce_opportunity_id',
                 'You must specify Salesforce ID for the renewed product. It must start with \'00k\'.',

--- a/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
+++ b/license_manager/apps/subscriptions/management/commands/seed_enterprise_devstack_data.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             expiration_date=timestamp + timedelta(days=365),
             is_active=True,
             for_internal_use_only=True,
-            salesforce_opportunity_line_item=123456789123456789,
+            salesforce_opportunity_line_item='00k456789123456789',
             product=Product.objects.get(name="B2B Paid")
         )
         with transaction.atomic():

--- a/license_manager/apps/subscriptions/tests/factories.py
+++ b/license_manager/apps/subscriptions/tests/factories.py
@@ -29,10 +29,9 @@ FAKER = Faker()
 
 def get_random_salesforce_id():
     """
-    Returns a random alpha-numeric string of the correct length for a salesforce opportunity id.
+    Returns a random alpha-numeric string of the correct length that starts with 00k for a salesforce opportunity line item.
     """
-    return ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
-                   for _ in range(SALESFORCE_ID_LENGTH))
+    return '00k' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=SALESFORCE_ID_LENGTH - 3))
 
 
 class CustomerAgreementFactory(factory.django.DjangoModelFactory):

--- a/license_manager/apps/subscriptions/tests/test_forms.py
+++ b/license_manager/apps/subscriptions/tests/test_forms.py
@@ -182,6 +182,28 @@ class TestSubscriptionPlanRenewalForm(TestCase):
         )
         assert not form.is_valid()
 
+    def test_empty_salesforce_opportunity_line_id(self):
+        prior_subscription_plan = SubscriptionPlanFactory.create()
+        form = make_bound_subscription_plan_renewal_form(
+            prior_subscription_plan=prior_subscription_plan,
+            effective_date=localized_utcnow() + timedelta(1),
+            renewed_expiration_date=prior_subscription_plan.expiration_date + timedelta(366),
+            salesforce_opportunity_id=None
+        )
+        assert form.has_error('salesforce_opportunity_id')
+        assert form.errors['salesforce_opportunity_id'] == ['This field is required.']
+        assert not form.is_valid()
+
+    def test_incorrect_salesforce_opportunity_line_id_format(self):
+        prior_subscription_plan = SubscriptionPlanFactory.create()
+        form = make_bound_subscription_plan_renewal_form(
+            prior_subscription_plan=prior_subscription_plan,
+            effective_date=localized_utcnow() + timedelta(1),
+            renewed_expiration_date=prior_subscription_plan.expiration_date + timedelta(366),
+            salesforce_opportunity_id='00p000000000000000'
+        )
+        assert not form.is_valid()
+
 
 @ddt.ddt
 @mark.django_db

--- a/license_manager/apps/subscriptions/tests/test_forms.py
+++ b/license_manager/apps/subscriptions/tests/test_forms.py
@@ -133,15 +133,26 @@ class TestSubscriptionPlanForm(TestCase):
         invalid_form = make_bound_subscription_form(has_product=False)
         assert invalid_form.is_valid() is False
 
-    def test_salesforce_opportunity_line_item(self):
+    @ddt.data(
+        {'salesforce_id': '00k123456789ABCdef', 'expected_value': True},
+        {'salesforce_id': None, 'expected_value': False},
+        {'salesforce_id': '00p123456789123456', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCdef', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCde', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCdeff', 'expected_value': False},
+        {'salesforce_id': '00K00k456789ABCdef', 'expected_value': False},
+    )
+    @ddt.unpack
+    def test_salesforce_opportunity_line_item(self, salesforce_id, expected_value):
         """
         Verify subscription plan form is invalid if salesforce_opportunity_id is None and the product requires it.
         """
-        invalid_form = make_bound_subscription_form(is_sf_id_required=True, salesforce_opportunity_line_item=None)
-        assert invalid_form.is_valid() is False
+        invalid_form = make_bound_subscription_form(is_sf_id_required=True, salesforce_opportunity_line_item=salesforce_id)
+        assert invalid_form.is_valid() is expected_value
 
 
 @mark.django_db
+@ddt.ddt
 class TestSubscriptionPlanRenewalForm(TestCase):
     """
     Unit tests for the SubscriptionPlanRenewalForm
@@ -194,15 +205,23 @@ class TestSubscriptionPlanRenewalForm(TestCase):
         assert form.errors['salesforce_opportunity_id'] == ['This field is required.']
         assert not form.is_valid()
 
-    def test_incorrect_salesforce_opportunity_line_id_format(self):
+    @ddt.data(
+        {'salesforce_id': '00p123456789123456', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCdef', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCde', 'expected_value': False},
+        {'salesforce_id': '00K123456789ABCdeff', 'expected_value': False},
+        {'salesforce_id': '00K00k456789ABCdef', 'expected_value': False},
+    )
+    @ddt.unpack
+    def test_incorrect_salesforce_opportunity_line_id_format(self, salesforce_id, expected_value):
         prior_subscription_plan = SubscriptionPlanFactory.create()
         form = make_bound_subscription_plan_renewal_form(
             prior_subscription_plan=prior_subscription_plan,
             effective_date=localized_utcnow() + timedelta(1),
             renewed_expiration_date=prior_subscription_plan.expiration_date + timedelta(366),
-            salesforce_opportunity_id='00p000000000000000'
+            salesforce_opportunity_id=salesforce_id
         )
-        assert not form.is_valid()
+        assert form.is_valid() is expected_value
 
 
 @ddt.ddt

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -93,6 +93,7 @@ def make_bound_subscription_plan_renewal_form(
         'salesforce_opportunity_id': salesforce_opportunity_id,
         'license_types_to_copy': license_types_to_copy,
     }
+    print(form_data)
     return SubscriptionPlanRenewalForm(form_data)
 
 

--- a/license_manager/apps/subscriptions/utils.py
+++ b/license_manager/apps/subscriptions/utils.py
@@ -1,6 +1,7 @@
 """ Utility functions for the subscriptions app. """
 import hashlib
 import hmac
+import re
 from base64 import b64encode
 from datetime import datetime
 
@@ -125,3 +126,11 @@ def get_subsidy_checksum(lms_user_id, course_key, license_uuid):
 
     digest = hmac.digest(key, message, digest_function)
     return b64encode(digest).decode()
+
+
+def verify_salesforce_opportunity_product_line_item(salesforce_opportunity_line_item):
+    """
+    Returns boolean value to confirm if the passed salesforce_opportunity_line_item format
+    is correct
+    """
+    return re.search(r'^00k', salesforce_opportunity_line_item)


### PR DESCRIPTION
Adds validation on the `SubscriptionPlanForm` class for `salesforce_opportunity_line_item`
Uses the approach of a form validation as opposed to model validation to account for existing `salesforce_opportunity_line_item` that do not match the following format:
 Regex: `/^00k[a-zA-Z0-9]{15}$/` 
 18 alphanumeric characters where the first three characters must be the sequence '00k'
 Only the lower case 'k' will be accepted
 
 Overrides the `help_text` for the field to inform the user of the new format restrictions.
 Adds additional text during validation error specifying that the `salesforce_opportunity_line_item` must start with '00k'
 Updates the seeded data for devstack with the correct format.
 Updates `get_random_salesforce_id` function to match the format due to its uses of generating random `salesforce_opportunity_line_item` field values for tests

![Screenshot 2023-06-29 at 4 02 42 PM](https://github.com/openedx/license-manager/assets/82611798/e769d145-b09e-43de-af3a-8726ef3b14b8)

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
