### PR TITLE
feat: create CRUD endpoint for `CustomerAgreement`

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -179,7 +179,7 @@ class CustomerAgreementCreateRequestSerializer(MinimalCustomerAgreementSerialize
             'default_enterprise_catalog_uuid',
             'disable_expiration_notifications',
             'disable_onboarding_notifications',
-        ]
+            ]
 
 
 class CustomerAgreementUpdateRequestSerializer(MinimalCustomerAgreementSerializer):

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -167,6 +167,21 @@ class CustomerAgreementSerializer(MinimalCustomerAgreementSerializer):
         return serializer.data
 
 
+class CustomerAgreementCreateRequestSerializer(MinimalCustomerAgreementSerializer):
+    """
+    Serializer for creating a new `CustomerAgreement` instance.
+    """
+
+    class Meta:
+        model = CustomerAgreement
+        fields = [
+            'enterprise_customer_uuid',
+            'default_enterprise_catalog_uuid',
+            'disable_expiration_notifications',
+            'disable_onboarding_notifications',
+            ]
+
+
 class LicenseSerializer(serializers.ModelSerializer):
     """
     Serializer for the `License` model.

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -179,7 +179,7 @@ class CustomerAgreementCreateRequestSerializer(MinimalCustomerAgreementSerialize
             'default_enterprise_catalog_uuid',
             'disable_expiration_notifications',
             'disable_onboarding_notifications',
-            ]
+        ]
 
 
 class CustomerAgreementUpdateRequestSerializer(MinimalCustomerAgreementSerializer):

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -182,6 +182,19 @@ class CustomerAgreementCreateRequestSerializer(MinimalCustomerAgreementSerialize
             ]
 
 
+class CustomerAgreementUpdateRequestSerializer(MinimalCustomerAgreementSerializer):
+    """
+    Serializer for partially updating an existing `CustomerAgreement` instance.
+    """
+
+    class Meta:
+        model = CustomerAgreement
+        fields = [
+            'default_enterprise_catalog_uuid',
+            'disable_onboarding_notifications',
+        ]
+
+
 class LicenseSerializer(serializers.ModelSerializer):
     """
     Serializer for the `License` model.

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -43,6 +43,7 @@ from license_manager.apps.core.models import User
 from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
+    CustomerAgreement,
     License,
     SubscriptionLicenseSource,
     SubscriptionsFeatureRole,
@@ -530,6 +531,7 @@ def test_customer_agreement_create_superuser_201(api_client, superuser):
 
     assert status.HTTP_201_CREATED == response.status_code
     _assert_customer_agreement_response_correct(response.data, customer_agreement)
+    assert CustomerAgreement.objects.filter(uuid=response.data['uuid']).exists()
 
 
 @pytest.mark.django_db

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -183,6 +183,42 @@ def _customer_agreement_list_request(api_client, user, enterprise_customer_uuid)
     return api_client.get(url)
 
 
