### PR TITLE
feat: added CRUD endpoints for Customer Agreements for Provisioning admins

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -558,8 +558,9 @@ def test_customer_agreement_detail_provisioning_admin_user_200(api_client, staff
         staff_user,
         customer_agreement.uuid,
         viewname='provisioning-admins-customer-agreement-detail',
-        )
+    )
     assert status.HTTP_200_OK == response.status_code
+
 
 @pytest.mark.django_db
 def test_customer_agreement_detail_staff_user_403(api_client, staff_user):

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -72,6 +72,11 @@ router.register(
     basename='customer-agreement',
 )
 router.register(
+    prefix='provisioning-admins/customer-agreement',
+    viewset=views.CustomerAgreementProvisioningAdminViewset,
+    basename='provisioning-admins-customer-agreement',
+)
+router.register(
     prefix='provisioning-admins/subscriptions',
     viewset=views.SubscriptionPlanProvisioningAdminViewset,
     basename='provisioning-admins',

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -90,19 +90,9 @@ ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
         summary='List all CustomerAgreements',
         description='List all CustomerAgreements with associated `SubscriptionPlans`',
     ),
-    create=extend_schema(
-        summary='Create a new CustomerAgreement',
-        description='Create a new CustomerAgreement for a given `enterprise_customer_uuid`',
-        request=serializers.CustomerAgreementCreateRequestSerializer,
-    ),
     retrieve=extend_schema(
         summary='Retrieve a CustomerAgreement',
         description='Retrieve a CustomerAgreement by its UUID',
-    ),
-    partial_update=extend_schema(
-        summary='Partial update a CustomerAgreement',
-        description='Partial update a CustomerAgreement by its UUID',
-        request=serializers.CustomerAgreementUpdateRequestSerializer,
     ),
     auto_apply=extend_schema(
         summary='Auto-apply a license',
@@ -112,10 +102,7 @@ ESTIMATED_COUNT_PAGINATOR_THRESHOLD = 10000
 class CustomerAgreementViewSet(
     PermissionRequiredForListingMixin,
     UserDetailsFromJwtMixin,
-    viewsets.GenericViewSet,
-    mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.CreateModelMixin,
+    viewsets.ReadOnlyModelViewSet,
 ):
     """ Viewset for read operations on CustomerAgreements. """
 
@@ -131,27 +118,6 @@ class CustomerAgreementViewSet(
     list_lookup_field = 'enterprise_customer_uuid'
     allowed_roles = [constants.SUBSCRIPTIONS_ADMIN_ROLE, constants.SUBSCRIPTIONS_LEARNER_ROLE]
     role_assignment_class = SubscriptionsRoleAssignment
-
-    def partial_update(self, request, *args, **kwargs):
-        """
-        Partial update a CustomerAgreement against given UUID.
-        """
-
-        if 'enterprise_customer_uuid' in request.data:
-            return Response(
-                'enterprise_customer_uuid cannot be updated',
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        customer_agreement = self.get_object()
-        serializer = serializers.CustomerAgreementSerializer(
-            customer_agreement,
-            data=request.data,
-            partial=True,
-        )
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     @property
     def requested_enterprise_uuid(self):

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -324,7 +324,7 @@ class CustomerAgreementProvisioningAdminViewset(
 
     def get_queryset(self):
         return CustomerAgreement.objects.all()
-    
+
     def partial_update(self, request, *args, **kwargs):
         """
         Partial update a CustomerAgreement against given UUID.


### PR DESCRIPTION
## Description

Description of changes made:
- Created new endpoints for provisioning admins to `create`, `retrieve`, and `partial_update`.
- Removed previously created endpoint for `create` and `partial_update`.

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-9034

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
