### PR TITLE
fix: renewal processing saves original activation keys

### DIFF
--- a/license_manager/apps/subscriptions/api.py
+++ b/license_manager/apps/subscriptions/api.py
@@ -167,7 +167,7 @@ def _renew_all_licenses(original_licenses, future_plan, is_auto_renewed):
         original_license.renewed_to = future_license
     License.bulk_update(
         future_licenses,
-        ['status', 'user_email', 'lms_user_id', 'activation_date', 'assigned_date'],
+        ['status', 'user_email', 'lms_user_id', 'activation_key', 'activation_date', 'assigned_date'],
     )
     License.bulk_update(
         original_licenses,

--- a/license_manager/apps/subscriptions/tests/test_api.py
+++ b/license_manager/apps/subscriptions/tests/test_api.py
@@ -91,6 +91,7 @@ class RenewalProcessingTests(TestCase):
             self.assertEqual(future_license.status, original_license.status)
             self.assertEqual(future_license.user_email, original_license.user_email)
             self.assertEqual(future_license.lms_user_id, original_license.lms_user_id)
+            self.assertEqual(future_license.activation_key, original_license.activation_key)
             if original_license.status == constants.ACTIVATED:
                 self.assertEqual(future_license.activation_date, expected_activation_datetime)
             self.assertEqual(future_license.assigned_date, NOW)
@@ -108,6 +109,7 @@ class RenewalProcessingTests(TestCase):
             LicenseFactory.create(
                 subscription_plan=prior_plan,
                 status=constants.ASSIGNED,
+                activation_key=uuid.uuid4(),
                 user_email='assigned_user_{}@example.com'.format(i)
             ) for i in range(5)
         ]


### PR DESCRIPTION
We previously were assigning, but not _saving_, the activation key from original to future licenses when processing renewals.
ENT-9276

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
