### PR TITLE
feat: add created time to subscriptions api response

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -68,7 +68,8 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
             'days_until_expiration',
             'days_until_expiration_including_renewals',
             'is_locked_for_renewal_processing',
-            'should_auto_apply_licenses'
+            'should_auto_apply_licenses',
+            'created',
         ]
 
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -939,6 +939,7 @@ def test_subscription_plan_create_non_staff_user_200(api_client, non_staff_user)
         "title",
         "uuid",
         "is_current",
+        "created",
     }
     assert response.json().keys() == expected_fields
 
@@ -1006,7 +1007,7 @@ def test_subscription_plan_provisioning_admins_list_non_staff_user_200(api_clien
         'is_active', 'is_revocation_cap_enabled', 'days_until_expiration',
         'days_until_expiration_including_renewals',
         'is_locked_for_renewal_processing', 'should_auto_apply_licenses',
-        'licenses', 'revocations', 'prior_renewals'
+        'licenses', 'revocations', 'prior_renewals', 'created',
     }
     for result in response.json()['results']:
         assert expected_result_keys.issubset(result.keys())


### PR DESCRIPTION
## Description

include created time in subscriptions api response `api/v1/subscriptions/`

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-9374

## Testing considerations
1. Follow the set up steps here https://github.com/openedx/license-manager to get the server running
2. checkout this branch with `git fetch -a` and `git checkout knguyen2/ent-9374`
3. visit http://localhost:18170/login  and get the customer uuid from any subscription plan http://localhost:18170/admin/subscriptions/subscriptionplan/. create a plan if one doesn't exist
5. copy the customer uuid and paste in the following link: https://license-manager-internal.stage.edx.org/api/v1/subscriptions/?enterprise_customer_uuid=<CUSTOMER_UUID>
6. verify that you see the created date
![Screenshot 2024-08-19 at 11 32 38 AM](https://github.com/user-attachments/assets/d27ce7d8-7c70-430d-b32b-0642fef7a24b)

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
