### PR TITLE
refactor: do batched requests for braze tracking in lic assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ mysql-client-shell: # Will drop you directly into a mysql client shell.
 app-restart-devserver: ## Kill the license-manager development server. Watcher should restart it.
 	docker-compose exec app bash -c 'kill $$(ps aux | egrep "manage.py ?\w* runserver" | egrep -v "while|grep" | awk "{print \$$2}")'
 
+worker-restart-celery: ## Kill the existing celery process and restart them
+	docker-compose exec worker bash -c 'ps aux | egrep "celery" | egrep -v "grep" | awk "{print \$$2}" | xargs kill -HUP'
+
 dev.stats: ## Get per-container CPU and memory utilization data.
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     tty: true
     volumes:
       - .:/edx/app/license_manager/license_manager
+      - ../src:/edx/src:cached
 
 networks:
   devstack_default:

--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -903,7 +903,7 @@ def send_utilization_threshold_reached_email_task(subscription_uuid):
 
 
 @shared_task(base=LoggedTaskWithRetry, soft_time_limit=SOFT_TIME_LIMIT, time_limit=MAX_TIME_LIMIT, bind=True)
-def track_license_changes_task(self, license_uuids, event_name, properties=None):
+def track_license_changes_task(self, license_uuids, event_name, properties=None, is_batch_assignment=False):
     """
     Calls ``track_license_changes()`` on some chunks of licenses.
 
@@ -921,7 +921,7 @@ def track_license_changes_task(self, license_uuids, event_name, properties=None)
     for uuid_str_chunk in chunks(license_uuids, 10):
         license_uuid_chunk = [uuid.UUID(uuid_str) for uuid_str in uuid_str_chunk]
         licenses = License.objects.filter(uuid__in=license_uuid_chunk)
-        track_license_changes(licenses, event_name, properties)
+        track_license_changes(licenses, event_name, properties, is_batch_assignment)
         logger.info('Task {} tracked license changes for license uuids {}'.format(
             self.request.id,
             license_uuid_chunk,

--- a/license_manager/apps/subscriptions/tests/test_event_utils.py
+++ b/license_manager/apps/subscriptions/tests/test_event_utils.py
@@ -13,7 +13,7 @@ from license_manager.apps.subscriptions.constants import (
 )
 from license_manager.apps.subscriptions.event_utils import (
     _iso_8601_format_string,
-    _track_event_via_braze_alias,
+    _track_batch_events_via_braze_alias,
     get_license_tracking_properties,
     track_license_changes,
 )
@@ -113,6 +113,6 @@ def test_track_event_via_braze_alias(mock_braze_client):
         "properties": test_event_properties,
         "_update_existing_only": False,
     }
-    _track_event_via_braze_alias(test_email, test_event_name, test_event_properties)
-    mock_braze_client().create_braze_alias.assert_any_call([test_email], ENTERPRISE_BRAZE_ALIAS_LABEL)
-    mock_braze_client().track_user.assert_any_call(attributes=[expected_attributes], events=[expected_event])
+    _track_batch_events_via_braze_alias(test_event_name, {test_email: test_event_properties})
+    mock_braze_client.return_value.create_braze_alias.assert_any_call([test_email], ENTERPRISE_BRAZE_ALIAS_LABEL)
+    mock_braze_client.return_value.track_user.assert_any_call(attributes=[expected_attributes], events=[expected_event])


### PR DESCRIPTION
## Description

Currently, each call to track license lifecycle state (e.g. during license assignment) seems to make 2 calls to braze **per license**:
1. Call to `create_braze_alias`.
2. Call to `track_user`.

This is an attempt to utilize the braze API more efficiently. If we don’t, we’re going to end up making around 1 million calls to braze during the execution of a script that assigns 400,000 emails. The risk here is that we get rate-limited, or just see "normal" failed requests to braze, and many users/licenses end up in a partially tracked state that leads to difficulties/support-overhead during license activation.

Another subtle change here: as part of assignment, we conditionally want to send assignment notification emails. These require that we have braze aliases setup.  I've re-ordered the chain of tasks we kick off to only explicitly create braze aliases in a task IF we're going to send those notifications.
Note that the task to track license changes also creates braze aliases during assignment (so we can track users who don't have an lms_user_id yet).  It's fine to do the alias tracking call multiple times (its idempotent on the Braze side), especially now that we're doing all alias creation as batched work.  But with this second change, we now will only create aliases at one point (during lifecycle tracking) when assignment notification is disabled.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-8304

## Testing considerations

- Ran a manual test in the braze dev account, results captured in ticket.

## Post-review

Squash commits into discrete sets of changes
