### PR TITLE
feat: Add manufacture_data django command

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/manufacture_data.py
+++ b/license_manager/apps/subscriptions/management/commands/manufacture_data.py
@@ -1,0 +1,19 @@
+"""
+Management command for making instances of models with test factories.
+"""
+
+from edx_django_utils.data_generation.management.commands.manufacture_data import \
+    Command as BaseCommand
+
+from license_manager.apps.subscriptions.tests.factories import *
+
+
+class Command(BaseCommand):
+    """
+    Management command for generating Django records from factories with custom attributes
+
+    Example usage:
+        TODO
+        $ ./manage.py manufacture_data --model license_manager.apps.subscriptions.models.SubscriptionPlan /
+            --title "Test Subscription Plan"
+    """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,9 +29,9 @@ backports-zoneinfo[tzdata]==0.2.1
     #   kombu
 billiard==4.2.0
     # via celery
-boto3==1.34.19
+boto3==1.34.21
     # via django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   boto3
     #   s3transfer
@@ -157,7 +157,7 @@ edx-braze-client==0.1.8
     # via -r requirements/base.in
 edx-celeryutils==1.2.3
     # via -r requirements/base.in
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -191,7 +191,7 @@ jmespath==1.0.1
     #   botocore
 jsonfield==3.1.0
     # via edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via drf-spectacular
 jsonschema-specifications==2023.12.1
     # via jsonschema

--- a/requirements/common_constraints.txt.
+++ b/requirements/common_constraints.txt.
@@ -1,0 +1,28 @@
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,11 +47,11 @@ billiard==4.2.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -235,7 +235,7 @@ edx-braze-client==0.1.8
     # via -r requirements/validation.txt
 edx-celeryutils==1.2.3
     # via -r requirements/validation.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -321,7 +321,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/validation.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/validation.txt
     #   drf-spectacular

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -49,17 +49,17 @@ backports-zoneinfo[tzdata]==0.2.1
     #   celery
     #   django
     #   kombu
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -234,7 +234,7 @@ edx-braze-client==0.1.8
     # via -r requirements/test.txt
 edx-celeryutils==1.2.3
     # via -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -309,7 +309,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/test.txt
     #   drf-spectacular

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,11 +39,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -189,7 +189,7 @@ edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -241,7 +241,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -44,11 +44,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -201,7 +201,7 @@ edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -255,7 +255,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,11 +44,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -210,7 +210,7 @@ edx-braze-client==0.1.8
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -272,7 +272,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -55,12 +55,12 @@ billiard==4.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.34.19
+boto3==1.34.21
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.34.19
+botocore==1.34.21
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -279,7 +279,7 @@ edx-celeryutils==1.2.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.10.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -368,7 +368,7 @@ jsonfield==3.1.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-celeryutils
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description
Adding support for the manufacture_data command from https://github.com/openedx/edx-django-utils/pull/369

[ENT-7510](https://2u-internal.atlassian.net/browse/ENT-7510)

## Testing instructions
1. `make app-shell`
2. `make requirements`
3. `python ./manage.py manufacture_data --model license_manager.apps.subscriptions.models.SubscriptionPlan --title "Test Subscription Plan"`

## Post-review

Squash commits into discrete sets of changes