### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/mysql8-migrations-check.yml
+++ b/.github/workflows/mysql8-migrations-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-latest ]
         python-version: [ 3.12 ]
 
     steps:


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/license-manager/issues/695
