### PR TITLE
feat: edx-rbac to 1.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,9 +22,9 @@ backoff==1.10.0
     #   analytics-python
 billiard==4.2.0
     # via celery
-boto3==1.34.158
+boto3==1.35.4
     # via django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   boto3
     #   s3transfer
@@ -117,7 +117,7 @@ django-model-utils==4.5.1
     #   -r requirements/base.in
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/base.in
 django-simple-history==3.7.0
     # via -r requirements/base.in
@@ -165,7 +165,7 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-opaque-keys==2.10.0
     # via edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.in
 edx-rest-api-client==5.7.1
     # via -r requirements/base.in
@@ -232,9 +232,7 @@ python-slugify==8.0.4
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/base.in
-    #   django-ses
+    # via -r requirements/base.in
 pyyaml==6.0.2
     # via
     #   code-annotations
@@ -265,7 +263,7 @@ s3transfer==0.10.2
     # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/base.in
 six==1.16.0
     # via
@@ -283,7 +281,7 @@ social-auth-core==4.5.4
     #   social-auth-app-django
 sqlparse==0.5.1
     # via django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,11 +33,11 @@ billiard==4.2.0
     # via
     #   -r requirements/validation.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -185,7 +185,7 @@ django-model-utils==4.5.1
     #   -r requirements/validation.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/validation.txt
 django-simple-history==3.7.0
     # via -r requirements/validation.txt
@@ -243,15 +243,15 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/validation.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/validation.txt
 edx-toggles==5.2.0
     # via -r requirements/validation.txt
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/validation.txt
-faker==26.3.0
+faker==27.4.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -459,9 +459,7 @@ python3-openid==3.2.0
     #   -r requirements/validation.txt
     #   social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/validation.txt
-    #   django-ses
+    # via -r requirements/validation.txt
 pywatchman==2.0.0
     # via -r requirements/dev.in
 pyyaml==6.0.2
@@ -505,7 +503,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/validation.txt
 six==1.16.0
     # via
@@ -538,7 +536,7 @@ sqlparse==0.5.1
     #   -r requirements/validation.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -548,7 +546,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/validation.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/validation.txt
     #   pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -43,11 +43,11 @@ billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -177,7 +177,7 @@ django-model-utils==4.5.1
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/test.txt
 django-simple-history==3.7.0
     # via -r requirements/test.txt
@@ -242,15 +242,15 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/test.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/test.txt
 edx-toggles==5.2.0
     # via -r requirements/test.txt
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -430,9 +430,7 @@ python3-openid==3.2.0
     #   -r requirements/test.txt
     #   social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/test.txt
-    #   django-ses
+    # via -r requirements/test.txt
 pyyaml==6.0.2
     # via
     #   -r requirements/test.txt
@@ -478,7 +476,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/test.txt
 six==1.16.0
     # via
@@ -503,7 +501,7 @@ social-auth-core==4.5.4
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==8.0.2
     # via
@@ -528,7 +526,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -539,7 +537,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.1.0
+setuptools==73.0.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,11 +28,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -143,7 +143,7 @@ django-model-utils==4.5.1
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/base.txt
 django-simple-history==3.7.0
     # via -r requirements/base.txt
@@ -197,7 +197,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
@@ -318,9 +318,7 @@ python3-openid==3.2.0
     #   -r requirements/base.txt
     #   social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/base.txt
-    #   django-ses
+    # via -r requirements/base.txt
 pyyaml==6.0.2
     # via
     #   -r requirements/base.txt
@@ -362,7 +360,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/base.txt
 six==1.16.0
     # via
@@ -388,7 +386,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -32,11 +32,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -154,7 +154,7 @@ django-model-utils==4.5.1
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/base.txt
 django-simple-history==3.7.0
     # via -r requirements/base.txt
@@ -210,7 +210,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
@@ -345,9 +345,7 @@ python3-openid==3.2.0
     #   -r requirements/base.txt
     #   social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/base.txt
-    #   django-ses
+    # via -r requirements/base.txt
 pyyaml==6.0.2
     # via
     #   -r requirements/base.txt
@@ -388,7 +386,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/base.txt
 six==1.16.0
     # via
@@ -417,7 +415,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -427,7 +425,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,11 +32,11 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -163,7 +163,7 @@ django-model-utils==4.5.1
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via -r requirements/base.txt
 django-simple-history==3.7.0
     # via -r requirements/base.txt
@@ -219,15 +219,15 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.1
     # via -r requirements/base.txt
 edx-toggles==5.2.0
     # via -r requirements/base.txt
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.in
-faker==26.3.0
+faker==27.4.0
     # via factory-boy
 freezegun==1.5.1
     # via -r requirements/test.in
@@ -370,9 +370,7 @@ python3-openid==3.2.0
     #   -r requirements/base.txt
     #   social-auth-core
 pytz==2024.1
-    # via
-    #   -r requirements/base.txt
-    #   django-ses
+    # via -r requirements/base.txt
 pyyaml==6.0.2
     # via
     #   -r requirements/base.txt
@@ -413,7 +411,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via -r requirements/base.txt
 six==1.16.0
     # via
@@ -440,7 +438,7 @@ sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -450,7 +448,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -41,12 +41,12 @@ billiard==4.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-boto3==1.34.158
+boto3==1.35.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.34.158
+botocore==1.35.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -208,7 +208,7 @@ django-model-utils==4.5.1
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   edx-rbac
-django-ses==4.1.0
+django-ses==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -293,7 +293,7 @@ edx-opaque-keys==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.9.0
+edx-rbac==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -305,9 +305,9 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -520,7 +520,6 @@ pytz==2024.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django-ses
 pyyaml==6.0.2
     # via
     #   -r requirements/quality.txt
@@ -573,7 +572,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -612,7 +611,7 @@ sqlparse==0.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -624,7 +623,7 @@ text-unidecode==1.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description
Upgrade edx-rbac to 1.10 so we can ignore invalid JWT cookie errors.

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-9379
