### PR TITLE
fix: Don't throw an exception if no pending licenses were found

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -166,6 +166,12 @@ def _batch_notify_or_remind_assigned_emails(
     if len(pending_licenses) > allowed_batch_size:
         raise Exception(f'Found more than {allowed_batch_size} licenses, no email sent to {action_type}')
 
+    if len(pending_licenses) == 0:
+        logger.warning(
+            f'{LICENSE_DEBUG_PREFIX} No pending licenses found for given emails, no email sent to {action_type}.'
+        )
+        return pending_licenses
+
     enterprise_api_client = EnterpriseApiClient()
     enterprise_customer = enterprise_api_client.get_enterprise_customer_data(
         subscription_plan.enterprise_customer_uuid,


### PR DESCRIPTION
It seems plausible to me that this would occasionally happen as part of the normal flow of things, so instead of alerting on-call just log a warning.

For posterity, here's the error:
```
Traceback (most recent call last):
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/autoretry.py", line 60, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/task.py", line 736, in retry
    raise_with_context(exc)
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/celery/app/autoretry.py", line 38, in run
    return task._orig_run(*args, **kwargs)
  File "/edx/app/license_manager/license_manager/apps/api/tasks.py", line 243, in send_assignment_email_task
    _batch_notify_or_remind_assigned_emails(
  File "/edx/app/license_manager/license_manager/apps/api/tasks.py", line 219, in _batch_notify_or_remind_assigned_emails
    raise exc
  File "/edx/app/license_manager/license_manager/apps/api/tasks.py", line 204, in _batch_notify_or_remind_assigned_emails
    braze_client_instance.create_braze_alias(
  File "/edx/app/license-manager/venvs/license-manager/lib/python3.8/site-packages/braze/client.py", line 361, in create_braze_alias
    raise BrazeClientError(msg)
braze.exceptions.BrazeClientError: Bad arguments, please check that emails, and alias_label are non-empty.
```