### PR TITLE
fix: account for license source records during license retirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ license_manager/conf/locale/messages.mo
 
 # emacs
 *~
+.projectile
 
 # QA
 coverage.xml

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1531,6 +1531,7 @@ class UserRetirementView(APIView):
             associated_license.save()
             # Clear historical pii after removing pii from the license itself
             associated_license.clear_historical_pii()
+            associated_license.delete_source()
         associated_licenses_uuids = [license.uuid for license in associated_licenses]
         message = 'Retired {} licenses with uuids: {} for user with lms_user_id {}'.format(
             len(associated_licenses_uuids),

--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -27,8 +27,6 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        ready_for_retirement_date = localized_utcnow() - timedelta(DAYS_TO_RETIRE)
-
         expired_licenses_for_retirement = License.get_licenses_exceeding_purge_duration(
             'subscription_plan__expiration_date',
         )
@@ -50,6 +48,8 @@ class Command(BaseCommand):
 
             # Clear historical pii after removing pii from the license itself
             expired_license.clear_historical_pii()
+            expired_license.delete_source()
+
         expired_license_uuids = sorted([expired_license.uuid for expired_license in expired_licenses_for_retirement])
         message = 'Retired {} expired licenses with uuids: {}'.format(len(expired_license_uuids), expired_license_uuids)
         logger.info(message)
@@ -65,6 +65,8 @@ class Command(BaseCommand):
             revoked_license.save()
             # Clear historical pii after removing pii from the license itself
             revoked_license.clear_historical_pii()
+            revoked_license.delete_source()
+
         revoked_license_uuids = sorted([revoked_license.uuid for revoked_license in revoked_licenses_for_retirement])
         message = 'Retired {} revoked licenses with uuids: {}'.format(len(revoked_license_uuids), revoked_license_uuids)
         logger.info(message)
@@ -82,6 +84,8 @@ class Command(BaseCommand):
             assigned_license.save()
             # Clear historical pii after removing pii from the license itself
             assigned_license.clear_historical_pii()
+            assigned_license.delete_source()
+
         assigned_license_uuids = sorted(
             [assigned_license.uuid for assigned_license in assigned_licenses_for_retirement],
         )

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1081,6 +1081,15 @@ class License(TimeStampedModel):
                     SegmentEvents.LICENSE_REVOKED,
                     event_properties)
 
+    def delete_source(self):
+        """
+        Deletes any related ``SubscriptionLicenseSource`` record.
+        """
+        try:
+            self.source.delete()  # pylint: disable=no-member
+        except SubscriptionLicenseSource.DoesNotExist:
+            logger.warning('Could not find related license source to delete for license %s', self.uuid)
+
     def activate(self, lms_user_id):
         """
         Update this license to activated and set the lms_user_id.


### PR DESCRIPTION
ENT-8172 | Delete related ``SubscriptionLicenseSource`` records when licenses are retired or expired. Without this change, re-assignments of retired licenses (remember that we throw licenses "back into the pool" on revocation, retirement, or expiration) causes an integrity error on the license source table.

### Consequences
1. Licenses that are retired due to edX user retirement (like PII-scrubbing) will lose their source identifiers - we won't have a way to re-associate those to the license or associated enrollments.  But I think this is ok because of what it means to retire a user.
2. Licenses that expire lose their associated source identifier.  I think that's fine, b/c expired licenses are those that haven't been activated in the 90 day activation window, so there's no enrollments associated with them.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-8172

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
