### PR TITLE
fix: attempt to fix bulk enrollment results link generation

### DIFF
--- a/license_manager/apps/api/models.py
+++ b/license_manager/apps/api/models.py
@@ -4,6 +4,7 @@ should be created here. As the API evolves, models may become more
 specific to a particular version of the API. In this case, the models
 in question should be moved to versioned sub-package.
 """
+import datetime
 import logging
 from uuid import uuid4
 
@@ -112,7 +113,7 @@ class BulkEnrollmentJob(TimeStampedModel):
         if hasattr(settings, "BULK_ENROLL_JOB_AWS_BUCKET") and settings.BULK_ENROLL_JOB_AWS_BUCKET:
             self.results_s3_object_name = (
                 f'{self.enterprise_customer_uuid}/{self.uuid}/Bulk-Enrollment-Results-'
-                '{datetime.datetime.utcnow().isoformat()}.csv'
+                f'{datetime.datetime.utcnow().isoformat()}.csv'
             )
             results_object_uri = upload_file_to_s3(
                 file_name,

--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -290,7 +290,9 @@ def create_presigned_url(bucket_name, object_name, expiration=300):
         Params={
             'Bucket': bucket_name,
             'Key': object_name,
-            "ResponseContentDisposition": f'attachment; filename={_get_short_file_name(object_name)}',
+            # RFC-2616 requires that the filename point to a "quoted-string" symbol, hence the double quotes surrounding
+            # the filename below.  https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html
+            "ResponseContentDisposition": f'attachment; filename="{_get_short_file_name(object_name)}"',
         },
         ExpiresIn=expiration
     )


### PR DESCRIPTION
Context
=======

The results log of a bulk enrollment job are stored in S3 (in addition to being sent to celery), and we provide an API endpoint to generate a signed download link which S3 uses to authorize temporary access to the results object. This not only allows us to build automation to consume job results, but currently is the ONLY way for engineers to view job results for celery tasks that age out of Flower.

Problem
=======

Currently, it is not possible to view bulk-license-enrollment results uploaded to S3. Attempts to generate a download link via the following GET endpoint result in a broken URL which contains a signature that does not match the request.

`GET /api/v1/bulk-license-enrollment/?enterprise_customer_uuid=<customer-uuid>&bulk_enrollment_job_uuid=<job-uuid>`

Returns:
```
{
    "job_id": "<job-uuid>",
    "download_url": "<Broken download URL which returns SignatureDoesNotMatch>"
}
```

Theory
======

This PR attempts to fix the broken signature in two ways:

1. Fix a regression in generation of the filename by adding a missing f-string prefix. This alone may fix the broken signature because the presence of certain special characters (such as curly braces) may cause a mismatch between the signed payload in the request vs. what S3 expects.

2. Add double quotes to a component of the response-content-disposition HTTP header.  This alone may also fix the broken signature by forcing certain special characters to be treated as such.  It is also more compliant with RFC-2616.

I don't know for sure if either will fix the issue, but they both seem net-better.