### PR TITLE
fix: retry celery tasks on HTTPError

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.utils import OperationalError
 from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError
 from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 from requests.exceptions import Timeout as RequestsTimeoutError
 
@@ -70,6 +71,7 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
         IntegrityError,
         OperationalError,
         BrazeClientError,
+        HTTPError,
     )
     retry_kwargs = {'max_retries': 3}
     # Use exponential backoff for retrying tasks


### PR DESCRIPTION
This will help retry tasks that fail due to intermittent auth errors, e.g. 401s due to expired JWTs that would be re-fetched on a second attempt.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
