### PR TITLE
feat: add enterprise default language in braze campaigns

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -180,6 +180,7 @@ def _batch_notify_or_remind_assigned_emails(
     enterprise_name = enterprise_customer.get('name')
     enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
     enterprise_contact_email = enterprise_customer.get('contact_email')
+    enterprise_default_language = enterprise_customer.get('default_language') or ''
 
     pending_license_by_email = {}
     emails_for_aliasing = []
@@ -198,6 +199,7 @@ def _batch_notify_or_remind_assigned_emails(
             'enterprise_customer_name': enterprise_name,
             'enterprise_sender_alias': enterprise_sender_alias,
             'enterprise_contact_email': enterprise_contact_email,
+            'enterprise_default_language': enterprise_default_language,
         }
         recipient = _aliased_recipient_object_from_email(user_email)
         recipient['attributes'].update(get_license_tracking_properties(pending_license))
@@ -292,6 +294,7 @@ def send_post_activation_email_task(enterprise_customer_uuid, user_email):
     enterprise_slug = enterprise_customer.get('slug')
     enterprise_sender_alias = get_enterprise_sender_alias(enterprise_customer)
     enterprise_contact_email = enterprise_customer.get('contact_email')
+    enterprise_default_language = enterprise_customer.get('default_language') or ''
 
     braze_campaign_id = settings.BRAZE_ACTIVATION_EMAIL_CAMPAIGN
     braze_trigger_properties = {
@@ -299,6 +302,7 @@ def send_post_activation_email_task(enterprise_customer_uuid, user_email):
         'enterprise_customer_name': enterprise_name,
         'enterprise_sender_alias': enterprise_sender_alias,
         'enterprise_contact_email': enterprise_contact_email,
+        'enterprise_default_language': enterprise_default_language,
     }
     recipient = _aliased_recipient_object_from_email(user_email)
 


### PR DESCRIPTION
## Description

This PR adds support for passing the enterprise customer’s default language to Braze email campaigns. This value is used to select localized content for license assignment, reminder, and activation emails.


## Summary: Passing Enterprise Default Language to Braze

## Context

License manager triggers multiple Braze campaigns and sends user data via the Braze API (`user_alias`, `attributes`, `trigger_properties`). We need to include an enterprise default language to support localized messaging without impacting users’ personal language preferences.


## Option 1: Send `default_language` as a user attribute (`pref-lang`)

**Pros**

* Minimal Braze changes
* Faster implementation

**Cons**

* Overrides user-selected language, potentially sending messages in the wrong language and degrading user experience
* Pollutes persistent user data, causing unintended impact across all current and future campaigns

---

### Option 2: Send `default_language` via `trigger_properties`

**Pros**

* Does not override user language
* Correct separation of concerns (campaign context vs user state)
* No long-term side effects in Braze

**Cons**

* Requires coordinated updates to templates, content blocks, and subjects
* Higher initial effort, though limited to a one-time migration

---

## Recommended Approach 

**Use `trigger_properties` to pass `enterprise_default_language`.**

### Language Resolution Logic (Braze Liquid)

1. User’s explicit language preference (if set)
2. Enterprise default language
3. Fallback language (e.g., `en`)

Example:

```liquid
{% assign lang = custom_attribute.${language}
   | default: trigger_properties.enterprise_default_language
   | default: "en" %}
```

This logic can be reused across templates, content blocks, and subjects to minimize duplication.

---

## Implementation Strategy

* Add `enterprise_default_language` to Braze `trigger_properties`
* Introduce centralized Liquid logic for language selection
* Update shared content blocks first, then campaign bodies and subjects
* Avoid modifying persistent user attributes

---

## Post-review

Squash commits into discrete sets of changes