### PR TITLE
feat: serialize available_subscription_catalogs on MinimalCustomerAgreementSerializer

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -130,6 +130,7 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
             'disable_expiration_notifications',
             'net_days_until_expiration',
             'subscription_for_auto_applied_licenses',
+            'available_subscription_catalogs',
         ]
 
     def get_subscription_for_auto_applied_licenses(self, obj):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2724,8 +2724,20 @@ class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
         response = self._get_url_with_customer_uuid(self.enterprise_customer_uuid)
 
         assert response.status_code == status.HTTP_200_OK
+
         customer_agreement_response = response.json().get('customer_agreement')
+        expected_days_until_expiration = self.customer_agreement.net_days_until_expiration
+        expected_disable_expire_notifications = self.customer_agreement.disable_expiration_notifications
         assert customer_agreement_response['uuid'] == str(self.customer_agreement.uuid)
+        assert customer_agreement_response['net_days_until_expiration'] == expected_days_until_expiration
+        assert customer_agreement_response['disable_expiration_notifications'] == expected_disable_expire_notifications
+        assert customer_agreement_response['subscription_for_auto_applied_licenses'] is None
+
+        print('customer_agreement_response?!?!', customer_agreement_response)
+        expected_available_catalog_uuids = [
+            str(self.customer_agreement.subscriptions.first().enterprise_catalog_uuid)
+        ]
+        assert customer_agreement_response['available_subscription_catalogs'] == expected_available_catalog_uuids
 
     def test_endpoint_results_correctly_ordered(self):
         """

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -2733,7 +2733,6 @@ class LearnerLicensesViewsetTests(LicenseViewTestMixin, TestCase):
         assert customer_agreement_response['disable_expiration_notifications'] == expected_disable_expire_notifications
         assert customer_agreement_response['subscription_for_auto_applied_licenses'] is None
 
-        print('customer_agreement_response?!?!', customer_agreement_response)
         expected_available_catalog_uuids = [
             str(self.customer_agreement.subscriptions.first().enterprise_catalog_uuid)
         ]

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -153,6 +153,23 @@ class CustomerAgreement(TimeStampedModel):
         return net_days
 
     @property
+    def available_subscription_catalogs(self):
+        """
+        Returns all the enterprise catalogs associated with the subscription plans
+        in this customer agreement.
+        """
+        default_catalog_uuid = self.default_enterprise_catalog_uuid
+        available_catalog_uuids = set()
+        for plan in self.subscriptions.filter(is_active=True).prefetch_related('renewal'):
+            if plan.days_until_expiration_including_renewals > 0:
+                available_catalog_uuids.add(
+                    str(plan.enterprise_catalog_uuid)
+                    if plan.enterprise_catalog_uuid
+                    else str(default_catalog_uuid)
+                )
+        return list(available_catalog_uuids)
+
+    @property
     def auto_applicable_subscription(self):
         """
         Get which subscription on CustomerAgreement is auto-applicable.


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/ENT-8675

This PR is in support of the frontend performance work to rearchitect `frontend-app-learner-portal-enterprise`. We removed the API call to fetch the `customer-agreement` as a standalone call, and instead now rely on the `customer_agreement` getting serialized in the response of `learner-licenses`.

However, related to Browse & Request (BnR) for subscriptions, the current implementation of the updated `useCatalogForSubsidyRequest` requires the user having an allocation subscription license in order to determine the enterprise catalog UUIDs associated with any available (active/current) subscription plans associated with the `CustomerAgreement`.

In BnR, however, the subscription catalogs must be known _prior_ to having any allocated subscription licenses. As such, this PR proposes serializing `available_subscription_catalogs` to the `MinimalCustomerAgreementSerializer`.

Other properties already returned in `MinimalCustomerAgreementSerializer` utilize the `self.subscriptions` query set (e.g., `auto_applicable_subscription`), so this PR follows that convention to implement a new `available_subscription_catalogs` property.

## Post-review

Squash commits into discrete sets of changes
