### PR TITLE
fix: query mapping validation data structure fix

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_validate_num_catalog_queries.py
@@ -99,7 +99,7 @@ class ValidateQueryMappingTaskTests(TestCase):
                 catalog_query_ids[index] = [str(uuid.uuid4())]
 
             # add one allowed *custom* catalog uuid to the response payload
-            catalog_query_ids[42] = allowed_custom_catalog_uuid
+            catalog_query_ids[42] = [allowed_custom_catalog_uuid]
 
             mock_api_client.return_value.get_distinct_catalog_queries.return_value = {
                 'num_distinct_query_ids': len(catalog_query_ids),

--- a/license_manager/apps/subscriptions/management/commands/validate_num_catalog_queries.py
+++ b/license_manager/apps/subscriptions/management/commands/validate_num_catalog_queries.py
@@ -56,9 +56,11 @@ class Command(BaseCommand):
         for catalog_uuid_batch in chunks(distinct_catalog_uuids, constants.VALIDATE_NUM_CATALOG_QUERIES_BATCH_SIZE):
             response = EnterpriseCatalogApiClient().get_distinct_catalog_queries(catalog_uuid_batch)
             query_ids = response['catalog_uuids_by_catalog_query_id']
-            for catalog_query_id, catalog_uuid in query_ids.items():
-                if catalog_uuid not in settings.CUSTOM_CATALOG_PRODUCTS_ALLOW_LIST:
-                    catalog_uuids_by_catalog_query_id[catalog_query_id] += catalog_uuid
+            for catalog_query_id, catalog_uuid_list in query_ids.items():
+                allow_list = set(settings.CUSTOM_CATALOG_PRODUCTS_ALLOW_LIST)
+                catalog_uuids = set(catalog_uuid_list) - allow_list
+                if catalog_uuids:
+                    catalog_uuids_by_catalog_query_id[catalog_query_id] += list(catalog_uuids)
 
         distinct_catalog_query_ids = catalog_uuids_by_catalog_query_id.keys()
         # Calculate the number of customer types using the distinct number of


### PR DESCRIPTION
`EnterpriseCatalogApiClient().get_distinct_catalog_queries()` returns a dict keyed by catalog id and valued by a _list_ of associated catalog uuids. Fixes a bug where the code treated the value as a _string_ when checking the allow list.

## Post-review

Squash commits into discrete sets of changes
