### PR TITLE
fix: more assign script fixes, reject emails with spaces

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# boilerplate to treat as module

--- a/scripts/local_assignment_multi.py
+++ b/scripts/local_assignment_multi.py
@@ -243,12 +243,13 @@ def request_assignments(subscription_plan_uuid, chunk_id, emails_for_chunk, envi
         response.raise_for_status()
     except requests.exceptions.HTTPError:
         # if it's a 401, try refetching the JWT and re-try the request
+        print(response.content)
         if response.status_code == 401:
             print('EXPIRED JWT, REFETCHING...')
             response = _post_assignments(subscription_plan_uuid, emails_for_chunk, environment, fetch_jwt)
             response.raise_for_status()
         else:
-            raise
+            print('Continuing past this exception.')
 
     response_data = response.json()
 
@@ -288,9 +289,14 @@ def do_assignment_for_chunk(
 
     results_for_chunk = []
     if payload_for_chunk:
-        results_for_chunk = request_assignments(
-            subscription_plan_uuid, chunk_id, payload_for_chunk, environment, fetch_jwt,
-        )
+        try:
+            results_for_chunk = request_assignments(
+                subscription_plan_uuid, chunk_id, payload_for_chunk, environment, fetch_jwt,
+            )
+        except Exception as exc:
+            print(exc)
+            print('continuing on...')
+            return
         with open(results_file, 'a+') as f_out:
             writer = csv.writer(f_out, delimiter=',')
             writer.writerows(results_for_chunk)

--- a/scripts/local_assignment_requirements.txt
+++ b/scripts/local_assignment_requirements.txt
@@ -1,2 +1,3 @@
 click
 requests
+django-rest-framework

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,13 @@
+# needed for email validation
+import django
+from rest_framework import serializers
+
+EMAIL_FIELD = serializers.EmailField()
+
+
+def is_valid_email(email):
+    try:
+        EMAIL_FIELD.run_validators(email)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
* license-manager assignment endpoint rejects input emails with spaces in them
* don't both requesting specific scopes when fetching a JWT, we don't need them
* track the invalid emails along with their university name and number of occurrences as part of the input validation script.
