### PR TITLE
feat: adds customer agreement to the paginator response

### DIFF
--- a/license_manager/apps/api/pagination.py
+++ b/license_manager/apps/api/pagination.py
@@ -82,19 +82,22 @@ class EstimatedCountLicensePagination(LicensePagination):
 
 class LearnerLicensesPaginationCustomerAgreement(DefaultPagination):
     """
-    TODO:
+    Adds the customer agreement object to the learner-licenses endpoint.
+    The learner licenses endpoint currently contains the subscription_licenses, with its
+    corresponding subscription_plan. In order to reduce the number of calls to the client,
+    we incorporate the customer_agreement accessible within a single call.
     """
 
     def get_paginated_response(self, data):
         """
-        Modifies the default paginated response to include ``customer_agreement`` dict.
+        Modifies the DefaultPagination response to include ``customer_agreement`` dict.
 
         Arguments:
-            self: PaginationWithFeatureFlags instance.
+            self: LearnerLicensesPaginationCustomerAgreement instance.
             data (dict): Results for current page.
 
         Returns:
-            (Response): DRF response object containing ``enterprise_features`` dict.
+            (Response): DRF response object containing ``customer_agreement`` dict.
         """
         paginated_response = super().get_paginated_response(data)
         enterprise_customer_uuid = self.request.query_params.get('enterprise_customer_uuid')

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -118,6 +118,8 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
     include a nested representation of related subscription plans.
     """
 
+    subscription_for_auto_applied_licenses = serializers.SerializerMethodField()
+
     class Meta:
         model = CustomerAgreement
         fields = [
@@ -127,7 +129,12 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
             'default_enterprise_catalog_uuid',
             'disable_expiration_notifications',
             'net_days_until_expiration',
+            'subscription_for_auto_applied_licenses',
         ]
+
+    def get_subscription_for_auto_applied_licenses(self, obj):
+        subscription_plan = obj.auto_applicable_subscription
+        return subscription_plan.uuid if subscription_plan else None
 
 
 class CustomerAgreementSerializer(MinimalCustomerAgreementSerializer):
@@ -135,13 +142,11 @@ class CustomerAgreementSerializer(MinimalCustomerAgreementSerializer):
     Expanded serializer for the `CustomerAgreement` model.
     """
     subscriptions = SerializerMethodField()
-    subscription_for_auto_applied_licenses = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomerAgreement
         fields = MinimalCustomerAgreementSerializer.Meta.fields + [
             'subscriptions',
-            'subscription_for_auto_applied_licenses'
         ]
 
     @property
@@ -159,10 +164,6 @@ class CustomerAgreementSerializer(MinimalCustomerAgreementSerializer):
 
         serializer = SubscriptionPlanSerializer(plans, many=True)
         return serializer.data
-
-    def get_subscription_for_auto_applied_licenses(self, obj):
-        subscription_plan = obj.auto_applicable_subscription
-        return subscription_plan.uuid if subscription_plan else None
 
 
 class LicenseSerializer(serializers.ModelSerializer):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2627,6 +2627,22 @@ class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert 'missing enterprise_customer_uuid query param' in str(response.content)
 
+    def test_endpoint_results_contains_customer_agreement(self):
+        """
+        Tests if the learner-licenses endpoint contains the customer agreement object
+        on the paginator.
+
+        Checks if the serialized customer agreement from the response matches the mocked
+        customer agreement.
+        """
+        self._assign_learner_roles()
+
+        response = self._get_url_with_customer_uuid(self.enterprise_customer_uuid)
+
+        assert response.status_code == status.HTTP_200_OK
+        customer_agreement_response = response.json().get('customer_agreement')
+        assert customer_agreement_response['uuid'] == str(self.customer_agreement.uuid)
+
     def test_endpoint_results_correctly_ordered(self):
         """
         Test the ordering of responses from the endpoint matches the following:

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -67,7 +67,11 @@ from license_manager.apps.subscriptions.utils import (
     localized_utcnow,
 )
 
-from ..pagination import EstimatedCountLicensePagination, LicensePagination
+from ..pagination import (
+    EstimatedCountLicensePagination,
+    LearnerLicensesPaginationCustomerAgreement,
+    LicensePagination,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -426,6 +430,8 @@ class LearnerLicensesViewSet(
     list_lookup_field = 'subscription_plan__customer_agreement__enterprise_customer_uuid'
     allowed_roles = [constants.SUBSCRIPTIONS_ADMIN_ROLE, constants.SUBSCRIPTIONS_LEARNER_ROLE]
     role_assignment_class = SubscriptionsRoleAssignment
+    pagination_class = LearnerLicensesPaginationCustomerAgreement
+
 
     @property
     def enterprise_customer_uuid(self):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -432,7 +432,6 @@ class LearnerLicensesViewSet(
     role_assignment_class = SubscriptionsRoleAssignment
     pagination_class = LearnerLicensesPaginationCustomerAgreement
 
-
     @property
     def enterprise_customer_uuid(self):
         return self.request.query_params.get('enterprise_customer_uuid')


### PR DESCRIPTION
Creates a new paginator class for the `LearnerLicensesViewSet` that contains the `customer_agreement` object.
If the `enterprise_customer_uuid` does not match an existing customer, the `customer_agreement` will return and empty object for the `customer_agreement` field.

Moves the `subscription_for_auto_applied_licenses` from the `CustomerAgreementSerializer` to the `MinimalCustomerAgreementSerializer`.

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
