### PR TITLE
fix: serialize only minimal info about a license's customer agreement

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -101,6 +101,24 @@ class SubscriptionPlanSerializer(serializers.ModelSerializer):
         }
 
 
+class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
+    """
+    Minimal serializer for the `CustomerAgreement` model that does not
+    include information about related subscription plan records.
+    """
+
+    class Meta:
+        model = CustomerAgreement
+        fields = [
+            'uuid',
+            'enterprise_customer_uuid',
+            'enterprise_customer_slug',
+            'default_enterprise_catalog_uuid',
+            'disable_expiration_notifications',
+            'net_days_until_expiration',
+        ]
+
+
 class CustomerAgreementSerializer(serializers.ModelSerializer):
     """
     Serializer for the `CustomerAgreement` model.
@@ -148,7 +166,7 @@ class LicenseSerializer(serializers.ModelSerializer):
     """
 
     subscription_plan_uuid = serializers.UUIDField(source='subscription_plan_id')
-    customer_agreement = CustomerAgreementSerializer(source='subscription_plan.customer_agreement')
+    customer_agreement = MinimalCustomerAgreementSerializer(source='subscription_plan.customer_agreement')
 
     class Meta:
         model = License

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -26,7 +26,9 @@ from edx_rest_framework_extensions.auth.jwt.tests.utils import (
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from license_manager.apps.api.serializers import CustomerAgreementSerializer
+from license_manager.apps.api.serializers import (
+    MinimalCustomerAgreementSerializer,
+)
 from license_manager.apps.api.tests.factories import BulkEnrollmentJobFactory
 from license_manager.apps.api.utils import (
     acquire_subscription_plan_lock,
@@ -346,7 +348,7 @@ def _assert_license_response_correct(response, subscription_license):
     assert response['activation_key'] == str(subscription_license.activation_key)
     assert response['activation_date'] == _iso_8601_format(subscription_license.activation_date)
     assert response['last_remind_date'] == _iso_8601_format(subscription_license.last_remind_date)
-    assert response['customer_agreement'] == CustomerAgreementSerializer(
+    assert response['customer_agreement'] == MinimalCustomerAgreementSerializer(
         subscription_license.subscription_plan.customer_agreement
     ).data
 


### PR DESCRIPTION
## Description

Avoids nested serialization of subscription plans, which can cause a large performance hit.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
