### PR TITLE
fix: second attempt to fix broken signature on bulk enroll results link

### DIFF
--- a/license_manager/apps/api/utils.py
+++ b/license_manager/apps/api/utils.py
@@ -292,7 +292,7 @@ def create_presigned_url(bucket_name, object_name, expiration=300):
             'Key': object_name,
             # RFC-2616 requires that the filename point to a "quoted-string" symbol, hence the double quotes surrounding
             # the filename below.  https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html
-            "ResponseContentDisposition": f'attachment; filename="{_get_short_file_name(object_name)}"',
+            "ResponseContentDisposition": f'attachment;filename="{_get_short_file_name(object_name)}"',
         },
         ExpiresIn=expiration
     )


### PR DESCRIPTION
The last attempt to fix the broken signature on the bulk enroll results link didn't work, so my next theory is that the StringToSign payload is different than what AWS generates on the backend because the provided payload contains a space character within the repsponse-content-disposition:

```
<StringToSign>
GET 1709587933 x-amz-security-token:<redacted> /<bucket>/<key>?response-content-disposition=attachment; filename="<filename>"
</StringToSign>
```

My theory is that the string to sign appears to use whitespace to separate tokens, and since the decoded URL contains whitespace it looks like an extra token.  This whitespace might be represented differently server-side vs. how the boto client generates it.

Note that BNF language definition for Content-Disposition in RFC-2616 describes no space between `;` and `filename` despite providing an example containing a space.  I found StackOverflow examples both with and without a space, so I think it should work either way.

If this doesn't work, I'll probably just give up!