### PR TITLE
FIX: trailing slash conflict for api endpoints

### DIFF
--- a/license_manager/apps/api/urls.py
+++ b/license_manager/apps/api/urls.py
@@ -4,12 +4,20 @@ Root API URLs.
 All API URLs should be versioned, so urlpatterns should only
 contain namespaces for the active versions of the API.
 """
+import re
+
 from django.urls import include, path
 
 from license_manager.apps.api.v1 import urls as v1_urls
 
 
+def optional_trailing_slash(urls):
+    for url in urls[0].urlpatterns:
+        url.pattern.regex = re.compile(url.pattern.regex.pattern.replace('/$', '/?$'))
+    return urls
+
+
 app_name = 'api'
 urlpatterns = [
-    path('v1/', include(v1_urls)),
+    path('v1/', optional_trailing_slash(include(v1_urls))),
 ]


### PR DESCRIPTION
## Description

Because Django adds a trailing slash at the end of the URL by default, adding a trailing slash to the endpoint makes it throw a 301 error. This PR makes it allow a trailing slash.

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-8526

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
