### PR TITLE
chore: add build-no-cache command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,10 @@ dev.up: dev.up.redis  # Starts all of the services, will bring up the devstack-d
 dev.up.build:
 	docker-compose up -d --build
 
+dev.up.build-no-cache:
+	docker-compose build --no-cache
+	docker-compose up -d
+
 dev.up.redis:
 	docker-compose -f $(DEVSTACK_WORKSPACE)/devstack/docker-compose.yml up -d redis
 


### PR DESCRIPTION
## Description

Adds `make dev.up.build-no-cache` similar to other Enterprise IDAs to re-build Docker images without cached dependencies.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
