### PR TITLE
build: ignore two spaces before inline comment flake8 error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [pycodestyle]
-ignore=E501,W503
+# E501: Line too long (80 chars)
+# W503: Line break occurred before a binary operator
+# E261: At least two spaces before inline comment
+ignore=E501,W503,E261
 max-line-length = 120
 exclude=.git,settings,migrations,license_manager/static,bower_components,license_manager/wsgi.py
 


### PR DESCRIPTION
## Description

I can't think of a less meaningful thing than two spaces before a comment.