### PR TITLE
chore: add dev.up.redis make target back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ validate_translations: fake_translations detect_changed_source_translations ## i
 dev.provision:
 	bash ./provision-license-manager.sh
 
+# Start redis via the devstack docker-compose.yml
+dev.up.redis:
+	docker-compose -f $(DEVSTACK_WORKSPACE)/devstack/docker-compose.yml up -d redis
+
 dev.up: dev.up.redis  # Starts all of the services, will bring up the devstack-defined redis container if not running.
 	docker-compose up -d
 


### PR DESCRIPTION
Adding back a make target we lost in a prior commit.
