### PR TITLE
fix: ensure `LearnerLicensesPaginationCustomerAgreement` uses `settings PAGE_SIZE` vs. `DefaultPagination`'S `page_size`

### DIFF
--- a/license_manager/apps/api/pagination.py
+++ b/license_manager/apps/api/pagination.py
@@ -1,6 +1,7 @@
 """
 Defines custom paginators used by subscription viewsets.
 """
+from django.conf import settings
 from django.core.paginator import Paginator as DjangoPaginator
 from django.utils.functional import cached_property
 from edx_rest_framework_extensions.paginators import DefaultPagination
@@ -87,6 +88,8 @@ class LearnerLicensesPaginationCustomerAgreement(DefaultPagination):
     corresponding subscription_plan. In order to reduce the number of calls to the client,
     we incorporate the customer_agreement accessible within a single call.
     """
+
+    page_size = PageNumberPagination.page_size
 
     def get_paginated_response(self, data):
         """

--- a/license_manager/apps/api/pagination.py
+++ b/license_manager/apps/api/pagination.py
@@ -1,7 +1,6 @@
 """
 Defines custom paginators used by subscription viewsets.
 """
-
 from django.core.paginator import Paginator as DjangoPaginator
 from django.utils.functional import cached_property
 from edx_rest_framework_extensions.paginators import DefaultPagination

--- a/license_manager/apps/api/pagination.py
+++ b/license_manager/apps/api/pagination.py
@@ -1,7 +1,7 @@
 """
 Defines custom paginators used by subscription viewsets.
 """
-from django.conf import settings
+
 from django.core.paginator import Paginator as DjangoPaginator
 from django.utils.functional import cached_property
 from edx_rest_framework_extensions.paginators import DefaultPagination


### PR DESCRIPTION
## Description

The `learner-licenses` API does not honor the default IDA settings `REST_FRAMEWORK['PAGE_SIZE']`. This is due to extending `DefaultPagination` from `edx_rest_framework_extensions.paginators`, which sets a `page_size=10`.

This PR ensures `LearnerLicensesPaginationCustomerAgreement` continues to rely on the default `PAGE_SIZE` from IDA settings instead.

## Testing considerations

- Include instructions for any required manual tests, and any manual testing that has
already been performed.
- Include unit and a11y tests as appropriate
- Consider performance issues.
- Check that Database migrations are backwards-compatible

## Post-review

Squash commits into discrete sets of changes
