### PR TITLE
feat: adds an endpoint for admins to view learner licenses

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -53,6 +53,8 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
         read_only=True,
     )
 
+    plan_type = serializers.CharField(source='product.plan_type', read_only=True)
+
     class Meta:
         model = SubscriptionPlan
         fields = [
@@ -70,6 +72,7 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
             'is_locked_for_renewal_processing',
             'should_auto_apply_licenses',
             'created',
+            'plan_type'
         ]
 
 
@@ -516,7 +519,33 @@ class StaffLicenseSerializer(serializers.ModelSerializer):
             'last_remind_date',
             'subscription_plan_title',
             'subscription_plan_expiration_date',
+            'activation_link'
+        ]
+
+
+class AdminLicenseSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ``License`` model that is usable by views for an enterprise admin.
+    """
+
+    subscription_plan_title = serializers.CharField(source='subscription_plan.title')
+    subscription_plan_expiration_date = serializers.DateTimeField(source='subscription_plan.expiration_date')
+    subscription_plan = MinimalSubscriptionPlanSerializer()
+
+    class Meta:
+        model = License
+        fields = [
+            'uuid',
+            'status',
+            'user_email',
+            'assigned_date',
+            'activation_date',
+            'revoked_date',
+            'last_remind_date',
+            'subscription_plan_title',
+            'subscription_plan_expiration_date',
             'activation_link',
+            'subscription_plan',
         ]
 
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -41,6 +41,7 @@ from license_manager.apps.api.v1.views import (
     ESTIMATED_COUNT_PAGINATOR_THRESHOLD,
 )
 from license_manager.apps.core.models import User
+from license_manager.apps.api.serializers import AdminLicenseSerializer
 from license_manager.apps.subscriptions import constants
 from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
@@ -940,6 +941,7 @@ def test_subscription_plan_create_non_staff_user_200(api_client, non_staff_user)
         "uuid",
         "is_current",
         "created",
+        "plan_type",
     }
     assert response.json().keys() == expected_fields
 
@@ -4639,3 +4641,48 @@ class StaffLicenseLookupViewTests(LicenseViewTestMixin, TestCase):
                 'subscription_plan_title': self.active_subscription_for_customer.title,
             },
         ], response.json())  # pylint: disable=no-member
+
+
+class AdminLicenseLookupViewSetTestCase(LicenseViewTestMixin, TestCase):
+    """
+    Tests for the ``AdminLicenseLookupViewSet``.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.admin_user = UserFactory(is_staff=True)
+
+        cls.other_subscription = SubscriptionPlanFactory.create(
+            customer_agreement=cls.customer_agreement,
+            enterprise_catalog_uuid=cls.enterprise_catalog_uuid,
+            is_active=True,
+            title='Other Subscription Plan',
+        )
+        cls.user_email = "testuser@example.com"
+
+    def test_missing_user_email_returns_400(self):
+        self.api_client.force_authenticate(user=self.admin_user)
+        url = reverse('api:v1:admin-license-view')
+        response = self.api_client.get(url, {"enterprise_customer_uuid": self.enterprise_customer_uuid})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, 'A ``user_email`` is required in the request data')
+
+    @mock.patch("license_manager.apps.api.models.License.for_user_and_customer")
+    def test_valid_request_returns_licenses(self, mock_license_query):
+        mock_license = License(
+            status="assigned",
+            assigned_date="2025-02-12T18:44:50Z",
+            activation_date="2025-02-12T18:44:52Z",
+            revoked_date=None,
+            last_remind_date=None,
+        )
+        mock_license_query.return_value = [mock_license]
+        url = reverse('api:v1:admin-license-view')
+        self.api_client.force_authenticate(user=self.admin_user)
+        response = self.api_client.get(url, {"user_email": self.user_email, "enterprise_customer_uuid": self.enterprise_customer_uuid})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("results", response.data)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["status"], "assigned")

--- a/license_manager/apps/api/v1/urls.py
+++ b/license_manager/apps/api/v1/urls.py
@@ -124,5 +124,10 @@ urlpatterns = [
         views.StaffLicenseLookupView.as_view(),
         name='staff-lookup-licenses',
     ),
+    re_path(
+        r'admin-license-view',
+        views.AdminLicenseLookupViewSet.as_view(),
+        name='admin-license-view',
+    ),
 ]
 urlpatterns += router.urls + subscription_router.urls


### PR DESCRIPTION
## Description

As part of the learner profile view feature in admin portal, we want to display a list of licenses that belong to a user. This PR adds an endpoint to support admins viewing a learner's licenses. 

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-10042

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
