### PR TITLE
feat: jitter email reminder execution

### DIFF
--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -442,6 +442,8 @@ BRAZE_API_URL = ''
 BRAZE_API_KEY = os.environ.get('BRAZE_API_KEY', '')
 BRAZE_APP_ID = os.environ.get('BRAZE_APP_ID', '')
 
+MAX_REMINDER_EMAIL_DELAY = 16
+
 # Set a datetime that a django action can reset license state to
 # Use year-month-day hour:minute:second format
 LICENSE_REVERT_SNAPSHOT_TIMESTAMP = '9999-12-31 23:59:59'


### PR DESCRIPTION
## Description

The previous change to batch up reminder email work into smaller, batched tasks had the unintended side effect of causing us to hit rate limit errors (because we went from a single, serial task that was far too big, to parallelized smaller tasks).
This change adds a countdown to the task execution to help reduce the frequency with which multiple of these tasks are running concurrently.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
