### PR TITLE
feat: disable throttling for priveleged users

### DIFF
--- a/license_manager/apps/core/throttles.py
+++ b/license_manager/apps/core/throttles.py
@@ -3,13 +3,28 @@ Custom DRF user-throttling classes
 so that we can throttle both bursty and sustained
 throughtput.
 """
-
+from django.conf import settings
 from rest_framework.throttling import UserRateThrottle
 
 
-class UserBurstRateThrottle(UserRateThrottle):
+class PrivelegedUserThrottle(UserRateThrottle):
+    """
+    Skips throttling is the requesting authenticated user
+    is in the list of priveleged user ids.
+    is staff or superuser.
+    """
+    def allow_request(self, request, view):
+        user = request.user
+
+        if user and user.is_authenticated and user.id in settings.PRIVELEGED_USER_IDS:
+            return True
+
+        return super().allow_request(request, view)
+
+
+class UserBurstRateThrottle(PrivelegedUserThrottle):
     scope = 'user_burst'
 
 
-class UserSustainedRateThrottle(UserRateThrottle):
+class UserSustainedRateThrottle(PrivelegedUserThrottle):
     scope = 'user_sustained'

--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -163,6 +163,9 @@ REST_FRAMEWORK = {
     }
 }
 
+# Maintain a list of user ids to opt-out of API throttle limits
+PRIVELEGED_USER_IDS = []
+
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 


### PR DESCRIPTION
Introduces a setting PRIVELEGED_USER_IDS, such that any user id in the list is exempt from throttling limits.

## Testing considerations

1. In your `private.py` file, include your requesting user id in the mentioned list.
2. `export MYJWT=[your JWT value]`
3. Execute the python below.

```python
import requests
import os
import time

def make_request(do_print=False):
    endpoint = 'http://localhost:18170/api/v1/subscriptions/[sub-plan-uuid]'
    headers = {
        'Authorization': f"JWT {os.environ['MYJWT']}",
    }
    response = requests.get(endpoint, headers=headers)
    response.raise_for_status()
    if do_print:
        print(response.json())

def loop_requests(max_seconds=10):
    count = 0
    start_time = time.time()
    while True:
        now = time.time()
        if (now - start_time) >= max_seconds:
            break
        make_request()
        count += 1

    print('Total count was:', count, 'over', max_seconds, 'seconds.')

if __name__ == '__main__':
    loop_requests(20)
```

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
