### PR TITLE
feat: make customer agreements fields available in learner license en…

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -354,6 +354,10 @@ class MinimalCustomerAgreementSerializer(serializers.ModelSerializer):
             'net_days_until_expiration',
             'subscription_for_auto_applied_licenses',
             'available_subscription_catalogs',
+            'has_custom_license_expiration_messaging',
+            'expired_subscription_modal_messaging',
+            'hyper_link_text_for_expired_modal',
+            'url_for_expired_modal',
         ]
 
     def get_subscription_for_auto_applied_licenses(self, obj):
@@ -371,10 +375,6 @@ class CustomerAgreementSerializer(MinimalCustomerAgreementSerializer):
         model = CustomerAgreement
         fields = MinimalCustomerAgreementSerializer.Meta.fields + [
             'subscriptions',
-            'has_custom_license_expiration_messaging',
-            'expired_subscription_modal_messaging',
-            'hyper_link_text_for_expired_modal',
-            'url_for_expired_modal',
         ]
 
     @property


### PR DESCRIPTION
**Description**

Make the newly added fields in the customer agreement model available in learner license endpoint.

endpoint:` /api/v1/learner-licenses?enterprise_customer_uuid=the-uuid&active_plans_only=true&current_plans_only=false`

<img width="1313" alt="Screenshot 2024-10-01 at 11 59 33 AM" src="https://github.com/user-attachments/assets/7e902386-738f-4be0-bf87-728c98662cda">


## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
