### PR TITLE
feat: generic bulk admin delete pattern

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -23,7 +23,7 @@ from license_manager.apps.subscriptions.api import (
 )
 from license_manager.apps.subscriptions.exceptions import CustomerAgreementError
 from license_manager.apps.subscriptions.forms import (
-    BulkDeleteLicensesForm,
+    BulkDeleteForm,
     CustomerAgreementAdminForm,
     LicenseTransferJobAdminForm,
     ProductForm,
@@ -39,6 +39,7 @@ from license_manager.apps.subscriptions.models import (
     Notification,
     PlanType,
     Product,
+    SubscriptionLicenseSource,
     SubscriptionPlan,
     SubscriptionPlanRenewal,
 )
@@ -49,6 +50,73 @@ def get_related_object_link(admin_viewname, object_pk, object_str):
         href=reverse(admin_viewname, args=(object_pk,)),
         object_string=object_str,
     ))
+
+
+def _bulk_delete_request_handler(request, queryset, model_name, table_name, delete_action_method):
+    """
+    Delete a large number of model instances, without listing each instance on the confirmation page.
+    A confirmation page is still presented to the user.
+    We achieve this as follows:
+    * On the first POST (when the user selects the action and clicks "Go"), we take
+      the SQL from the queryset, with its parameters, and store it in the django cache.
+    * Our Form stores the cache key, which we'll need later.
+    * We put the count of records into the rendered template.
+    * In the template rendered to the user, they'll see a count and click "Confirm". The input
+      name of the submit element routes the request back to here, with "confirm_deletion" as a key
+      in the POST body.  The POST body will also have our cache key inside it.
+    * Using the cache key, the ``if 'confirm_deletion'`` branch below will load the query
+      and params from the cache, then we'll execute it as a raw queryset.
+
+    We do all this because deleting in bulk means we might want to delete more records than
+    can be transferred back and forth via HTTP headers and query params.
+    """
+    if 'confirm_deletion' not in request.POST:
+        cache_key = f'bulk-delete-admin-{model_name}:{uuid.uuid4()}'
+        record_count = queryset.count()
+        cache.set(cache_key, queryset.query.sql_with_params(), 600)
+
+        form = BulkDeleteForm(
+            # _selected_action needs some model instance identifiers just for the routing to work,
+            # so we simply pass along the first one.
+            initial={
+                '_selected_action': queryset.values_list("pk", flat=True).first(),
+                'cache_key': cache_key,
+                'record_count': record_count,
+            }
+        )
+        return render(
+            request,
+            "admin/bulk_delete.html",
+            {
+                'record_count': record_count,
+                'form': form,
+                'model_name': model_name,
+                'delete_action_method': delete_action_method,
+            }
+        )
+    elif 'confirm_deletion' in request.POST:
+        # process the confirmation of deletion of these records
+        cached_sql, params = cache.get(request.POST['cache_key'])
+        cache.delete(request.POST['cache_key'])
+
+        # grab everything after the FROM of our SELECT query,
+        # and turn it into a DELETE query. Strip the ORDER BY out of it.
+        delete_sql = f"DELETE `{table_name}` FROM {cached_sql.partition('FROM')[2]}"
+        delete_sql = delete_sql.partition('ORDER BY')[0]
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(delete_sql, params)
+        except Exception as exc:  # pylint: disable=broad-except
+            messages.add_message(request, messages.ERROR, exc)
+        else:
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Successfully deleted {request.POST['record_count']} {model_name} records",
+            )
+
+        return HttpResponseRedirect(request.get_full_path())
 
 
 @admin.register(License)
@@ -192,62 +260,14 @@ class LicenseAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
         """
         Delete a large number of licenses, without listing each license on the confirmation page.
         A confirmation page is still presented to the user.
-        We achieve this as follows:
-        * On the first POST (when the user selects the action and clicks "Go"), we take
-          the SQL from the queryset, with its parameters, and store it in the django cache.
-        * Our Form stores the cache key, which we'll need later.
-        * We put the count of records into the rendered template.
-        * In the template rendered to the user, they'll see a count and click "Confirm". The input
-          name of the submit element routes the request back to here, with "confirm_deletion" as a key
-          in the POST body.  The POST body will also have our cache key inside it.
-        * Using the cache key, the ``if 'confirm_deletion'`` branch below will load the query
-          and params from the cache, then we'll execute it as a raw queryset.
-
-        We do all this because deleting in bulk means we might want to delete more records than
-        can be transferred back and forth via HTTP headers and query params.
         """