+def _customer_agreement_create_request(api_client, user, enterprise_customer_uuid):
+    """
+    Helper method that requests to create a new CustomerAgreement for a specific enterprise customer uuid.
+    """
+    if user:
+        api_client.force_authenticate(user=user)
+
+    url = reverse('api:v1:customer-agreement-list')
+    data = {
+        'enterprise_customer_uuid': str(enterprise_customer_uuid),
+        'default_enterprise_catalog_uuid': str(uuid4()),
+        'disable_expiration_notifications': False,
+        'disable_onboarding_notifications': True,
+    }
+
+    return api_client.post(url, data=data)
+
+
+def _customer_agreement_partial_update_request(api_client, user, customer_agreement_uuid):
+    """
+    Helper method that requests to partially update a CustomerAgreement.
+    """
+    if user:
+        api_client.force_authenticate(user=user)
+
+    url = reverse('api:v1:customer-agreement-detail', kwargs={
+        'customer_agreement_uuid': customer_agreement_uuid,
+    })
+
+    data = {
+        'disable_onboarding_notifications': False,
+    }
+
+    return api_client.patch(url, data=data)
+
+
 def _subscriptions_list_request(api_client, user, enterprise_customer_uuid=None, current_plan=None):
     """
     Helper method that requests a list of subscriptions entities for a given enterprise_customer_uuid.
@@ -367,11 +403,59 @@ def test_customer_agreement_unauthenticated_user_401(api_client):
 
 
 @pytest.mark.django_db
+def test_customer_agreement_create_unauthenticated_user_401(api_client):
+    """
+    Verify that unauthenticated users receive a 401 from the customer agreement create endpoint.
+    """
+    response = _customer_agreement_create_request(
+        api_client=api_client,
+        user=None,
+        enterprise_customer_uuid=uuid4(),
+    )
+    assert status.HTTP_401_UNAUTHORIZED == response.status_code
+
+
+@pytest.mark.django_db
+def test_customer_agreement_partial_update_unauthenticated_user_401(api_client):
+    """
+    Verify that unauthenticated users receive a 401 from the customer agreement partial update endpoint.
+    """
+    response = _customer_agreement_partial_update_request(
+        api_client=api_client,
+        user=None,
+        customer_agreement_uuid=uuid4(),
+    )
+    assert status.HTTP_401_UNAUTHORIZED == response.status_code
+
+
+@pytest.mark.django_db
+def test_customer_agreement_create_non_staff_user_403(api_client, staff_user):
+    """
+    Verify that non-staff users without JWT roles receive a 403 from the customer agreement create endpoint.
+    """
+    response = _customer_agreement_create_request(
+        api_client=api_client,
+        user=staff_user,
+        enterprise_customer_uuid=uuid4(),
+    )
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
 def test_customer_agreement_non_staff_user_403(api_client, non_staff_user):
     """
     Verify that non-staff users without JWT roles receive a 403 from the customer agreement detail endpoint.
     """
     response = _customer_agreement_detail_request(api_client, non_staff_user, uuid4())
+    assert status.HTTP_403_FORBIDDEN == response.status_code
+
+
+@pytest.mark.django_db
+def test_customer_agreement_partial_update_non_staff_user_403(api_client, non_staff_user):
+    """
+    Verify that non-staff users without JWT roles receive a 403 from the customer agreement partial update endpoint.
+    """
+    response = _customer_agreement_partial_update_request(api_client, non_staff_user, uuid4())
     assert status.HTTP_403_FORBIDDEN == response.status_code
 
 
@@ -433,6 +517,32 @@ def test_customer_agreement_list_superuser_200(api_client, superuser):
     assert status.HTTP_200_OK == response.status_code
     assert 1 == response.data['count']
     _assert_customer_agreement_response_correct(response.data['results'][0], customer_agreement)
+
+
+@pytest.mark.django_db
+def test_customer_agreement_create_superuser_201(api_client, superuser):
+    """
+    Verify that superusers can create a new customer agreement.
+    """
+    enterprise_customer_uuid = uuid4()
+    response = _customer_agreement_create_request(api_client, superuser, enterprise_customer_uuid)
+    customer_agreement = CustomerAgreementFactory.create(enterprise_customer_uuid=enterprise_customer_uuid)
+
+    assert status.HTTP_201_CREATED == response.status_code
+    _assert_customer_agreement_response_correct(response.data, customer_agreement)
+
+
+@pytest.mark.django_db
+def test_customer_agreement_partial_update_superuser_200(api_client, superuser):
+    """
+    Verify that superusers can partially update a customer agreement.
+    """
+    enterprise_customer_uuid = uuid4()
+    customer_agreement = CustomerAgreementFactory.create(enterprise_customer_uuid=enterprise_customer_uuid)
+    response = _customer_agreement_partial_update_request(api_client, superuser, customer_agreement.uuid)
+
+    assert status.HTTP_200_OK == response.status_code
+    _assert_customer_agreement_response_correct(response.data, customer_agreement)
 
 
 @pytest.mark.django_db

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -128,6 +128,13 @@ class CustomerAgreementViewSet(
     allowed_roles = [constants.SUBSCRIPTIONS_ADMIN_ROLE, constants.SUBSCRIPTIONS_LEARNER_ROLE]
     role_assignment_class = SubscriptionsRoleAssignment
 
+    def get_permission_required(self):
+        if self.action == 'create':
+            return constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
+        if self.action == 'partial_update':
+            return constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
+        return super().get_permission_required()
+
     def partial_update(self, request, *args, **kwargs):
         """
         Partial update a CustomerAgreement against given UUID.

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -17,7 +17,7 @@ from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )
-from rest_framework import filters, permissions, status, viewsets, mixins
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError, ValidationError

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -95,6 +95,11 @@ ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
         summary='Retrieve a CustomerAgreement',
         description='Retrieve a CustomerAgreement by its UUID',
     ),
