### PR TITLE
(ENT-10938)-Code changes for Enterprise subscription revoke endpoint returning successfully status code(200 & 207)

### DIFF
--- a/api-compact.yaml
+++ b/api-compact.yaml
@@ -52,6 +52,10 @@ apigateway_get_responses: &apigateway_get_responses
 bulk_revoke_apigateway_responses: &bulk_revoke_apigateway_responses
   default:
     statusCode: "400"
+  200:
+    statusCode: "200"
+  207:
+    statusCode: "207"
   204:
     statusCode: "204"
   401:
@@ -140,8 +144,10 @@ get_responses: &get_responses
     description: "Internal Server Error"
 
 bulk_revoke_responses: &bulk_revoke_responses
-  204:
-    description: "No Content - All revocations were successful"
+  200:
+    description: "OK - All revocations were successful"
+  207:
+    description: "Multi-Status - Some revocations were successful, others failed"
   400:
     description: "Bad Request"
   401:

--- a/api.yaml
+++ b/api.yaml
@@ -2,6 +2,7 @@
 # This file was generated using http://www.yamllint.com/.
 
 ---
+---
 apigateway_responses:
   "200":
     statusCode: "200"
@@ -39,8 +40,12 @@ apigateway_get_responses:
   default:
     statusCode: "400"
 bulk_revoke_apigateway_responses:
+  "200":
+    statusCode: "200"
   "204":
     statusCode: "204"
+  "207":
+    statusCode: "207"
   "401":
     statusCode: "401"
   "403":
@@ -118,8 +123,10 @@ get_responses:
   "500":
     description: Internal Server Error
 bulk_revoke_responses:
-  "204":
-    description: No Content - All revocations were successful
+  "200":
+    description: OK - All revocations were successful
+  "207":
+    description: Multi-Status - Some revocations were successful, others failed
   "400":
     description: Bad Request
   "401":
@@ -286,8 +293,10 @@ endpoints:
               items:
                 $ref: "#/definitions/RequestPayload"
         responses:
-          "204":
-            description: No Content - All revocations were successful
+          "200":
+            description: OK - All revocations were successful
+          "207":
+            description: Multi-Status - Some revocations were successful, others failed
           "400":
             description: Bad Request
           "401":
@@ -302,8 +311,12 @@ endpoints:
             description: Internal Server Error
         x-amazon-apigateway-integration:
           responses:
+            "200":
+              statusCode: "200"
             "204":
               statusCode: "204"
+            "207":
+              statusCode: "207"
             "401":
               statusCode: "401"
             "403":

--- a/api.yaml
+++ b/api.yaml
@@ -2,7 +2,6 @@
 # This file was generated using http://www.yamllint.com/.
 
 ---
----
 apigateway_responses:
   "200":
     statusCode: "200"


### PR DESCRIPTION
**Title**
Enterprise subscription revoke endpoint returning success in body with a 400 status code. (ENT-10938)
**Overview / Purpose**
We did code changes for successful revocations. 
we changed 2 files  
	1)api-compact.yaml
	2)api.yaml
**Testing**:
we verified our code changes in postman api with following details
	uuid:7309a1c6-104d-40d4-8616-a994ca56b058
	endpoint:https://api.stage.edx.org/enterprise/v1/subscriptions/uuid/licenses/bulk-revoke