### PR TITLE
build: add pymemcache dependency

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,11 +3,6 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -8,3 +8,4 @@ gevent
 gunicorn
 PyYAML
 python-memcached
+pymemcache

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -289,6 +289,8 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/production.in
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description
- Under the issue https://github.com/edx/edx-arch-experiments/issues/440, adding `pymemcache` to requirements in order to migrate sandbox, stage and prod cache backends from `MemCachedCache` to `PyMemcacheCache`.