### PR TITLE
fix: edx-braze-client 0.2.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -153,7 +153,7 @@ drf-spectacular==0.27.0
     # via -r requirements/base.in
 edx-auth-backends==4.2.0
     # via -r requirements/base.in
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/base.in
 edx-celeryutils==1.2.3
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -231,7 +231,7 @@ drf-spectacular==0.27.0
     # via -r requirements/validation.txt
 edx-auth-backends==4.2.0
     # via -r requirements/validation.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/validation.txt
 edx-celeryutils==1.2.3
     # via -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -230,7 +230,7 @@ drf-spectacular==0.27.0
     # via -r requirements/test.txt
 edx-auth-backends==4.2.0
     # via -r requirements/test.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/test.txt
 edx-celeryutils==1.2.3
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -185,7 +185,7 @@ drf-spectacular==0.27.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -197,7 +197,7 @@ drf-spectacular==0.27.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -206,7 +206,7 @@ drf-spectacular==0.27.0
     # via -r requirements/base.txt
 edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via -r requirements/base.txt
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -271,7 +271,7 @@ edx-auth-backends==4.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-braze-client==0.2.1
+edx-braze-client==0.2.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
https://github.com/edx/braze-client/pull/23
Be defensive about presence of an `email` field when reading response from the export-users endpoint.
