### PR TITLE
feat: expose sf_opp_line_item in min subs plan serializer

### DIFF
--- a/license_manager/apps/api/serializers.py
+++ b/license_manager/apps/api/serializers.py
@@ -72,7 +72,8 @@ class MinimalSubscriptionPlanSerializer(serializers.ModelSerializer):
             'is_locked_for_renewal_processing',
             'should_auto_apply_licenses',
             'created',
-            'plan_type'
+            'plan_type',
+            'salesforce_opportunity_line_item',
         ]
 
 

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -442,6 +442,7 @@ def _assert_subscription_response_correct(response, subscription, expected_days_
         expected_days_until_renewal_expiration or days_until_expiration)
     assert response['prior_renewals'] == subscription.prior_renewals
     assert response['is_locked_for_renewal_processing'] == subscription.is_locked_for_renewal_processing
+    assert response['salesforce_opportunity_line_item'] == subscription.salesforce_opportunity_line_item
 
 
 def _assert_license_response_correct(response, subscription_license):


### PR DESCRIPTION
ENT-10004 | We need to access this field for use in the provisioning workflow within enterprise-access.

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
