### PR TITLE
fix: don't nullify lms_user_id when clearing PII from licenses

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -30,9 +30,8 @@ class Command(BaseCommand):
         expired_licenses_for_retirement = License.get_licenses_exceeding_purge_duration(
             'subscription_plan__expiration_date',
         )
-        # Scrub all piii on licenses whose subscription expired over 90 days ago, and mark the licenses as revoked
+        # Scrub all pii on licenses whose subscription expired over 90 days ago, and mark the licenses as revoked
         for expired_license in expired_licenses_for_retirement:
-            original_lms_user_id = expired_license.lms_user_id
             # record event data BEFORE we clear the license data:
             event_properties = get_license_tracking_properties(expired_license)
 
@@ -42,7 +41,7 @@ class Command(BaseCommand):
             expired_license.save()
 
             event_properties = get_license_tracking_properties(expired_license)
-            track_event(original_lms_user_id,
+            track_event(expired_license.lms_user_id,
                         SegmentEvents.LICENSE_REVOKED,
                         event_properties)
 

--- a/license_manager/apps/subscriptions/models.py
+++ b/license_manager/apps/subscriptions/models.py
@@ -1344,13 +1344,12 @@ class License(TimeStampedModel):
         the license after calling this, or use something like bulk_update which saves each object as part of its updates
         """
         self.user_email = None
-        self.lms_user_id = None
 
     def clear_historical_pii(self):
         """
         Helper function to remove pii (user_email & lms_user_id) from the license's historical records.
         """
-        self.history.update(user_email=None, lms_user_id=None)  # pylint: disable=no-member
+        self.history.update(user_email=None)  # pylint: disable=no-member
 
     def reset_to_unassigned(self):
         """

--- a/license_manager/apps/subscriptions/tests/utils.py
+++ b/license_manager/apps/subscriptions/tests/utils.py
@@ -190,7 +190,6 @@ def assert_pii_cleared(license_obj):
     Helper to verify that pii on a license has been cleared.
     """
     assert license_obj.user_email is None
-    assert license_obj.lms_user_id is None
 
 
 def assert_historical_pii_cleared(license_obj):
@@ -199,4 +198,3 @@ def assert_historical_pii_cleared(license_obj):
     """
     for history_record in license_obj.history.all():
         assert history_record.user_email is None
-        assert history_record.lms_user_id is None


### PR DESCRIPTION
The lms_user_id was assumed to be PII, but it actually is not.  Teams performing data analysis have voiced a desire to have us stop clearing lms_user_id as it is the most reliable join record to link retired licenses to retired LMS users.

It's also just good practice to not clear records when they don't need to be cleared.

ENT-9962