### PR TITLE
docs: adds comments related to celery task

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -86,6 +86,9 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     # Use exponential backoff for retrying tasks
     # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
     # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
+    # The retry_backoff_max default value is 600 seconds -> 10 minutes
+    # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff_max
+    # This will result in the final backoff time reducing from 2⁴ × 60 seconds = 960 seconds to 600 seconds
     retry_backoff = 60
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously.
     # The actual delay value will be a random number in the range (0, retry_backoff)


### PR DESCRIPTION
## Description
Adds docs in parity to whats currently in enterprise access.
https://github.com/openedx/enterprise-access/pull/491

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-9039

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
