### PR TITLE
Add CSSSanitizer to sanitize_html

### DIFF
--- a/license_manager/apps/subscriptions/sanitize.py
+++ b/license_manager/apps/subscriptions/sanitize.py
@@ -1,5 +1,5 @@
 import bleach
-
+from bleach.css_sanitizer import CSSSanitizer
 
 def sanitize_html(html_content):
     """
@@ -7,8 +7,9 @@ def sanitize_html(html_content):
     while disallowing JavaScript and unsafe protocols.
     """
     # Define allowed tags and attributes
-    allowed_tags = bleach.ALLOWED_TAGS  # Allow all standard HTML tags
+    allowed_tags = set.union(bleach.ALLOWED_TAGS, set({"span"}))  # Allow all standard HTML tags
     allowed_attrs = {"*": ["className", "class", "style", "id"]}
+    css_sanitizer = CSSSanitizer(allowed_css_properties=["color", "font-weight"])
 
     # Clean the HTML content
     sanitized_content = bleach.clean(
@@ -16,7 +17,8 @@ def sanitize_html(html_content):
         tags=allowed_tags,
         attributes=allowed_attrs,
         strip=True,  # Strip disallowed tags completely
-        protocols=["http", "https"],  # Only allow http and https URLs
+        protocols=["http", "https"],  # Only allow http and https URLs,
+        css_sanitizer=css_sanitizer,
     )
 
     # Use bleach.linkify to ensure no javascript: links in <a> tags

--- a/license_manager/apps/subscriptions/sanitize.py
+++ b/license_manager/apps/subscriptions/sanitize.py
@@ -1,6 +1,7 @@
 import bleach
 from bleach.css_sanitizer import CSSSanitizer
 
+
 def sanitize_html(html_content):
     """
     Sanitize HTML content to allow only safe tags and attributes,

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -41,3 +41,4 @@ simplejson
 zipp
 django-log-request-id
 bleach
+bleach[css]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,11 +22,11 @@ backoff==1.10.0
     #   analytics-python
 billiard==4.2.1
     # via celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/base.in
-boto3==1.35.48
+boto3==1.35.49
     # via django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   boto3
     #   s3transfer
@@ -289,6 +289,8 @@ stevedore==5.3.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
+tinycss2==1.2.1
+    # via bleach
 typing-extensions==4.12.2
     # via edx-opaque-keys
 tzdata==2024.2
@@ -309,7 +311,9 @@ vine==5.1.0
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
-    # via bleach
+    # via
+    #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via -r requirements/base.in
 

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -34,3 +34,7 @@ elasticsearch<7.14.0
 # This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
 # has been resolved and edx-platform is running with pymongo>=4.4.0
 event-tracking<2.4.1
+
+# Cause: https://github.com/openedx/edx-lint/issues/458
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
+pip<24.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,13 +33,13 @@ billiard==4.2.1
     # via
     #   -r requirements/validation.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/validation.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/validation.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/validation.txt
     #   boto3
@@ -240,7 +240,7 @@ edx-drf-extensions==10.5.0
     #   edx-rbac
 edx-i18n-tools==1.6.3
     # via -r requirements/validation.txt
-edx-lint==5.4.0
+edx-lint==5.4.1
     # via -r requirements/validation.txt
 edx-opaque-keys==2.11.0
     # via
@@ -550,11 +550,15 @@ text-unidecode==1.3
     # via
     #   -r requirements/validation.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/validation.txt
+    #   bleach
 tomlkit==0.13.2
     # via
     #   -r requirements/validation.txt
     #   pylint
-typeguard==4.3.0
+typeguard==4.4.0
     # via inflect
 typing-extensions==4.12.2
     # via
@@ -590,6 +594,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/validation.txt
     #   bleach
+    #   tinycss2
 wheel==0.44.0
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -43,13 +43,13 @@ billiard==4.2.1
     # via
     #   -r requirements/test.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/test.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -239,7 +239,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.4.0
+edx-lint==5.4.1
     # via -r requirements/test.txt
 edx-opaque-keys==2.11.0
     # via
@@ -535,6 +535,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/test.txt
+    #   bleach
 tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
@@ -573,6 +577,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/test.txt
     #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via -r requirements/test.txt
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,8 @@ wheel==0.44.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==75.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,13 +28,13 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/base.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -395,6 +395,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/base.txt
+    #   bleach
 typing-extensions==4.12.2
     # via
     #   -r requirements/base.txt
@@ -427,6 +431,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via -r requirements/base.txt
 zope-event==5.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -32,13 +32,13 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/base.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -207,7 +207,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==5.4.0
+edx-lint==5.4.1
     # via -r requirements/quality.in
 edx-opaque-keys==2.11.0
     # via
@@ -424,6 +424,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/base.txt
+    #   bleach
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
@@ -458,6 +462,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via -r requirements/base.txt
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,13 +32,13 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via -r requirements/base.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/base.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -216,7 +216,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==5.4.0
+edx-lint==5.4.1
     # via -r requirements/test.in
 edx-opaque-keys==2.11.0
     # via
@@ -447,6 +447,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/base.txt
+    #   bleach
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
@@ -482,6 +486,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via -r requirements/base.txt
 

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -41,16 +41,16 @@ billiard==4.2.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-bleach==6.1.0
+bleach[css]==6.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -289,7 +289,7 @@ edx-drf-extensions==10.5.0
     #   edx-rbac
 edx-i18n-tools==1.6.3
     # via -r requirements/validation.in
-edx-lint==5.4.0
+edx-lint==5.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -627,6 +627,11 @@ text-unidecode==1.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   python-slugify
+tinycss2==1.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   bleach
 tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
@@ -672,6 +677,7 @@ webencodings==0.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   bleach
+    #   tinycss2
 zipp==3.20.2
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## Description

Bleach documentation suggests that if you want to use stye elements in your HTML tags you must also include a CSS sanitizer when calling bleach.clean. 

https://bleach.readthedocs.io/en/latest/clean.html#allowed-attributes-attributes
 
> Note
> 
> If you allow style, you need to also sanitize css. See [Sanitizing CSS](https://bleach.readthedocs.io/en/latest clean.html#clean-chapter-sanitizing-css) for details.

