### PR TITLE
fix: Add SECURE_PROXY_SSL_HEADER field to fix pagination issue

### DIFF
--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -709,8 +709,8 @@ class LearnerLicensesViewSet(
         # Update user_email on licenses if the user has changed their email.
         # Ideally we would receive an event when a user changes their info from the lms and update
         # licenses that way, but this will work for now.
-        license_with_oudated_email = next((lcs for lcs in licenses if lcs.user_email != self.user_email), None)
-        if license_with_oudated_email:
+        license_with_outdated_email = next((lcs for lcs in licenses if lcs.user_email != self.user_email), None)
+        if license_with_outdated_email:
             # This should be a very infrequent operation
             update_user_email_for_licenses_task(self.lms_user_id, self.user_email)
 

--- a/license_manager/settings/production.py
+++ b/license_manager/settings/production.py
@@ -8,6 +8,14 @@ from license_manager.settings.utils import get_env_setting, get_logger_config
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ALLOWED_HOSTS = ['*']
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,


### PR DESCRIPTION
This PR adds the `SECURE_PROXY_SSL_HEADER` field to the production settings file to mitigate an issue during pagination.

The paginated `next` field would pass the URL as a `http` url, resulting in a malformed request for the consuming user of `next` when traversing pagination. 

See docs.
Django: https://docs.djangoproject.com/en/5.2/ref/settings/#secure-proxy-ssl-header

## Description

Description of changes made

Link to the associated ticket: https://openedx.atlassian.net/browse/ENT-XXXX

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
