### PR TITLE
feat: add serializers for bulk license enrollment endpoint

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -402,9 +402,18 @@ class EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer(serializers.Se
     Serializer for the enterprise enrollment with license subsidy query params
     """
 
-    enterprise_customer_uuid = serializers.UUIDField(required=True)
-    enroll_all = serializers.BooleanField(required=False)
-    subscription_uuid = serializers.UUIDField(required=False)
+    enterprise_customer_uuid = serializers.UUIDField(
+        required=True,
+        help_text='The UUID of the associated enterprise customer',
+    )
+    enroll_all = serializers.BooleanField(
+        required=False,
+        help_text='A boolean indicating whether to enroll all learners or not',
+    )
+    subscription_uuid = serializers.UUIDField(
+        required=False,
+        help_text='The UUID of the subscription',
+    )
 
     class Meta:
         fields = [
@@ -425,6 +434,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyRequestSerializer(serializers.Serial
         ),
         allow_empty=False,
         required=True,
+        help_text='an array of learners\' emails',
     )
     course_run_keys = serializers.ListField(
         child=serializers.CharField(
@@ -433,8 +443,12 @@ class EnterpriseEnrollmentWithLicenseSubsidyRequestSerializer(serializers.Serial
         ),
         allow_empty=False,
         required=True,
+        help_text='an array of course run keys',
     )
-    notify = serializers.BooleanField(required=True)
+    notify = serializers.BooleanField(
+        required=True,
+        help_text='a boolean indicating whether to notify learners or not',
+    )
 
     class Meta:
         fields = [

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -395,3 +395,50 @@ class LicenseAdminAssignActionSerializer(CustomTextWithMultipleEmailsSerializer)
                 )
 
         return super().validate(attrs)
+
+
+class EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for the enterprise enrollment with license subsidy query params
+    """
+
+    enterprise_customer_uuid = serializers.UUIDField(required=True)
+    enroll_all = serializers.BooleanField(required=False)
+    subscription_uuid = serializers.UUIDField(required=False)
+
+    class Meta:
+        fields = [
+            'enterprise_customer_uuid',
+            'enroll_all',
+            'subscription_uuid',
+        ]
+
+
+class EnterpriseEnrollmentWithLicenseSubsidyRequestSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for the enterprise enrollment with license subsidy request
+    """
+
+    emails = serializers.ListField(
+        child=serializers.EmailField(
+            allow_blank=False,
+        ),
+        allow_empty=False,
+        required=True,
+    )
+    course_run_keys = serializers.ListField(
+        child=serializers.CharField(
+            allow_blank=False,
+            write_only=True,
+        ),
+        allow_empty=False,
+        required=True,
+    )
+    notify = serializers.BooleanField(required=True)
+
+    class Meta:
+        fields = [
+            'emails',
+            'course_run_keys',
+            'notify',
+        ]

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -11,6 +11,7 @@ from django.db import DatabaseError, transaction
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from edx_rbac.decorators import permission_required
 from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import (
@@ -1261,6 +1262,12 @@ class EnterpriseEnrollmentWithLicenseSubsidyView(LicenseBaseView):
     @permission_required(
         constants.SUBSCRIPTIONS_ADMIN_LEARNER_ACCESS_PERMISSION,
         fn=lambda request: utils.get_context_for_customer_agreement_from_request(request),  # pylint: disable=unnecessary-lambda
+    )
+    @extend_schema(
+        parameters=[
+            serializers.EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer,
+        ],
+        request=serializers.EnterpriseEnrollmentWithLicenseSubsidyRequestSerializer,
     )
     def post(self, request):
         """


### PR DESCRIPTION
## Description

Created serializers for the POST `bulk-license-enrollment` endpoint to enable query params and request body.

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-8179

Please confirm if any field is out of scope or under the wrong validation.
<img width="1460" alt="image" src="https://github.com/openedx/license-manager/assets/46846821/f9b6b2f8-121f-42f5-be48-e7b82856d1c9">


## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
