### PR TITLE
feat: return serialized subs license in license-activation POST

### DIFF
--- a/license_manager/apps/api/v1/tests/test_api_eventing.py
+++ b/license_manager/apps/api/v1/tests/test_api_eventing.py
@@ -246,7 +246,7 @@ class LicenseLearnerActionsEventTests(LicenseViewTestMixin, TestCase):
                 url = reverse('api:v1:license-activation') + '/?' + query_params.urlencode()
                 response = self.api_client.post(url)
 
-            assert status.HTTP_204_NO_CONTENT == response.status_code
+            assert status.HTTP_200_OK == response.status_code
             license_to_be_activated.refresh_from_db()
 
             assert mock_activated_track_event.call_count == 1

--- a/license_manager/apps/api/v1/tests/test_license_activation_view.py
+++ b/license_manager/apps/api/v1/tests/test_license_activation_view.py
@@ -145,8 +145,18 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         with freeze_time(self.now):
             response = self._post_request(str(self.activation_key))
 
-        assert status.HTTP_204_NO_CONTENT == response.status_code
+        # Verify that the response contains activated subscription license.
+        assert status.HTTP_200_OK == response.status_code
+        activated_license = response.json()
+        assert activated_license['uuid'] == str(license_to_be_activated.uuid)
+        assert activated_license['status'] == constants.ACTIVATED
+        expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        assert activated_license['activation_date'] == expected_activation_date
+
+        # Refresh license from the database
         license_to_be_activated.refresh_from_db()
+
+        # Verify that the license has been activated in the DB
         assert constants.ACTIVATED == license_to_be_activated.status
         assert self.lms_user_id == license_to_be_activated.lms_user_id
         assert self.now == license_to_be_activated.activation_date
@@ -159,7 +169,7 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
                 self.user.email,
             )
 
-    def test_license_already_activated_returns_204(self):
+    def test_license_already_activated_returns_200(self):
         self._assign_learner_roles(
             jwt_payload_extra={
                 'user_id': self.lms_user_id,
@@ -174,7 +184,13 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
 
         response = self._post_request(str(self.activation_key))
 
-        assert status.HTTP_204_NO_CONTENT == response.status_code
+        assert status.HTTP_200_OK == response.status_code
+        activated_license = response.json()
+        assert activated_license['uuid'] == str(already_activated_license.uuid)
+        assert activated_license['status'] == constants.ACTIVATED
+        expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        assert activated_license['activation_date'] == expected_activation_date
+
         already_activated_license.refresh_from_db()
         assert constants.ACTIVATED == already_activated_license.status
         assert self.lms_user_id == already_activated_license.lms_user_id
@@ -217,7 +233,12 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         with freeze_time(self.now):
             response = self._post_request(str(self.activation_key))
 
-        assert status.HTTP_204_NO_CONTENT == response.status_code
+        assert status.HTTP_200_OK == response.status_code
+        activated_license = response.json()
+        assert activated_license['uuid'] == str(license_b.uuid)
+        assert activated_license['status'] == constants.ACTIVATED
+        expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        assert activated_license['activation_date'] == expected_activation_date
 
         license_b.refresh_from_db()
         assert constants.ACTIVATED == license_b.status
@@ -268,7 +289,12 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         with freeze_time(self.now):
             response = self._post_request(str(license_a_activation_key))
 
-        assert status.HTTP_204_NO_CONTENT == response.status_code
+        assert status.HTTP_200_OK == response.status_code
+        activated_license = response.json()
+        assert activated_license['uuid'] == str(license_b.uuid)
+        assert activated_license['status'] == constants.ACTIVATED
+        expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        assert activated_license['activation_date'] == expected_activation_date
 
         license_b.refresh_from_db()
         assert constants.ACTIVATED == license_b.status
@@ -341,7 +367,13 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         with freeze_time(self.now):
             response = self._post_request(str(self.activation_key))
 
-        assert status.HTTP_204_NO_CONTENT == response.status_code
+        assert status.HTTP_200_OK == response.status_code
+        activated_license = response.json()
+        assert activated_license['uuid'] == str(current_assigned_license.uuid)
+        assert activated_license['status'] == constants.ACTIVATED
+        expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        assert activated_license['activation_date'] == expected_activation_date
+
         current_assigned_license.refresh_from_db()
         prior_assigned_license.refresh_from_db()
         assert prior_assigned_license.activation_date != self.now

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1779,10 +1779,10 @@ class LicenseActivationView(LicenseBaseView):
                  license's subscription plan.
             * 404 Not Found - if the email found in the request's JWT and the provided ``activation_key``
                  do not match those of any existing license in an activate subscription plan.
-            * 204 No Content - if such a license was found, and if the license is currently ``assigned``,
+            * 200 OK - if such a license was found, and if the license is currently ``assigned``,
                  it is updated with a status of ``activated``, its ``activation_date`` is set, and its ``lms_user_id``
                  is updated to the value found in the request's JWT.  If the license is already ``activated``,
-                 no update is made to it.
+                 no update is made to it. The activated license is then returned in the response.
             * 422 Unprocessable Entity - if we find a license, but it's status is not currently ``assigned``
                  or ``activated``, we do nothing and return a 422 with a message indicating that the license
                  cannot be activated.
@@ -1801,7 +1801,8 @@ class LicenseActivationView(LicenseBaseView):
 
         # There's an implied logical branch where the license is already activated
         # in which case we also return as if the activation action was successful.
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        serialized_license = serializers.LicenseSerializer(user_license)
+        return Response(serialized_license.data, status=status.HTTP_200_OK)
 
     def _track_and_notify(self, user_license):
         """


### PR DESCRIPTION
## Description

[ENT-9649](https://2u-internal.atlassian.net/browse/ENT-9649)

## Testing considerations

- Call POST `license-activation` with an assigned license. Observe the now-activated license in the response.
- Call POST `license-activation` with an already-activated license. Observe the already-activated license in the response.

## Post-review

Squash commits into discrete sets of changes
