### PR TITLE
feat: support a custom-subs-catalog allow list

### DIFF
--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -462,3 +462,9 @@ SPECTACULAR_SETTINGS = {
         'license_manager.apps.api.utils.make_swagger_var_param_optional',
     ],
 }
+
+# An allow list of enterprise catalog uuids that excused from  violations
+# in the ``validate_num_catalog_queries`` management command
+CUSTOM_CATALOG_PRODUCTS_ALLOW_LIST = [
+
+]


### PR DESCRIPTION
A proposed quick-fix for disambiguating noise from signal in our scheduled management command that validates the number of distinct catalog queries associated with subscription plans is what we expect. 
1. There are certain plans/queries that are allowed to be bespoke - this change at least gives us a place to (manually) declare that these bespoke queries are non-harmful, by adding a configurable allow list of enterprise catalog uuids that are excused from violations in the ``validate_num_catalog_queries`` management command.
2. Also, fix logic in this command to calculate the distinct number of plan types, instead of only products, for comparison against the number of used catalog queries founds amongst non-internal-use-only plans.

## Post-review

Squash commits into discrete sets of changes
