### PR TITLE
fix: desired number of sub plan licenses.

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -193,6 +193,7 @@ class SubscriptionPlanAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         'customer_agreement',
         'last_freeze_timestamp',
         'salesforce_opportunity_id',
+        'desired_num_licenses'
     ]
     writable_fields = [
         'title',
@@ -338,8 +339,10 @@ class SubscriptionPlanAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         customer_agreement_catalog = obj.customer_agreement.default_enterprise_catalog_uuid
         obj.enterprise_catalog_uuid = (obj.enterprise_catalog_uuid or customer_agreement_catalog)
 
-        # Set desired_num_licenses which will lead to the eventual creation of those licenses.
-        obj.desired_num_licenses = form.cleaned_data.get('num_licenses', 0)
+        # If we're creating the model instance, determine the desired number of licenses
+        # from the form and store that in the model. This will lead to the eventual creation of those licenses.
+        if not change:
+            obj.desired_num_licenses = form.cleaned_data.get('num_licenses', 0)
 
         super().save_model(request, obj, form, change)
 

--- a/license_manager/apps/subscriptions/tasks.py
+++ b/license_manager/apps/subscriptions/tasks.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 TASK_RETRY_SECONDS = 60
 PROVISION_LICENSES_BATCH_SIZE = 300
 
+PROVISION_LICENSES_TIME_LIMIT_SECONDS = 60 * 30
+
 
 class RequiredTaskUnreadyError(Exception):
     """
@@ -75,7 +77,13 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     retry_jitter = True
 
 
-@shared_task(base=LoggedTaskWithRetry, bind=True, default_retry_delay=TASK_RETRY_SECONDS)
+@shared_task(
+    base=LoggedTaskWithRetry,
+    bind=True,
+    default_retry_delay=TASK_RETRY_SECONDS,
+    soft_time_limit=PROVISION_LICENSES_TIME_LIMIT_SECONDS,
+    time_limit=PROVISION_LICENSES_TIME_LIMIT_SECONDS,
+)
 @subscription_plan_semaphore()
 def provision_licenses_task(self, subscription_plan_uuid=None):  # pylint: disable=unused-argument
     """


### PR DESCRIPTION
* Sets a longer timelimit on `provision_licenses_task()`
* Fixes bug where saving an existing plan overwrites desired number of license back to 0.

Fixing this bug allows us to "top up" the licenses in a plan to the desired number by simply saving the plan again.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
