### PR TITLE
fix: reminder task filters for only assigned licenses

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -962,11 +962,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
 
         if should_validate_emails:
             # Make sure there is a license that is still pending activation associated with the given emails
-            licenses = License.objects.filter(
-                subscription_plan=subscription_plan,
-                user_email__in=user_emails,
-                status=constants.ASSIGNED,
-            )
+            licenses = subscription_plan.assigned_licenses.filter(user_email__in=user_emails)
             license_by_email = {lcs.user_email: lcs for lcs in licenses}
             for email in user_emails:
                 pending_license = license_by_email.get(email)


### PR DESCRIPTION
Prior to this change, the reminder task did not filter down to only assigned licenses.
Also, the task now just rejects workloads if the number of recipients would exceed the batch size; it's up to the caller to ensure that tasks receive small-enough input.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-8735

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
