### PR TITLE
fix: batchify get_licenses_exceeding_purge_duration()

### DIFF
--- a/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/retire_old_licenses.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from itertools import chain
 
 from django.core.management.base import BaseCommand
 
@@ -26,12 +27,18 @@ class Command(BaseCommand):
         ' reassigned for over 90 days, or whose associated subscription has expired for over 90 days.'
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument("--batch-size", required=False, type=int)
+
     def handle(self, *args, **options):
+        batch_size_kwarg = {'batch_size': options['batch_size']} if options['batch_size'] else {}
         expired_licenses_for_retirement = License.get_licenses_exceeding_purge_duration(
             'subscription_plan__expiration_date',
+            **batch_size_kwarg,
         )
+        expired_license_uuids = []
         # Scrub all pii on licenses whose subscription expired over 90 days ago, and mark the licenses as revoked
-        for expired_license in expired_licenses_for_retirement:
+        for expired_license in chain(*expired_licenses_for_retirement):
             # record event data BEFORE we clear the license data:
             event_properties = get_license_tracking_properties(expired_license)
 
@@ -48,8 +55,8 @@ class Command(BaseCommand):
             # Clear historical pii after removing pii from the license itself
             expired_license.clear_historical_pii()
             expired_license.delete_source()
+            expired_license_uuids.append(expired_license.uuid)
 
-        expired_license_uuids = sorted([expired_license.uuid for expired_license in expired_licenses_for_retirement])
         message = 'Retired {} expired licenses with uuids: {}'.format(len(expired_license_uuids), expired_license_uuids)
         logger.info(message)
 
@@ -57,17 +64,19 @@ class Command(BaseCommand):
             'revoked_date',
             status=REVOKED,
             subscription_plan__for_internal_use_only=False,
+            **batch_size_kwarg,
         )
+        revoked_license_uuids = []
         # Scrub all pii on the revoked licenses, but they should stay revoked and keep their other info as we currently
         # add an unassigned license to the subscription's license pool whenever one is revoked.
-        for revoked_license in revoked_licenses_for_retirement:
+        for revoked_license in chain(*revoked_licenses_for_retirement):
             revoked_license.clear_pii()
             revoked_license.save()
             # Clear historical pii after removing pii from the license itself
             revoked_license.clear_historical_pii()
             revoked_license.delete_source()
+            revoked_license_uuids.append(revoked_license.uuid)
 
-        revoked_license_uuids = sorted([revoked_license.uuid for revoked_license in revoked_licenses_for_retirement])
         message = 'Retired {} revoked licenses with uuids: {}'.format(len(revoked_license_uuids), revoked_license_uuids)
         logger.info(message)
 
@@ -77,19 +86,19 @@ class Command(BaseCommand):
             'assigned_date',
             status=ASSIGNED,
             subscription_plan__for_internal_use_only=False,
+            **batch_size_kwarg,
         )
+        assigned_license_uuids = []
         # We place previously assigned licenses that are now retired back into the unassigned license pool, so we scrub
         # all data on them.
-        for assigned_license in assigned_licenses_for_retirement:
+        for assigned_license in chain(*assigned_licenses_for_retirement):
             assigned_license.reset_to_unassigned()
             assigned_license.save()
             # Clear historical pii after removing pii from the license itself
             assigned_license.clear_historical_pii()
             assigned_license.delete_source()
+            assigned_license_uuids.append(assigned_license.uuid)
 
-        assigned_license_uuids = sorted(
-            [assigned_license.uuid for assigned_license in assigned_licenses_for_retirement],
-        )
         message = 'Retired {} assigned licenses that exceeded their inactivation duration with uuids: {}'.format(
             len(assigned_license_uuids),
             assigned_license_uuids,

--- a/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
+++ b/license_manager/apps/subscriptions/management/commands/tests/test_retire_old_licenses.py
@@ -141,7 +141,7 @@ class RetireOldLicensesCommandTests(TestCase):
         Verify that the command retires the correct licenses appropriately and logs messages about the retirement.
         """
         with freeze_time(localized_utcnow()), self.assertLogs(level='INFO') as log:
-            call_command(self.command_name)
+            call_command(self.command_name, '--batch-size=2')
 
             # Verify all expired licenses that were ready for retirement have been retired correctly
             expired_licenses = self.expired_subscription_plan.licenses.all()


### PR DESCRIPTION
Helps avoid OOM errors in license retirement jobs that should work on many thousands of licenses. ENT-10498

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-10498

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
