### PR TITLE
chore: Allow logging format to be overridden

### DIFF
--- a/license_manager/settings/base.py
+++ b/license_manager/settings/base.py
@@ -311,8 +311,11 @@ LOGIN_REDIRECT_URL = '/admin/'
 PLATFORM_NAME = 'Your Platform Name Here'
 # END OPENEDX-SPECIFIC CONFIGURATION
 
+# Override the default logging format string (default defined within utils.py).
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", None)
+
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG, dev_env=True)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 """############################# BEGIN CELERY CONFIG ##################################"""
 

--- a/license_manager/settings/local.py
+++ b/license_manager/settings/local.py
@@ -64,7 +64,7 @@ JWT_AUTH.update({
 
 ENABLE_AUTO_AUTH = True
 
-LOGGING = get_logger_config(debug=DEBUG, dev_env=True)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 LOG_SQL = False
 

--- a/license_manager/settings/production.py
+++ b/license_manager/settings/production.py
@@ -10,8 +10,6 @@ TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ['*']
 
-LOGGING = get_logger_config()
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH', 'REST_FRAMEWORK')
@@ -40,6 +38,9 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
     # of Django settings.
     vars().update(FILE_STORAGE_BACKEND)
     vars().update(MEDIA_STORAGE_BACKEND)
+
+# Must be generated after loading config YAML because LOGGING_FORMAT_STRING might be overridden.
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/license_manager/settings/utils.py
+++ b/license_manager/settings/utils.py
@@ -1,7 +1,6 @@
 import platform
 import sys
-from logging.handlers import SysLogHandler
-from os import environ, path
+from os import environ
 
 from django.core.exceptions import ImproperlyConfigured
 
@@ -14,15 +13,23 @@ def get_env_setting(setting):
         error_msg = "Set the [%s] env variable!" % setting
         raise ImproperlyConfigured(error_msg)
 
-def get_logger_config(log_dir='/var/tmp',
-                      logging_env="no_env",
-                      edx_filename="edx.log",
-                      dev_env=False,
-                      debug=False,
-                      service_variant='license_manager'):
+def get_logger_config(
+    logging_env: str = "no_env",
+    debug: bool = False,
+    service_variant: str = 'enterprise-access',
+    format_string: str = None,
+):
     """
-    Return the appropriate logging config dictionary. You should assign the
-    result of this to the LOGGING var in your settings.
+    Return the appropriate logging config dictionary, to be assigned to the LOGGING var in settings.
+
+    Arguments:
+        logging_env (str): Environment name.
+        debug (bool): Debug logging enabled.
+        service_variant (str): Name of the service.
+        format_string (str): Override format string for your logfiles.
+
+    Returns:
+        dict(string): Returns a dictionary of config values
     """
 
     hostname = platform.node().split(".")[0]
@@ -38,13 +45,18 @@ def get_logger_config(log_dir='/var/tmp',
 
     handlers = ['console']
 
+    standard_format = format_string or (
+        '%(asctime)s %(levelname)s %(process)d [%(name)s] '
+        '[request_id %(request_id)s] '
+        '%(filename)s:%(lineno)d - %(message)s'
+    )
+
     logger_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s %(process)d [request_id %(request_id)s] '
-                          '[%(name)s] %(filename)s:%(lineno)d - %(message)s',
+                'format': standard_format,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},


### PR DESCRIPTION
Allow logging format to be overridden via LOGGING_FORMAT_STRING.

ENT-10092