### PR TITLE
perf: save one query per sub plan to serialize plans and agreements

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.fields import SerializerMethodField
 from license_manager.apps.subscriptions.constants import (
     ACTIVATED,
     ASSIGNED,
+    REVOKED,
     SALESFORCE_ID_LENGTH,
 )
 from license_manager.apps.subscriptions.models import (
@@ -73,7 +74,13 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
         more details.
         """
         count_by_status = obj.license_count_by_status()
-        count_by_status['total'] = obj.num_licenses
+
+        total_count = 0
+        for status, count_for_status in count_by_status.items():
+            if status != REVOKED:
+                total_count += count_for_status
+
+        count_by_status['total'] = total_count
         count_by_status['allocated'] = count_by_status[ASSIGNED] + count_by_status[ACTIVATED]
         return count_by_status
 


### PR DESCRIPTION
## Description

Calling `SubscriptionPlan.num_licenses` causes us to do a DB query of the form
```
SELECT COUNT(*) AS `__count` FROM `subscriptions_license` WHERE (`subscriptions_license`.`subscription_plan_id` = %s AND NOT (`subscriptions_license`.`status` = %s))
```
In the context of serializing subscription plans and their parent/customer agreements, we do a query to get a count of all licenses by status per related subscription plan, as well as a query to compute `num_licenses` as above.  However, the latter can be computed in memory from the former very easily, without going to the DB a second time.  This change skips the call to `num_licenses` and instead does arithmetic based on the `count_by_status` we already have to compute.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
