### PR TITLE
fix: updates return results to empty array

### DIFF
--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -4696,3 +4696,21 @@ class AdminLicenseLookupViewSetTestCase(LicenseViewTestMixin, TestCase):
         self.assertIn("results", response.data)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(response.data["results"][0]["status"], "assigned")
+
+    @mock.patch("license_manager.apps.api.models.License.for_user_and_customer")
+    def test_no_licenses_returns_empty_results(self, mock_license_query):
+        """
+        Test that when no licenses are found, the endpoint returns empty results instead of 404.
+        """
+        mock_license_query.return_value = []
+        url = reverse('api:v1:admin-license-view')
+        self.api_client.force_authenticate(user=self.admin_user)
+        response = self.api_client.get(url, {
+            "user_email": self.user_email,
+            "enterprise_customer_uuid": self.enterprise_customer_uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("results", response.data)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -2038,10 +2038,6 @@ class AdminLicenseLookupViewSet(LicenseBaseView):
             lms_user_id=None,
             enterprise_customer_uuid=enterprise_customer_uuid
         )
-        if not user_licenses:
-            return Response(
-                status=status.HTTP_404_NOT_FOUND,
-            )
         paginator = PageNumberPagination()
         licenses_page = paginator.paginate_queryset(user_licenses, request, view=self)
 


### PR DESCRIPTION
## Description

Updates the endpoint `/api/v1/admin-license-view` to return empty results instead of a 404 error when no licenses are found for a given user email and enterprise customer. This is to better support the frontend-end logic to determine whether to display data rather than throwing an error.

Link to the associated ticket: https://2u-internal.atlassian.net/browse/ENT-10261

|before|after|
|------|-----|
| ![Screenshot 2025-04-02 at 12 32 32 PM](https://github.com/user-attachments/assets/a67ca82b-1bd8-4201-9ce8-ff6ed19b626a) | ![Screenshot 2025-04-02 at 12 32 22 PM](https://github.com/user-attachments/assets/d3c5bba7-219b-464c-a7c9-bcac93a27e5c)|

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
