### PR TITLE
Require subscription_uuid when enroll_all is provided regardless of its value

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -717,7 +717,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer(serializers.Se
         ]
 
     def validate(self, attrs):
-        if attrs.get('enroll_all') and not attrs.get('subscription_uuid'):
+        if attrs.get('enroll_all') is not None and not attrs.get('subscription_uuid'):
             raise serializers.ValidationError({'subscription_id': 'This field is required when enroll_all is True.'})
         return attrs
 

--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -702,6 +702,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer(serializers.Se
     )
     enroll_all = serializers.BooleanField(
         required=False,
+        allow_null=True,
         help_text='A boolean indicating whether to enroll all learners or not',
     )
     subscription_uuid = serializers.UUIDField(
@@ -718,7 +719,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyQueryParamsSerializer(serializers.Se
 
     def validate(self, attrs):
         if attrs.get('enroll_all') is not None and not attrs.get('subscription_uuid'):
-            raise serializers.ValidationError({'subscription_id': 'This field is required when enroll_all is True.'})
+            raise serializers.ValidationError({'subscription_id': 'This field is required when enroll_all is provided'})
         return attrs
 
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -4096,7 +4096,7 @@ class EnterpriseEnrollmentWithLicenseSubsidyViewTests(LicenseViewTestMixin, Test
         url = self._get_url_with_params(enroll_all=True)
         response = self.api_client.post(url, data)
         assert response.status_code == 400
-        expected_json = {'subscription_id': ['This field is required when enroll_all is True.']}
+        expected_json = {'subscription_id': ['This field is required when enroll_all is provided']}
         assert response.json() == expected_json
 
     def test_bulk_licensed_enrollment_with_missing_emails(self):


### PR DESCRIPTION
Description:
Require subscription_uuid when enroll_all is provided regardless of whether it is True or False.

JIRA:
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/issues/ENT-8314