### PR TITLE
perf: instance cache and select-related for license serialization

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -106,6 +106,7 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
     Minimal serializer for the `CustomerAgreement` model that does not
     include information about related subscription plan records.
     """
+    net_days_until_expiration = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomerAgreement
@@ -117,6 +118,19 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
             'disable_expiration_notifications',
             'net_days_until_expiration',
         ]
+
+    def get_net_days_until_expiration(self, obj):
+        """
+        Cache the net_days_until_expiration of the agreement
+        to serializer for the lifetime of this serializer instance.
+        """
+        # pylint: disable=attribute-defined-outside-init,access-member-before-definition
+        if hasattr(self, '_cached_net_days_until_expiration'):
+            return self._cached_net_days_until_expiration
+
+        value = obj.net_days_until_expiration
+        self._cached_net_days_until_expiration = value
+        return value
 
 
 class CustomerAgreementSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -141,7 +141,7 @@ class CustomerAgreement(TimeStampedModel):
 
     history = HistoricalRecords()
 
-    @property
+    @cached_property
     def net_days_until_expiration(self):
         """
         Returns the max number of days until expiration


### PR DESCRIPTION
## Description

For large numbers of licenses (> 1000), this change gets us from 100s of SQL queries down to around 10 for each page of admin-license-list results.

1. Select/prefetch related plans, customer agreements, and renewals in the base queryset of the viewset.
2. add `@cached_property` to net_days_until_expiration on the agreement model.
3. ...but, (2) alone is not enough, because the license serializer is going to instantiate a new instance of a CustomerAgreement per license (but because of (1), it doesn't go to the DB to hydrate it).  So we need to roll our own instance cache of `MinimalCustomerAgreementSerializer.net_days_until_expiration`.
4. For good measure, throw an instance cache onto the viewset's `_get_subscription_plan()` - this eliminated 4 duplicate queries.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