+    partial_update=extend_schema(
+        summary='Partial update a CustomerAgreement',
+        description='Partial update a CustomerAgreement by its UUID',
+        request=serializers.CustomerAgreementUpdateRequestSerializer,
+    ),
     auto_apply=extend_schema(
         summary='Auto-apply a license',
         description='Auto-apply licenses for the given `user_email` and `lms_user_id`.',
@@ -122,6 +127,27 @@ class CustomerAgreementViewSet(
     list_lookup_field = 'enterprise_customer_uuid'
     allowed_roles = [constants.SUBSCRIPTIONS_ADMIN_ROLE, constants.SUBSCRIPTIONS_LEARNER_ROLE]
     role_assignment_class = SubscriptionsRoleAssignment
+
+    def partial_update(self, request, *args, **kwargs):
+        """
+        Partial update a CustomerAgreement against given UUID.
+        """
+
+        if 'enterprise_customer_uuid' in request.data:
+            return Response(
+                'enterprise_customer_uuid cannot be updated',
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        customer_agreement = self.get_object()
+        serializer = serializers.CustomerAgreementSerializer(
+            customer_agreement,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     @property
     def requested_enterprise_uuid(self):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -115,7 +115,7 @@ class CustomerAgreementViewSet(
 ):
     """ Viewset for read operations on CustomerAgreements. """
 
-    authentication_classes = [JwtAuthentication]
+    authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
 
     lookup_field = 'uuid'

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -81,6 +81,20 @@ ASSIGNMENT_LOCK_TIMEOUT_SECONDS = 300
 ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary='List all CustomerAgreements',
+        description='List all CustomerAgreements with associated `SubscriptionPlans`',
+    ),
+    retrieve=extend_schema(
+        summary='Retrieve a CustomerAgreement',
+        description='Retrieve a CustomerAgreement by its UUID',
+    ),
+    auto_apply=extend_schema(
+        summary='Auto-apply a license',
+        description='Auto-apply licenses for the given `user_email` and `lms_user_id`.',
+    ),
+)
 class CustomerAgreementViewSet(
     PermissionRequiredForListingMixin,
     UserDetailsFromJwtMixin,

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -128,13 +128,6 @@ class CustomerAgreementViewSet(
     allowed_roles = [constants.SUBSCRIPTIONS_ADMIN_ROLE, constants.SUBSCRIPTIONS_LEARNER_ROLE]
     role_assignment_class = SubscriptionsRoleAssignment
 
-    def get_permission_required(self):
-        if self.action == 'create':
-            return constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
-        if self.action == 'partial_update':
-            return constants.SUBSCRIPTIONS_ADMIN_ACCESS_PERMISSION
-        return super().get_permission_required()
-
     def partial_update(self, request, *args, **kwargs):
         """
         Partial update a CustomerAgreement against given UUID.

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -86,6 +86,11 @@ ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
         summary='List all CustomerAgreements',
         description='List all CustomerAgreements with associated `SubscriptionPlans`',
     ),
+    create=extend_schema(
+        summary='Create a new CustomerAgreement',
+        description='Create a new CustomerAgreement for a given `enterprise_customer_uuid`',
+        request=serializers.CustomerAgreementCreateRequestSerializer,
+    ),
     retrieve=extend_schema(
         summary='Retrieve a CustomerAgreement',
         description='Retrieve a CustomerAgreement by its UUID',
@@ -101,6 +106,7 @@ class CustomerAgreementViewSet(
     viewsets.GenericViewSet,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
 ):
     """ Viewset for read operations on CustomerAgreements. """
 

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -17,7 +17,7 @@ from edx_rbac.mixins import PermissionRequiredForListingMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )
-from rest_framework import filters, permissions, status, viewsets
+from rest_framework import filters, permissions, status, viewsets, mixins
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError, ValidationError
@@ -84,7 +84,9 @@ ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
 class CustomerAgreementViewSet(
     PermissionRequiredForListingMixin,
     UserDetailsFromJwtMixin,
-    viewsets.ReadOnlyModelViewSet,
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
 ):
     """ Viewset for read operations on CustomerAgreements. """
 


### PR DESCRIPTION
## Description

- Updated `CustomerAgreementViewSet` to support `Create` and `Partial Update` actions
- Enhanced swagger documentation.
- Added `SessionAuthentication`
- Wrote test cases for newly created endpoints

<img width="1433" alt="image" src="https://github.com/openedx/license-manager/assets/35958006/9dd5de56-e29f-40a8-9785-182198f0e955">



Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-8798

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
