### PR TITLE
chore: update Django to 4.2.7 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -131,7 +131,7 @@ dill==0.3.7
     # via
     #   -r requirements/validation.txt
     #   pylint
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -127,7 +127,7 @@ dill==0.3.7
     # via
     #   -r requirements/test.txt
     #   pylint
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -94,7 +94,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -106,7 +106,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 dill==0.3.7
     # via pylint
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -113,7 +113,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 dill==0.3.7
     # via pylint
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -141,7 +141,7 @@ dill==0.3.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-django==4.2.6
+django==4.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt


### PR DESCRIPTION
### Description
This PR updates Django to version 4.2.7 in the Quince release branch. The update includes the latest security patch, as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)