### PR TITLE
Aed/remove license count check

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -286,6 +286,9 @@ class SubscriptionPlanAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         'start_date',
         'expiration_date',
     )
+
+    autocomplete_fields = ['customer_agreement']
+
     actions = ['process_unused_licenses_post_freeze']
 
     def get_queryset(self, request):

--- a/license_manager/apps/subscriptions/constants.py
+++ b/license_manager/apps/subscriptions/constants.py
@@ -96,7 +96,7 @@ DAYS_TO_RETIRE = 90
 
 # Subscription validation constants
 MIN_NUM_LICENSES = 0
-MAX_NUM_LICENSES = 11000
+MAX_NUM_LICENSES = 1000000 # Set a reasonably high max to prevent us from crashing.
 
 # Number of license uuids enrollments are expired for in each batch
 LICENSE_EXPIRATION_BATCH_SIZE = 100


### PR DESCRIPTION
## Description

Set a much higher maximum number of allowed licenses per plan, since we did all this nice scaling/async work.
Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-8396

Without this change, non-test plans were still limited to only 11,000 licenses during plan creation.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
