### PR TITLE
feat: allow up to 2M licenses for a subscription plan.

### DIFF
--- a/license_manager/apps/subscriptions/tasks.py
+++ b/license_manager/apps/subscriptions/tasks.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 TASK_RETRY_SECONDS = 60
 PROVISION_LICENSES_BATCH_SIZE = 300
 
-PROVISION_LICENSES_TIME_LIMIT_SECONDS = 60 * 30
+# 200 minutes will get you about 2 million licenses, give or take.
+PROVISION_LICENSES_TIME_LIMIT_SECONDS = 60 * 200
 
 
 class RequiredTaskUnreadyError(Exception):


### PR DESCRIPTION
During stage testing, I provisioned 345k licenses before hitting the 30 minute timeout.  200 minutes should be enough for about 2M licenses.

ENT-8269