-        if 'confirm_deletion' not in request.POST:
-            cache_key = f'bulk-delete-admin:{uuid.uuid4()}'
-            record_count = queryset.count()
-            cache.set(cache_key, queryset.query.sql_with_params(), 600)
-
-            form = BulkDeleteLicensesForm(
-                # _selected_action needs some license identifiers just for the routing to work,
-                # so we simply pass along the first one.
-                initial={
-                    '_selected_action': queryset.values_list("uuid", flat=True).first(),
-                    'cache_key': cache_key,
-                    'record_count': record_count
-                }
-            )
-            return render(
-                request,
-                "admin/bulk_delete.html",
-                {'record_count': record_count, 'form': form}
-            )
-        elif 'confirm_deletion' in request.POST:
-            # process the confirmation of deletion of these licenses
-            cached_sql, params = cache.get(request.POST['cache_key'])
-            cache.delete(request.POST['cache_key'])
-
-            # grab everything after the FROM of our SELECT query,
-            # and turn it into a DELETE query. Strip the ORDER BY out of it.
-            delete_sql = f"DELETE `subscriptions_license` FROM {cached_sql.partition('FROM')[2]}"
-            delete_sql = delete_sql.partition('ORDER BY')[0]
-
-            try:
-                with connection.cursor() as cursor:
-                    cursor.execute(delete_sql, params)
-            except Exception as exc:  # pylint: disable=broad-except
-                messages.add_message(request, messages.ERROR, exc)
-            else:
-                messages.add_message(
-                    request,
-                    messages.SUCCESS,
-                    f"Successfully deleted {request.POST['record_count']} licenses",
-                )
-
-            return HttpResponseRedirect(request.get_full_path())
+        return _bulk_delete_request_handler(
+            request=request,
+            queryset=queryset,
+            model_name='License',
+            table_name='subscriptions_license',
+            delete_action_method='delete_bulk_licenses',
+        )
 
 
 @admin.register(SubscriptionPlan)
@@ -891,6 +911,10 @@ class LicenseEventAdmin(admin.ModelAdmin):
         'license__subscription_plan__customer_agreement__enterprise_customer_slug__startswith'
     )
 
+    autocomplete_fields = ['license']
+
+    actions = ['delete_bulk_license_events']
+
     @admin.display(description='Enterprise')
     def enterprise(self, instance):
         """Return license enterprise"""
@@ -915,3 +939,50 @@ class LicenseEventAdmin(admin.ModelAdmin):
     def plan_uuid(self, instance):
         """Return license plan uuid"""
         return instance.license.subscription_plan.uuid
+
+    @admin.action(
+        description='Delete bulk license events'
+    )
+    def delete_bulk_license_events(self, request, queryset):
+        """
+        Delete a large number of license event records, without listing each
+        record on the confirmation page.
+        A confirmation page is still presented to the user.
+        """
+        return _bulk_delete_request_handler(
+            request=request,
+            queryset=queryset,
+            model_name='LicenseEvent',
+            table_name='subscriptions_licenseevent',
+            delete_action_method='delete_bulk_license_events',
+        )
+
+
+@admin.register(SubscriptionLicenseSource)
+class SubscriptionLicenseSourceAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+    list_display = [
+        'license',
+        'source_id',
+        'source_type',
+    ]
+
+    autocomplete_fields = ['license']
+
+    actions = ['delete_bulk_license_sources']
+
+    @admin.action(
+        description='Delete bulk license sources'
+    )
+    def delete_bulk_license_sources(self, request, queryset):
+        """
+        Delete a large number of license source records, without listing each
+        record on the confirmation page.
+        A confirmation page is still presented to the user.
+        """
+        return _bulk_delete_request_handler(
+            request=request,
+            queryset=queryset,
+            model_name='SubscriptionLicenseSource',
+            table_name='subscriptions_subscriptionlicensesource',
+            delete_action_method='delete_bulk_license_sources',
+        )

--- a/license_manager/apps/subscriptions/forms.py
+++ b/license_manager/apps/subscriptions/forms.py
@@ -473,9 +473,9 @@ class LicenseTransferJobAdminForm(forms.ModelForm):
         )
 
 
-class BulkDeleteLicensesForm(forms.Form):
+class BulkDeleteForm(forms.Form):
     """
-    Confirmation page form for the bulk license deletion action.
+    Confirmation page form for the bulk model deletion action.
     """
     _selected_action = forms.CharField(widget=forms.HiddenInput())
     cache_key = forms.CharField()

--- a/license_manager/apps/subscriptions/templates/admin/bulk_delete.html
+++ b/license_manager/apps/subscriptions/templates/admin/bulk_delete.html
@@ -3,11 +3,11 @@
 {% block content %}
 <form action="" method="post">{% csrf_token %}
     {{ form }}
-    <p>The count of licenses to be deleted: {{ record_count }}</p>
-    <p>Really delete all of these licenses?</p>
+    <p>The count of {{ model_name }} records to be deleted: {{ record_count }}</p>
+    <p>Really delete all of these records?</p>
     <!--  Link the action name in hidden params -->
     <div class="submit-row">
-      <input type="hidden" name="action" value="delete_bulk_licenses" />
+      <input type="hidden" name="action" value="{{ delete_action_method }}"/>
       <input type="submit" class="button" name="confirm_deletion" value="Confirm Deletion" />
     </div>
 </form>


### PR DESCRIPTION
Extend custom bulk deletion to LicenseEvent and SubscriptionLicenseSource models. ENT-10377

![image](https://github.com/user-attachments/assets/2ab36c18-591a-419d-a99a-95671d2a1136)
![image](https://github.com/user-attachments/assets/759df56d-9ae0-4d87-b3da-42ecf9b800a8)
![image](https://github.com/user-attachments/assets/589cda75-4ef4-46e1-a186-bed34a0d18ed)

![image](https://github.com/user-attachments/assets/ff52688a-fef8-4b55-b1ba-4b791b35bbbd)
![image](https://github.com/user-attachments/assets/a2233f43-6ea3-45c7-abc9-c133f52839ed)
![image](https://github.com/user-attachments/assets/2eaa0b48-69cf-435c-b127-7bee34152cac)

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
