### PR TITLE
feat: use LearnerLicenseSerializer for auto-apply API

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1411,8 +1411,19 @@ class CustomerAgreementViewSetTests(LicenseViewSetActionMixin, TestCase):
         self._setup_request_jwt(user=self.super_user)
         response = self.api_client.post(self.auto_apply_url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()['user_email'] == self.super_user.email
-        assert response.json()['status'] == 'activated'
+
+        response_json = response.json()
+        response_subscription_plan = response_json['subscription_plan']
+        response_customer_agreement = response_json['customer_agreement']
+        assert response_json['user_email'] == self.super_user.email
+        assert response_json['status'] == 'activated'
+        assert response_json['subscription_plan']['uuid'] == str(plan.uuid)
+        assert response_subscription_plan['title'] == plan.title
+        assert response_subscription_plan['enterprise_catalog_uuid'] == str(plan.enterprise_catalog_uuid)
+        assert response_subscription_plan['is_active'] == plan.is_active
+        assert response_customer_agreement['uuid'] == str(self.customer_agreement.uuid)
+        expected_customer_agreement_customer_uuid = str(self.customer_agreement.enterprise_customer_uuid)
+        assert response_customer_agreement['enterprise_customer_uuid'] == expected_customer_agreement_customer_uuid
 
         # Check if 1 License has become auto_applied
         assert plan.licenses.filter(auto_applied=True).count() == 1

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -156,7 +156,10 @@ class CustomerAgreementViewSet(
         """
         now = localized_utcnow()
 
-        auto_applied_license = subscription_plan.unassigned_licenses.first()
+        auto_applied_license = subscription_plan.unassigned_licenses.select_related(
+            'subscription_plan',
+            'subscription_plan__customer_agreement',
+        ).first()
         if not auto_applied_license:
             return None
 

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -219,7 +219,7 @@ class CustomerAgreementViewSet(
             )
 
         # Serialize the License we created to be returned in response
-        serializer = serializers.LicenseSerializer(license_obj)
+        serializer = serializers.LearnerLicenseSerializer(license_obj)
         response_data = serializer.data
         return Response(data=response_data, status=status.HTTP_200_OK)
 
@@ -248,7 +248,7 @@ class CustomerAgreementViewSet(
             logger.info(info_message)
 
             license_obj = active_or_assigned_licenses[0]
-            serializer = serializers.LicenseSerializer(license_obj)
+            serializer = serializers.LearnerLicenseSerializer(license_obj)
             response_data = serializer.data
             return Response(data=response_data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/ENT-8563

Makes use of the `LearnerLicenseSerializer` on the `auto-apply` API endpoint for consistent data representations between the list of licenses returned by `learner-licenses` and when a license is auto-applied (e.g., for integrated customers).

The primary difference is that the associated `subscription_plan` is now returned alongside the license.

```js
{
    "uuid": "00dd289d-694e-49ec-9c63-160938ce6090",
    "status": "activated",
    "userEmail": "astankiewicz@edx.org",
    "activationDate": "2023-10-18T17:40:08.461063Z",
    "lastRemindDate": "2023-10-18T17:40:08.461063Z",
    "subscriptionPlanUuid": "0aa4a80b-5772-4734-b73f-4d26de3326e5",
    "revokedDate": null,
    "activationKey": "503f6607-c2eb-4333-940f-96707669106a",
    "customerAgreement": {
        "uuid": "d5733156-5f3d-439d-bcd5-89cfc3ad2bde",
        "enterpriseCustomerUuid": "02982884-1f1f-4103-b6d7-3a602c1afcbd",
        "enterpriseCustomerSlug": "adam-autoapplied-enterprise",
        "defaultEnterpriseCatalogUuid": null,
        "disableExpirationNotifications": false,
        "netDaysUntilExpiration": 228,
        "subscriptionForAutoAppliedLicenses": "0aa4a80b-5772-4734-b73f-4d26de3326e5"
    },
    "subscriptionPlan": {
        "title": "Test Auto-Applied Subscription",
        "uuid": "0aa4a80b-5772-4734-b73f-4d26de3326e5",
        "startDate": "2023-10-18T16:30:57Z",
        "expirationDate": "2024-10-18T16:30:58Z",
        "enterpriseCustomerUuid": "02982884-1f1f-4103-b6d7-3a602c1afcbd",
        "enterpriseCatalogUuid": "0005bb70-a1c6-4d8e-a801-9a9fa287a13b",
        "isActive": true,
        "isRevocationCapEnabled": false,
        "daysUntilExpiration": 228,
        "daysUntilExpirationIncludingRenewals": 228,
        "isLockedForRenewalProcessing": false,
        "shouldAutoApplyLicenses": true
    }
}
```