### PR TITLE
feat: case-insensitive search fields on customer agreement admin.

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -405,8 +405,8 @@ class CustomerAgreementAdmin(admin.ModelAdmin):
     search_fields = (
         'uuid__startswith',
         'enterprise_customer_uuid__startswith',
-        'enterprise_customer_slug__startswith',
-        'enterprise_customer_name__startswith',
+        'enterprise_customer_slug__istartswith',
+        'enterprise_customer_name__istartswith',
     )
     actions = ['sync_agreement_with_enterprise_customer']
 
@@ -711,8 +711,8 @@ class LicenseTransferJobAdmin(admin.ModelAdmin):
 
     search_fields = (
         'customer_agreement__enterprise_customer_uuid__startswith',
-        'customer_agreement__enterprise_customer_slug__startswith',
-        'customer_agreement__enterprise_customer_name__startswith',
+        'customer_agreement__enterprise_customer_slug__istartswith',
+        'customer_agreement__enterprise_customer_name__istartswith',
         'old_subscription_plan',
         'new_subscription_plan',
     )


### PR DESCRIPTION
ENT-8636
QoL improvement for finding the relavent customer agreement when creating a new subs plan.
Before:
<img width="599" alt="image" src="https://github.com/openedx/license-manager/assets/2307986/d8ae4be2-12ac-455d-80f7-8d6e313c70dd">

After:
<img width="586" alt="image" src="https://github.com/openedx/license-manager/assets/2307986/ca1f8672-cdf8-41bc-9e46-92d4720a5384">

## Post-review

Squash commits into discrete sets of changes
