### PR TITLE
feat: learner-licenses view does nested serialization of related cust…

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2696,6 +2696,13 @@ class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
             # Ensure UUIDs are in expected order
             assert str(expected.uuid) == actual['uuid']
 
+            # Assert that nested subscription plan and customer agreement are
+            # serialized in the response for each license.
+            plan = expected.subscription_plan
+            agreement = plan.customer_agreement
+            assert actual['customer_agreement']['uuid'] == str(agreement.uuid)
+            assert actual['subscription_plan']['uuid'] == str(plan.uuid)
+
     def test_endpoint_respects_active_only_query_parameter(self):
         self._assign_learner_roles()
 

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -148,7 +148,7 @@ class CustomerAgreement(TimeStampedModel):
         of _any_ plan in this agreement.
         """
         net_days = 0
-        for plan in self.subscriptions.all():
+        for plan in self.subscriptions.all().prefetch_related('renewal'):
             net_days = max(net_days, plan.days_until_expiration_including_renewals)
         return net_days
 

--- a/license_manager/settings/local.py
+++ b/license_manager/settings/local.py
@@ -63,7 +63,21 @@ ENABLE_AUTO_AUTH = True
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True)
 
+LOG_SQL = False
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
+
+    # LOG_SQL may be set to True in private.py, which will
+    # enable logging of SQL statements via the django.db.backends module.
+    if LOG_SQL:
+        LOGGING['loggers']['django.db.backends'] = {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+            # We have a root 'django' logger enabled
+            # that we don't want to propagage too, so that
+            # this doesn't print multiple times.
+            'propagate': False,
+        }


### PR DESCRIPTION
… agreement. The learner-licenses viewset now returns records like this:
```
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "uuid": "4a3833a3-20a2-4c4d-8d56-a09a2caf58d4",
            "status": "activated",
            "user_email": "edx@example.com",
            "activation_date": "2021-07-01T00:00:00Z",
            "last_remind_date": null,
            "subscription_plan_uuid": "13e4e40f-fc0c-4761-9ebc-cf3ad7bbd45a",
            "revoked_date": null,
            "activation_key": null,
            "customer_agreement": {
                "uuid": "ea968344-3e21-48a8-aa54-dcb1733b80dc",
                "enterprise_customer_uuid": "378d5bf0-f67d-4bf7-8b2a-cbbc53d0f772",
                "enterprise_customer_slug": "pied-piper",
                "default_enterprise_catalog_uuid": null,
                "disable_expiration_notifications": false,
                "net_days_until_expiration": 0
            },
            "subscription_plan": {
                "title": "The Future Plan A",
                "uuid": "13e4e40f-fc0c-4761-9ebc-cf3ad7bbd45a",
                "start_date": "2021-07-01T00:00:00Z",
                "expiration_date": "2022-07-01T00:00:00Z",
                "enterprise_customer_uuid": "378d5bf0-f67d-4bf7-8b2a-cbbc53d0f772",
                "enterprise_catalog_uuid": "7467c9d2-433c-4f7e-ba2e-c5c7798527b2",
                "is_active": true,
                "is_revocation_cap_enabled": false,
                "days_until_expiration": -602,
                "days_until_expiration_including_renewals": -602,
                "is_locked_for_renewal_processing": false,
                "should_auto_apply_licenses": null
            }
        }
    ]
}
```

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
