### PR TITLE
build: pin edx-braze-client<1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,8 @@ path<16.15.0
 # when i include that new version (7.0.0) in the requirements upgrade, most of the jobs start failing
 # so i have to pin this version to 6.1.0
 edx-django-utils==6.1.0
+
+# pinning braze-client below version 1, which will likely introduce a breaking-change
+# as the package is converted to an openedx plugin.
+# https://github.com/edx/braze-client/pull/30
+edx-braze-client<1


### PR DESCRIPTION
ENT-10153 | pinning braze-client below version 1, which will likely introduce a breaking-change as the package is converted to an openedx plugin.
see: https://github.com/edx/braze-client/pull/30

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
