### PR TITLE
fix: DB tx isolation and informative license logging

### DIFF
--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -105,11 +105,19 @@ class EmailTaskTests(TestCase):
             'contact_email': self.contact_email,
         }
 
+        # Add an extra recipient with no associated license
+        # to hit debug-logging test coverage
         tasks.send_assignment_email_task(
             self.custom_template_text,
-            self.email_recipient_list,
+            self.email_recipient_list + ['no-license@foo.com'],
             self.subscription_plan.uuid,
         )
+
+        called_emails = [
+            _call.kwargs['recipients'][0]['attributes']['email']
+            for _call in mock_braze_client().send_campaign_message.call_args_list
+        ]
+        self.assertNotIn('no-license@foo.com', called_emails)
 
         for user_email in self.email_recipient_list:
             expected_license_key = str(self.subscription_plan.licenses.get(
@@ -179,11 +187,19 @@ class EmailTaskTests(TestCase):
             'contact_email': self.contact_email,
         }
         with freeze_time(localized_utcnow()):
+            # Add an extra recipient with no associated license
+            # to hit debug-logging test coverage
             tasks.send_reminder_email_task(
                 self.custom_template_text,
-                self.email_recipient_list,
+                self.email_recipient_list + ['no-license@foo.com'],
                 self.subscription_plan.uuid
             )
+
+            called_emails = [
+                _call.kwargs['recipients'][0]['attributes']['email']
+                for _call in mock_braze_client().send_campaign_message.call_args_list
+            ]
+            self.assertNotIn('no-license@foo.com', called_emails)
 
             for user_email in self.email_recipient_list:
                 expected_license_key = str(self.subscription_plan.licenses.get(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -148,7 +148,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/base.in
 edx-auth-backends==4.2.0
     # via -r requirements/base.in
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/base.in
 edx-celeryutils==1.2.3
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -226,7 +226,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/validation.txt
 edx-auth-backends==4.2.0
     # via -r requirements/validation.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/validation.txt
 edx-celeryutils==1.2.3
     # via -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -225,7 +225,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
 edx-auth-backends==4.2.0
     # via -r requirements/test.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/test.txt
 edx-celeryutils==1.2.3
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -181,7 +181,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -193,7 +193,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -202,7 +202,7 @@ edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -264,7 +264,7 @@ edx-auth-backends==4.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-braze-client==0.1.7
+edx-braze-client==0.1.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description
Track license changes in a celery task outside of the DB transaction block that updates the license state, so that task can read the committed updates to the license records.
Also add helpful logging to our license assignment/reminder email tasks. ENT-7795

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-7795

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
