### PR TITLE
feat: bulk delete licenses from django admin

### DIFF
--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -471,3 +471,12 @@ class LicenseTransferJobAdminForm(forms.ModelForm):
         js = (
             'filtered_subscription_admin.js',
         )
+
+
+class BulkDeleteLicensesForm(forms.Form):
+    """
+    Confirmation page form for the bulk license deletion action.
+    """
+    _selected_action = forms.CharField(widget=forms.HiddenInput())
+    cache_key = forms.CharField()
+    record_count = forms.IntegerField()

--- a/license_manager/apps/subscriptions/templates/admin/bulk_delete.html
+++ b/license_manager/apps/subscriptions/templates/admin/bulk_delete.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<form action="" method="post">{% csrf_token %}
+    {{ form }}
+    <p>The count of licenses to be deleted: {{ record_count }}</p>
+    <p>Really delete all of these licenses?</p>
+    <!--  Link the action name in hidden params -->
+    <div class="submit-row">
+      <input type="hidden" name="action" value="delete_bulk_licenses" />
+      <input type="submit" class="button" name="confirm_deletion" value="Confirm Deletion" />
+    </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
ENT-10321 | We want a way to delete without listing every single license record that will be deleted, because it causes HTTP timeouts and other issues on large querysets.

This allows us to utilize the power of DjangoQL to construct specific queries of licenses we want to filter on prior to deletion:
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/33fd11fc-3332-4bac-9f3e-8661889aa6e0" />

Confirmation page (you can just hit Back if you don't want to proceed):
<img width="923" alt="image" src="https://github.com/user-attachments/assets/b217f29c-0411-4921-ac9c-1e55e42ef1ef" />

Bam!
<img width="814" alt="image" src="https://github.com/user-attachments/assets/2c4690a2-0234-4dff-8e20-5c570af5ad25" />

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
