### PR TITLE
feat: prefetch django admin license related models

### DIFF
--- a/license_manager/apps/subscriptions/admin.py
+++ b/license_manager/apps/subscriptions/admin.py
@@ -157,9 +157,20 @@ class LicenseAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     actions = ['revert_licenses_to_snapshot_time', 'delete_bulk_licenses']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related(
+        """
+        We use a prefetch_related instead of select_related below very intentionally.
+        In environments with a large number of license records, using a select_related() -
+        which is implemented with a JOIN - on a queryset ultimately ordered by *license* uuid,
+        can cause the SQL query planner to utilize a filesort to join to the subscription_plan.
+        With a large number of records, that is very slow.
+        A prefetch_related() makes separate queries for subscription plans
+        and sources, but each is filtered to include in the results only the records corresponding
+        to the licenses on the current page of results. Those are very efficient queries,
+        which utilize a PK index and a simple index, respectively.
+        """
+        return super().get_queryset(request).prefetch_related(
             'subscription_plan',
-            'source'
+            'source',
         )
 
     @admin.display(description='Source ID')


### PR DESCRIPTION
the query to load the license list page in django admin is:
```
SELECT subscriptions_license [...]
FROM subscriptions_license 
    INNER JOIN subscriptions_subscriptionplan ON ( subscriptions_license . subscription_plan_id = subscriptions_subscriptionplan . uuid ) 
    LEFT OUTER JOIN subscriptions_subscriptionlicensesource ON ( subscriptions_license . uuid = subscriptions_subscriptionlicensesource . license_id ) 
ORDER BY subscriptions_license . uuid DESC 
LIMIT ?
```

The problematic aspect is NOT the ordering by license uuid. Here's the EXPLAIN of this query:

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: subscriptions_subscriptionplan
   partitions: NULL
         type: ALL
possible_keys: PRIMARY
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 1723
     filtered: 100.00
        Extra: Using temporary; Using filesort
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: subscriptions_license
   partitions: NULL
         type: ref
possible_keys: subscriptions_license_subscription_plan_id_476673e5,subscription_plan_status_idx
          key: subscriptions_license_subscription_plan_id_476673e5
      key_len: 96
          ref: license_manager.subscriptions_subscriptionplan.uuid
         rows: 165
     filtered: 100.00
        Extra: NULL
*************************** 3. row ***************************
           id: 1
  select_type: SIMPLE
        table: subscriptions_subscriptionlicensesource
   partitions: NULL
         type: eq_ref
possible_keys: license_id
          key: license_id
      key_len: 96
          ref: license_manager.subscriptions_license.uuid
         rows: 1
     filtered: 100.00
        Extra: NULL
3 rows in set, 1 warning (0.00 sec)
```

The filesort is actually due to joining on the _plan_. I propose that we simply change the queryset of this model admin to use prefetch_related() instead of select_related(). With this change, when looking at djt when loading the page locally, we see 3 queries to fetch the license rows now, as expected, and each has a simple query plan that does not require filesort.

```
-- fetch first page of licenses, simple query using backward index scan.
SELECT `subscriptions_license`...
  FROM `subscriptions_license`
 ORDER BY `subscriptions_license`.`uuid` DESC
 LIMIT 100
-- fetch corresponding plans for the first page, simple query using index.
SELECT `subscriptions_subscriptionplan`...
  FROM `subscriptions_subscriptionplan`
 WHERE `subscriptions_subscriptionplan`.`uuid` IN ('94c5264f0eff4035a594e6fd87ed6cae', '2be798dc738b487ca1a1b4cfaaba3abc', '5f4b4c2541d541c0948fd8991d86c491', 'e30ca360a37b49359d26fd51658282eb', '6fb7fbd0434b47f183f1f3646cb08d2a', 'b3d73f82bf3143c489bad11e871f9ace')
-- fetch corresponding license sources for the first page, simple query using index
SELECT `subscriptions_subscriptionlicensesource`...
  FROM `subscriptions_subscriptionlicensesource`
 WHERE `subscriptions_subscriptionlicensesource`.`license_id` IN ([the list of license uuids for the first page])
```
