### PR TITLE
fix: retire_old_licenses ignores test plans

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -57,6 +57,7 @@ class Command(BaseCommand):
         revoked_licenses_for_retirement = License.get_licenses_exceeding_purge_duration(
             'revoked_date',
             status=REVOKED,
+            subscription_plan__for_internal_use_only=False,
         )
         # Scrub all pii on the revoked licenses, but they should stay revoked and keep their other info as we currently
         # add an unassigned license to the subscription's license pool whenever one is revoked.


### PR DESCRIPTION
## Description
I'd like to ignore test plans from license retirement, so that in environments with plans that have large numbers of assigned licenses for load/scale-testing, we don't OOM when retiring assigned licenses that have exceeded their purge duration. This is a stop-gap solution - what we really need are changes to
1. Make this mgmt command work in smaller chunks, for scalability, and
2. A way to quickly/cleanly/efficiently *delete* test plans in certain environments.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
