### PR TITLE
feat: serialize subscription plan is_current field

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -48,6 +48,10 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
     """
     Minimal serializer for the `SubscriptionPlan` model.
     """
+    is_current = serializers.BooleanField(
+        help_text='Indicates whether start_date <= now <= expiration_date.',
+        read_only=True,
+    )
 
     class Meta:
         model = SubscriptionPlan
@@ -59,6 +63,7 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
             'enterprise_customer_uuid',
             'enterprise_catalog_uuid',
             'is_active',
+            'is_current',
             'is_revocation_cap_enabled',
             'days_until_expiration',
             'days_until_expiration_including_renewals',

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -938,6 +938,7 @@ def test_subscription_plan_create_staff_user_200(api_client, staff_user, boolean
         "start_date",
         "title",
         "uuid",
+        "is_current",
     }
     assert response.json().keys() == expected_fields
 

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -15,6 +15,7 @@ from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.forms import ValidationError
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from edx_rbac.models import UserRole, UserRoleAssignment
@@ -490,6 +491,13 @@ class SubscriptionPlan(TimeStampedModel):
         Note: expiration_date is a required field so checking for None isn't needed.
         """
         return days_until(self.expiration_date)
+
+    @property
+    def is_current(self):
+        """
+        Returns a boolean indicating whether start_date <= now <= expiration_date.
+        """
+        return self.start_date <= timezone.now() <= self.expiration_date
 
     @property
     def has_revocations_remaining(self):

--- a/license_manager/apps/subscriptions/tests/test_models.py
+++ b/license_manager/apps/subscriptions/tests/test_models.py
@@ -81,6 +81,29 @@ class SubscriptionsModelTests(TestCase):
         )
         self.assertEqual(renewed_subscription_plan_2.prior_renewals, [renewal_1, renewal_2])
 
+    @ddt.data(
+        {'start_date_delta': timedelta(days=-1), 'end_date_delta': timedelta(days=1), 'expected_current': True},
+        {'start_date_delta': timedelta(days=-1), 'end_date_delta': timedelta(days=0), 'expected_current': True},
+        {'start_date_delta': timedelta(days=0), 'end_date_delta': timedelta(days=1), 'expected_current': True},
+        {'start_date_delta': timedelta(days=0), 'end_date_delta': timedelta(days=0), 'expected_current': True},
+        {'start_date_delta': timedelta(days=1), 'end_date_delta': timedelta(days=1), 'expected_current': False},
+        {'start_date_delta': timedelta(days=10), 'end_date_delta': timedelta(days=150), 'expected_current': False},
+        {'start_date_delta': timedelta(days=-1), 'end_date_delta': timedelta(days=-1), 'expected_current': False},
+        {'start_date_delta': timedelta(days=-10), 'end_date_delta': timedelta(days=-5), 'expected_current': False},
+    )
+    @ddt.unpack
+    def test_is_current(self, start_date_delta, end_date_delta, expected_current):
+        today = localized_utcnow()
+        with freezegun.freeze_time(today):
+            subscription_plan = SubscriptionPlanFactory.create(
+                start_date=today + start_date_delta,
+                expiration_date=today + end_date_delta,
+            )
+            if expected_current:
+                self.assertTrue(subscription_plan.is_current)
+            else:
+                self.assertFalse(subscription_plan.is_current)
+
     @ddt.data(True, False)
     def test_is_locked_for_renewal_processing(self, is_locked_for_renewal_processing):
         today = localized_utcnow()


### PR DESCRIPTION
## Description

Compute `is_current` at the API layer so that the frontend doesn't have to duplicate business logic.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
