### PR TITLE
fix: use LearnerLicenseSerializer in LicenseActivationView

### DIFF
--- a/license_manager/apps/api/v1/tests/test_license_activation_view.py
+++ b/license_manager/apps/api/v1/tests/test_license_activation_view.py
@@ -152,6 +152,7 @@ class LicenseActivationViewTests(LicenseViewTestMixin, TestCase):
         assert activated_license['status'] == constants.ACTIVATED
         expected_activation_date = self.now.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         assert activated_license['activation_date'] == expected_activation_date
+        assert activated_license['subscription_plan']['uuid'] == str(license_to_be_activated.subscription_plan.uuid)
 
         # Refresh license from the database
         license_to_be_activated.refresh_from_db()

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1801,7 +1801,7 @@ class LicenseActivationView(LicenseBaseView):
 
         # There's an implied logical branch where the license is already activated
         # in which case we also return as if the activation action was successful.
-        serialized_license = serializers.LicenseSerializer(user_license)
+        serialized_license = serializers.LearnerLicenseSerializer(user_license)
         return Response(serialized_license.data, status=status.HTTP_200_OK)
 
     def _track_and_notify(self, user_license):


### PR DESCRIPTION
## Description

* When testing license activation again since adding serializers to the BFF in enterprise-access, it was observed the license activation response is not parity with the `learner-licenses` API data, where it should have a nested `subscription_plan`. This PR migrates `LicenseSerializer` -> `LearnerLicenseSerializer` in `LicenseActivationView` (non-breaking change).

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
