### PR TITLE
feat: updates license serializer to include the customer agreement from subscription plans

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -148,6 +148,7 @@ class LicenseSerializer(serializers.ModelSerializer):
     """
 
     subscription_plan_uuid = serializers.UUIDField(source='subscription_plan_id')
+    customer_agreement = serializers.SerializerMethodField()
 
     class Meta:
         model = License
@@ -160,7 +161,12 @@ class LicenseSerializer(serializers.ModelSerializer):
             'subscription_plan_uuid',
             'revoked_date',
             'activation_key',
+            'customer_agreement'
         ]
+
+    def get_customer_agreement(self, obj):
+        customer_agreement = obj.subscription_plan.customer_agreement
+        return CustomerAgreementSerializer(customer_agreement).data
 
 
 class StaffLicenseSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -148,7 +148,7 @@ class LicenseSerializer(serializers.ModelSerializer):
     """
 
     subscription_plan_uuid = serializers.UUIDField(source='subscription_plan_id')
-    customer_agreement = serializers.SerializerMethodField()
+    customer_agreement = CustomerAgreementSerializer(source='subscription_plan.customer_agreement')
 
     class Meta:
         model = License
@@ -163,10 +163,6 @@ class LicenseSerializer(serializers.ModelSerializer):
             'activation_key',
             'customer_agreement'
         ]
-
-    def get_customer_agreement(self, obj):
-        customer_agreement = obj.subscription_plan.customer_agreement
-        return CustomerAgreementSerializer(customer_agreement).data
 
 
 class StaffLicenseSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -26,6 +26,7 @@ from edx_rest_framework_extensions.auth.jwt.tests.utils import (
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from license_manager.apps.api.serializers import CustomerAgreementSerializer
 from license_manager.apps.api.tests.factories import BulkEnrollmentJobFactory
 from license_manager.apps.api.utils import (
     acquire_subscription_plan_lock,
@@ -335,6 +336,7 @@ def _assert_license_response_correct(response, subscription_license):
         'revoked_date',
         'activation_key',
         'activation_date',
+        'customer_agreement'
     }
     assert set(response.keys()) == expected_fields
     assert response['uuid'] == str(subscription_license.uuid)
@@ -344,6 +346,9 @@ def _assert_license_response_correct(response, subscription_license):
     assert response['activation_key'] == str(subscription_license.activation_key)
     assert response['activation_date'] == _iso_8601_format(subscription_license.activation_date)
     assert response['last_remind_date'] == _iso_8601_format(subscription_license.last_remind_date)
+    assert response['customer_agreement'] == CustomerAgreementSerializer(
+        subscription_license.subscription_plan.customer_agreement
+    ).data
 
 
 @pytest.mark.django_db

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -401,6 +401,7 @@ class LearnerLicensesViewSet(
             }
           ]
         }
+        customer_agreement: <CustomerAgreementSerializer>
         user_email: "edx@example.com"
         uuid: "4e03efb7-b4ea-4a52-9cfc-11519920a40a"
       ]


### PR DESCRIPTION
Updates the `LicenseSerializer` to include the `customer_agreement` from the `subscription_plan` object as `customer_agreement`.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
